### PR TITLE
chore: phase 0 — scaffolding, uv tooling, trampolines, Linux Docker CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    name: Linux (lint + unit + docker)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Docker engine version
+        run: docker version
+
+      - name: Install
+        run: ./install
+
+      - name: Lint
+        run: ./lint
+
+      - name: Test (unit + docker)
+        run: ./test
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Assert py3-none-any wheel
+        run: |
+          set -e
+          ls dist/
+          test -n "$(ls dist/*-py3-none-any.whl)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+.venv/
+dist/
+build/
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.coverage

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -1,0 +1,38 @@
+"""Lint driver for bosn. Invoked by ./lint via `uv run python ci/lint.py`."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+CHECKS: list[list[str]] = [
+    ["ruff", "format", "--check", "."],
+    ["ruff", "check", "."],
+    ["pyright"],
+]
+
+
+def run(cmd: list[str]) -> int:
+    print(f"\n>>> {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, cwd=ROOT).returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else list(argv)
+    failed: list[str] = []
+    for check in CHECKS:
+        cmd = check + argv if argv else check
+        if run(cmd) != 0:
+            failed.append(cmd[0] + " " + (cmd[1] if len(cmd) > 1 else ""))
+    if failed:
+        print(f"\nLINT FAILED: {', '.join(failed)}", file=sys.stderr)
+        return 1
+    print("\nLINT OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test.py
+++ b/ci/test.py
@@ -1,0 +1,39 @@
+"""Test driver for bosn. Invoked by ./test via `uv run python ci/test.py`.
+
+Docker-backed tests carry the `docker` marker. They are skipped automatically when no
+engine is reachable, and are additionally excluded outright on non-Linux CI runners so
+the unit suite stands alone without an engine.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def docker_tests_enabled() -> bool:
+    """Docker tests run on Linux, and in CI only on Linux runners."""
+    if os.environ.get("BOSN_SKIP_DOCKER_TESTS"):
+        return False
+    if os.environ.get("CI") and not sys.platform.startswith("linux"):
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else list(argv)
+    cmd = ["pytest", "-v"]
+    if not docker_tests_enabled():
+        print("Docker tests disabled for this platform; running unit tests only.")
+        cmd += ["-m", "not docker"]
+    cmd += argv
+    print(f">>> {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, cwd=ROOT).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/install
+++ b/install
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+
+if ! command -v uv > /dev/null 2>&1; then
+  echo "uv not found; installing..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+uv sync --all-groups
+echo "bosn environment ready."

--- a/lint
+++ b/lint
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+exec uv run python ci/lint.py "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[project]
+name = "bosn"
+version = "0.1.0"
+description = "A machine-wide lifecycle supervisor for container development resources"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.11"
+authors = [{ name = "Zach Vorhies" }]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "running-process>=1.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/zackees/bosn"
+
+[project.scripts]
+bosn = "bosn.cli:main"
+bosn-docker = "bosn.docker_cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.6",
+    "pyright>=1.1.380",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/bosn"]
+
+[tool.ruff]
+line-length = 100
+src = ["src", "tests", "ci"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.pyright]
+include = ["src", "tests", "ci"]
+pythonVersion = "3.11"
+typeCheckingMode = "standard"
+reportMissingImports = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "docker: test requires a reachable Docker engine (Linux CI only)",
+]

--- a/src/bosn/__init__.py
+++ b/src/bosn/__init__.py
@@ -1,0 +1,5 @@
+"""bosn - a machine-wide lifecycle supervisor for container development resources."""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/src/bosn/__main__.py
+++ b/src/bosn/__main__.py
@@ -1,0 +1,6 @@
+"""Allow `python -m bosn` to invoke the CLI."""
+
+from bosn.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -1,0 +1,22 @@
+"""The `bosn` command line entry point."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from bosn import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="bosn", description=__doc__)
+    parser.add_argument("--version", action="version", version=__version__)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    parser.parse_args(argv if argv is not None else sys.argv[1:])
+    parser.print_help()
+    return 0

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -1,0 +1,22 @@
+"""The `bosn-docker` command line entry point (Docker/Compose drop-in front door)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from bosn import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="bosn-docker", description=__doc__)
+    parser.add_argument("--version", action="version", version=__version__)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    parser.parse_args(argv if argv is not None else sys.argv[1:])
+    parser.print_help()
+    return 0

