### PR TITLE
feat: phase 1 — CLI verb dispatch + bosn doctor

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -1,4 +1,9 @@
-"""The `bosn` command line entry point."""
+"""The `bosn` command line entry point.
+
+Every verb from the design is registered here. Verbs whose implementation has not landed
+yet exit with a specific error naming the verb and the phase that will land it — never a
+silent no-op and never a fallback to raw Docker.
+"""
 
 from __future__ import annotations
 
@@ -7,16 +12,71 @@ import sys
 from collections.abc import Sequence
 
 from bosn import __version__
+from bosn.engine import Engine
+
+NOT_IMPLEMENTED_EXIT = 3
+
+# verb -> (help text, phase that lands it)
+VERBS: dict[str, tuple[str, str]] = {
+    "run": ("run an ad-hoc command in a stack", "phase 5"),
+    "shell": ("interactive session in the persistent container", "phase 5"),
+    "tasks": ("list manifest tasks, stacks, digests, registration state", "phase 5"),
+    "jobs": ("list daemon-owned jobs", "phase 3"),
+    "attach": ("attach to a daemon-owned job", "phase 3"),
+    "status": ("tiers, leases, managed bytes vs ceiling, foreign registries", "phase 6"),
+    "gc": ("report or reclaim collectable resources", "phase 6"),
+    "done": ("mark this workspace finished; its caches become collectable", "phase 6"),
+    "doctor": ("engine health and reachability", "implemented"),
+}
+
+
+class VerbNotImplementedError(RuntimeError):
+    def __init__(self, verb: str, phase: str) -> None:
+        super().__init__(f"`bosn {verb}` is not implemented yet (lands in {phase}).")
+        self.verb = verb
+        self.phase = phase
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="bosn", description=__doc__)
+    parser = argparse.ArgumentParser(
+        prog="bosn", description="bosn - container lifecycle supervisor"
+    )
     parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument(
+        "--engine",
+        default="docker",
+        help="container engine binary to drive (default: docker)",
+    )
+    subparsers = parser.add_subparsers(dest="verb", metavar="VERB")
+    for verb, (help_text, _) in VERBS.items():
+        sub = subparsers.add_parser(verb, help=help_text)
+        sub.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
     return parser