--- a/test
+++ b/test
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+exec uv run python ci/test.py "$@"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,40 @@
+"""Phase 0 smoke tests: the console entry points exist and report a version."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+import bosn
+from bosn import cli, docker_cli
+
+
+def test_version_string_is_populated() -> None:
+    assert bosn.__version__
+    assert bosn.__version__[0].isdigit()
+
+
+@pytest.mark.parametrize("module", [cli, docker_cli])
+def test_version_flag_exits_zero_and_prints_version(module, capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        module.main(["--version"])
+    assert exc.value.code == 0
+    assert bosn.__version__ in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("module", [cli, docker_cli])
+def test_bare_invocation_prints_help(module, capsys) -> None:
+    assert module.main([]) == 0
+    assert module.build_parser().prog in capsys.readouterr().out
+
+
+def test_python_dash_m_entry_point() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "bosn", "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert bosn.__version__ in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,159 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "bosn"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "running-process" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "running-process", specifier = ">=1.0.0" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.380" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.6" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
+]
+
+[[package]]
+name = "running-process"
+version = "4.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/53/f4daf3bf2f2a0bfe1679193583a926af89fb8dd023e348f76d24a21ba445/running_process-4.10.1.tar.gz", hash = "sha256:f3672037919752e3ce75762041ac69c6053db6563e5b921f789ed5cf6eda9c3d", size = 1210783, upload-time = "2026-08-08T01:12:01.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/29/3c2bd13ed98dd8032ef034d06b93fad56d1c90f4c6c3b1ac3c794d1a1abc/running_process-4.10.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d701eecff7616cbdf4e121f1e88e9e1ddf0bf4b200041e00e4c0d3bf4ef6ebc9", size = 2744583, upload-time = "2026-08-08T01:11:50.546Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/9a/00f49a3f0eb9bcb80a626b74ad79832d83791152f2b14ba3f78d99f05717/running_process-4.10.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d88df68d5bbed721e0d98947a56a3e394271b41c152b54d322f25cfd2c933dec", size = 2730972, upload-time = "2026-08-08T01:11:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/db/e893c31afcf4485100524812fcf368f8968243b641ab7319ef85fe1b943e/running_process-4.10.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2220e6fb043915f0ba73025922fd59dab961fad9b7b19eb5bda1debfe27a6fc4", size = 4100545, upload-time = "2026-08-08T01:11:54.488Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4b/7c685ed227ad74d97af024e431a2ef11450e2b856db7e9bd8bd046f09674/running_process-4.10.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a2700a539f9b3d87ea7ca1e085058e67ad46f218cb3a88ba19b7548eaaeb7b9", size = 4215053, upload-time = "2026-08-08T01:11:56.564Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/48/f2698b5ce22850d91a6de03f0fa31e1bb736cf2403bdd05933b3d67d53d0/running_process-4.10.1-cp310-abi3-win_amd64.whl", hash = "sha256:83778de4b29cb7ffaf097490fb142ce0d0aa9963e85845513c5e6dee0dbc2f17", size = 3626697, upload-time = "2026-08-08T01:11:58.213Z" },
+    { url = "https://files.pythonhosted.org/packages/75/32/3560dbd76b7bf82ae35722a16094c54826f3a257a2918312a8111f09028c/running_process-4.10.1-cp310-abi3-win_arm64.whl", hash = "sha256:c66b48aec7ef6c2fa6f75ebc73a95c0853ddbef7c69e2ffab61a385dd20fc825", size = 3354947, upload-time = "2026-08-08T01:11:59.856Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
Phase 0 of #3.

- `pyproject.toml` (hatchling, py3-none-any, python >= 3.11), `bosn` + `bosn-docker` console scripts, `running-process` dependency.
- `./install`, `./lint`, `./test` bash trampolines; `./lint`/`./test` only exec `uv run python ci/lint.py` / `ci/test.py`.
- `ci/lint.py`: ruff format --check, ruff check, pyright. `ci/test.py`: pytest with passthrough args, excludes the `docker` marker on non-Linux CI.
- `.github/workflows/ci.yml`: ubuntu-latest only, runs docker version + install/lint/test + asserts a py3-none-any wheel.
- RED → GREEN: `tests/test_cli_smoke.py` fails without the entry points, passes with them. 6 passed locally, lint clean.

Refs #3