+
+
+def cmd_doctor(engine_binary: str) -> int:
+    info = Engine(engine_binary).info()
+    print(f"engine binary:  {info.binary}")
+    print(f"client version: {info.client_version or '-'}")
+    print(f"server version: {info.server_version or '-'}")
+    print(f"reachable:      {'yes' if info.reachable else 'no'}")
+    if not info.reachable:
+        print(f"diagnosis:      {info.detail}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
-    parser.parse_args(argv if argv is not None else sys.argv[1:])
-    parser.print_help()
-    return 0
+    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if ns.verb is None:
+        parser.print_help()
+        return 0
+
+    if ns.verb == "doctor":
+        return cmd_doctor(ns.engine)
+
+    error = VerbNotImplementedError(ns.verb, VERBS[ns.verb][1])
+    print(str(error), file=sys.stderr)
+    return NOT_IMPLEMENTED_EXIT

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -1,0 +1,104 @@
+"""Container engine access.
+
+Engine access goes through the `docker` CLI rather than a Docker-specific API binding,
+which is what keeps podman cheap as a second target. Commands are always argument lists,
+never shell strings.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+
+import running_process as rp
+
+DEFAULT_TIMEOUT = 60
+
+
+class EngineError(RuntimeError):
+    """The engine could not be reached or refused a command."""
+
+
+@dataclass(frozen=True)
+class EngineResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+@dataclass(frozen=True)
+class EngineInfo:
+    binary: str
+    reachable: bool
+    client_version: str | None = None
+    server_version: str | None = None
+    detail: str | None = None
+
+
+class Engine:
+    """A thin wrapper over the `docker` (or `podman`) CLI."""
+
+    def __init__(self, binary: str = "docker", timeout: int = DEFAULT_TIMEOUT) -> None:
+        self.binary = binary
+        self.timeout = timeout
+
+    def available(self) -> bool:
+        """True when the engine binary is on PATH. Does not prove the daemon is up."""
+        return shutil.which(self.binary) is not None
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        if not self.available():
+            raise EngineError(f"{self.binary!r} is not on PATH")
+        completed = rp.subprocess_run(
+            [self.binary, *args],
+            cwd=None,
+            check=False,
+            timeout=self.timeout,
+        )
+        result = EngineResult(
+            returncode=completed.returncode,
+            stdout=(completed.stdout or "").strip(),
+            stderr=(getattr(completed, "stderr", "") or "").strip(),
+        )
+        if check and not result.ok:
+            raise EngineError(
+                f"{self.binary} {' '.join(args)} failed ({result.returncode}): "
+                f"{result.stderr or result.stdout}"
+            )
+        return result
+
+    def info(self) -> EngineInfo:
+        """Probe the engine. Never raises — the result carries the diagnosis."""
+        if not self.available():
+            return EngineInfo(
+                binary=self.binary,
+                reachable=False,
+                detail=f"{self.binary!r} is not on PATH",
+            )
+        try:
+            client = self.run(["version", "--format", "{{.Client.Version}}"])
+            server = self.run(["version", "--format", "{{.Server.Version}}"])
+        except Exception as exc:  # noqa: BLE001 - doctor must never crash
+            return EngineInfo(binary=self.binary, reachable=False, detail=str(exc))
+        if not server.ok:
+            return EngineInfo(
+                binary=self.binary,
+                reachable=False,
+                client_version=client.stdout or None,
+                detail=server.stderr or server.stdout or "engine daemon unreachable",
+            )
+        return EngineInfo(
+            binary=self.binary,
+            reachable=True,
+            client_version=client.stdout or None,
+            server_version=server.stdout or None,
+        )
+
+
+def engine_reachable(binary: str = "docker") -> bool:
+    """Convenience probe used to skip Docker-backed tests when no engine is present."""
+    return Engine(binary, timeout=20).info().reachable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures. Docker-marked tests skip themselves when no engine is reachable."""
+
+from __future__ import annotations
+
+import pytest
+
+from bosn.engine import Engine, engine_reachable
+
+_ENGINE_REACHABLE: bool | None = None
+
+
+def _reachable() -> bool:
+    global _ENGINE_REACHABLE
+    if _ENGINE_REACHABLE is None:
+        _ENGINE_REACHABLE = engine_reachable()
+    return bool(_ENGINE_REACHABLE)
+
+
+@pytest.fixture(scope="session")
+def engine() -> Engine:
+    return Engine()
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if item.get_closest_marker("docker") and not _reachable():
+        pytest.skip("no reachable Docker engine")

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -1,0 +1,35 @@
+"""Phase 1: verb dispatch is complete and unimplemented verbs fail loudly."""
+
+from __future__ import annotations
+
+import pytest
+
+from bosn import cli
+
+
+@pytest.mark.parametrize("verb", sorted(set(cli.VERBS) - {"doctor"}))
+def test_unimplemented_verbs_fail_with_a_specific_error(verb: str, capsys) -> None:
+    code = cli.main([verb])
+    assert code == cli.NOT_IMPLEMENTED_EXIT, f"{verb} must not silently succeed"
+    err = capsys.readouterr().err
+    assert verb in err
+    assert "not implemented" in err
+
+
+def test_every_designed_verb_is_registered() -> None:
+    designed = {"run", "shell", "tasks", "jobs", "attach", "status", "gc", "done", "doctor"}
+    assert designed <= set(cli.VERBS)
+
+
+def test_unknown_verb_is_rejected() -> None:
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["definitely-not-a-verb"])
+    assert exc.value.code != 0
+
+
+def test_doctor_reports_unreachable_engine_without_crashing(capsys) -> None:
+    code = cli.main(["--engine", "definitely-not-an-engine-binary", "doctor"])
+    assert code == 1
+    captured = capsys.readouterr()
+    assert "reachable:      no" in captured.out
+    assert "not on PATH" in captured.err

--- a/tests/test_engine_docker.py
+++ b/tests/test_engine_docker.py
@@ -1,0 +1,28 @@
+"""Phase 1: `bosn doctor` against a real engine. Docker-marked: Linux CI only."""
+
+from __future__ import annotations
+
+import pytest
+
+from bosn import cli
+from bosn.engine import Engine
+
+
+@pytest.mark.docker
+def test_engine_info_reports_versions(engine: Engine) -> None:
+    info = engine.info()
+    assert info.reachable
+    assert info.client_version
+    assert info.server_version
+
+
+@pytest.mark.docker
+def test_doctor_exits_zero_against_a_live_engine(capsys) -> None:
+    assert cli.main(["doctor"]) == 0
+    assert "reachable:      yes" in capsys.readouterr().out
+
+
+@pytest.mark.docker
+def test_engine_run_surfaces_failures(engine: Engine) -> None:
+    result = engine.run(["not-a-docker-subcommand"])
+    assert not result.ok


### PR DESCRIPTION
Phase 1 of #3.

- `src/bosn/engine.py`: docker-CLI wrapper (argument lists, no shell) built on `running_process.subprocess_run`; `Engine.info()` never raises, it returns a diagnosis.
- Full verb table in `cli.py`; unimplemented verbs exit 3 naming the verb + landing phase.
- `bosn doctor` reports client/server versions and reachability.
- Docker-backed tests carry `@pytest.mark.docker` and skip when no engine is reachable; `ci/test.py` also excludes them on non-Linux CI.
- 20 passed locally (including the 3 live-Docker tests), lint clean.

Refs #3