### PR TITLE
feat: phase 2 — sqlite WAL registry + label contract

### DIFF
--- a/src/bosn/clock.py
+++ b/src/bosn/clock.py
@@ -1,0 +1,35 @@
+"""Time source.
+
+Retention is a function of time, so time is injectable: TTL tests advance a fake clock
+instead of sleeping out real durations.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Protocol
+
+
+class Clock(Protocol):
+    def now(self) -> float:
+        """Seconds since the epoch."""
+        ...
+
+
+class SystemClock:
+    def now(self) -> float:
+        return time.time()
+
+
+class FakeClock:
+    """A manually advanced clock for retention tests."""
+
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self._now = float(start)
+
+    def now(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> float:
+        self._now += float(seconds)
+        return self._now

--- a/src/bosn/labels.py
+++ b/src/bosn/labels.py
@@ -1,0 +1,96 @@
+"""The label contract.
+
+Ownership is machine-readable: every managed resource carries a complete label set
+including the owning daemon's `registry` UUID. A resource is *ours* only when every
+required label is present and the registry id matches. Anything else is foreign or
+unlabeled — counted and reported, never deleted. Name prefixes are never ownership proof.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+NAMESPACE = "com.zackees.bosn"
+
+REGISTRY = f"{NAMESPACE}.registry"
+KIND = f"{NAMESPACE}.kind"
+STACK = f"{NAMESPACE}.stack"
+GENERATION = f"{NAMESPACE}.generation"
+SCOPE = f"{NAMESPACE}.scope"
+WORKSPACE = f"{NAMESPACE}.workspace"
+CREATED = f"{NAMESPACE}.created"
+
+REQUIRED_LABELS: tuple[str, ...] = (REGISTRY, KIND, STACK, GENERATION, SCOPE, WORKSPACE, CREATED)
+
+KINDS: frozenset[str] = frozenset({"container", "volume", "image", "builder"})
+SCOPES: frozenset[str] = frozenset({"spec", "stack", "machine"})
+
+
+class LabelError(ValueError):
+    """A label set is malformed."""
+
+
+@dataclass(frozen=True)
+class ResourceLabels:
+    registry: str
+    kind: str
+    stack: str
+    generation: str
+    scope: str
+    workspace: str
+    created: str
+
+    def __post_init__(self) -> None:
+        if self.kind not in KINDS:
+            raise LabelError(f"unknown kind {self.kind!r}; expected one of {sorted(KINDS)}")
+        if self.scope not in SCOPES:
+            raise LabelError(f"unknown scope {self.scope!r}; expected one of {sorted(SCOPES)}")
+        if not self.registry:
+            raise LabelError("registry id must not be empty")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            REGISTRY: self.registry,
+            KIND: self.kind,
+            STACK: self.stack,
+            GENERATION: self.generation,
+            SCOPE: self.scope,
+            WORKSPACE: self.workspace,
+            CREATED: self.created,
+        }
+
+    def to_docker_args(self) -> list[str]:
+        """Render as repeated `--label k=v` arguments for the engine CLI."""
+        args: list[str] = []
+        for key, value in self.to_dict().items():
+            args += ["--label", f"{key}={value}"]
+        return args
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, str]) -> ResourceLabels:
+        missing = [key for key in REQUIRED_LABELS if not raw.get(key)]
+        if missing:
+            raise LabelError(f"incomplete label set; missing {missing}")
+        return cls(
+            registry=raw[REGISTRY],
+            kind=raw[KIND],
+            stack=raw[STACK],
+            generation=raw[GENERATION],
+            scope=raw[SCOPE],
+            workspace=raw[WORKSPACE],
+            created=raw[CREATED],
+        )
+
+
+def is_complete(raw: dict[str, str]) -> bool:
+    """True when every required label is present and non-empty."""
+    return all(raw.get(key) for key in REQUIRED_LABELS)
+
+
+def is_owned_by(raw: dict[str, str], registry_id: str) -> bool:
+    """Ownership proof: a complete label set whose registry id is ours.
+
+    Incomplete labels are never ownership proof, even when the registry id matches --
+    a partially labeled resource may have been created by a version we cannot reason about.
+    """
+    return is_complete(raw) and raw.get(REGISTRY) == registry_id

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -1,0 +1,334 @@
+"""The sqlite registry.
+
+State is sqlite in WAL mode, chosen over alternatives specifically for failure shape:
+WAL readers never block behind a hung writer, so read-only verbs keep working when the
+daemon is wedged. The daemon is the only writer; read-only verbs open the file directly.
+
+Losing the database is survivable. Ownership lives in the Docker labels; the registry is
+authoritative only for time and leases, so a lost registry rebuilds by rescanning labels.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from bosn.clock import Clock, SystemClock
+
+SCHEMA_VERSION = 1
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS resources (
+    id          TEXT PRIMARY KEY,
+    kind        TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    stack       TEXT NOT NULL,
+    generation  TEXT NOT NULL,
+    scope       TEXT NOT NULL,
+    workspace   TEXT NOT NULL,
+    created_at  REAL NOT NULL,
+    last_used   REAL NOT NULL,
+    state       TEXT NOT NULL DEFAULT 'active'
+);
+
+CREATE INDEX IF NOT EXISTS idx_resources_stack ON resources(stack);
+CREATE INDEX IF NOT EXISTS idx_resources_state ON resources(state);
+
+CREATE TABLE IF NOT EXISTS leases (
+    id            TEXT PRIMARY KEY,
+    resource_id   TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    pid           INTEGER NOT NULL,
+    proc_start    REAL NOT NULL,
+    acquired_at   REAL NOT NULL,
+    heartbeat_at  REAL NOT NULL,
+    ttl_seconds   REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_leases_resource ON leases(resource_id);
+
+CREATE TABLE IF NOT EXISTS generations (
+    digest      TEXT PRIMARY KEY,
+    stack       TEXT NOT NULL,
+    created_at  REAL NOT NULL,
+    superseded_at REAL
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    at        REAL NOT NULL,
+    kind      TEXT NOT NULL,
+    detail    TEXT NOT NULL DEFAULT ''
+);
+"""
+
+
+def default_state_dir() -> Path:
+    override = os.environ.get("BOSN_STATE_DIR")
+    if override:
+        return Path(override)
+    is_windows = os.name.lower().startswith("nt")
+    if is_windows:
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "bosn"
+    xdg = os.environ.get("XDG_STATE_HOME")
+    if xdg:
+        return Path(xdg) / "bosn"
+    return Path.home() / ".local" / "state" / "bosn"
+
+
+def default_db_path() -> Path:
+    return default_state_dir() / "registry.sqlite3"
+
+
+@dataclass(frozen=True)
+class Resource:
+    id: str
+    kind: str
+    name: str
+    stack: str
+    generation: str
+    scope: str
+    workspace: str
+    created_at: float
+    last_used: float
+    state: str = "active"
+
+
+@dataclass(frozen=True)
+class Lease:
+    id: str
+    resource_id: str
+    pid: int
+    proc_start: float
+    acquired_at: float
+    heartbeat_at: float
+    ttl_seconds: float
+
+    def expired_by_time(self, now: float) -> bool:
+        return (now - self.heartbeat_at) > self.ttl_seconds
+
+
+class Registry:
+    """A WAL-mode sqlite registry. Use as a context manager or call close()."""
+
+    def __init__(
+        self,
+        path: Path | str | None = None,
+        *,
+        clock: Clock | None = None,
+        read_only: bool = False,
+    ) -> None:
+        self.path = Path(path) if path is not None else default_db_path()
+        self.clock: Clock = clock or SystemClock()
+        self.read_only = read_only
+        if not read_only:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(self.path), isolation_level=None)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA foreign_keys=ON")
+        self.conn.execute("PRAGMA busy_timeout=5000")
+        if not read_only:
+            self.conn.executescript(SCHEMA)
+            self._ensure_meta()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def __enter__(self) -> Registry:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def _ensure_meta(self) -> None:
+        self.conn.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', ?)",
+            (str(SCHEMA_VERSION),),
+        )
+        self.conn.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES ('registry_id', ?)",
+            (str(uuid.uuid4()),),
+        )
+
+    def meta(self, key: str) -> str | None:
+        row = self.conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+        return row["value"] if row else None
+
+    @property
+    def registry_id(self) -> str:
+        value = self.meta("registry_id")
+        if value is None:
+            raise RuntimeError("registry has no registry_id; database not initialized")
+        return value
+
+    @property
+    def journal_mode(self) -> str:
+        return str(self.conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+
+    # -- resources ---------------------------------------------------------
+
+    def register_resource(
+        self,
+        *,
+        kind: str,
+        name: str,
+        stack: str,
+        generation: str,
+        scope: str,
+        workspace: str,
+        resource_id: str | None = None,
+        created_at: float | None = None,
+    ) -> Resource:
+        now = self.clock.now()
+        rid = resource_id or str(uuid.uuid4())
+        created = now if created_at is None else created_at
+        self.conn.execute(
+            "INSERT OR REPLACE INTO resources"
+            "(id, kind, name, stack, generation, scope, workspace, created_at, last_used, state)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')",
+            (rid, kind, name, stack, generation, scope, workspace, created, created),
+        )
+        self.log_event("resource.registered", f"{kind}:{name}")
+        resource = self.get_resource(rid)
+        assert resource is not None
+        return resource
+
+    def get_resource(self, resource_id: str) -> Resource | None:
+        row = self.conn.execute("SELECT * FROM resources WHERE id = ?", (resource_id,)).fetchone()
+        return _resource_from_row(row) if row else None
+
+    def list_resources(self, *, state: str | None = None) -> list[Resource]:
+        if state is None:
+            rows = self.conn.execute("SELECT * FROM resources ORDER BY created_at").fetchall()
+        else:
+            rows = self.conn.execute(
+                "SELECT * FROM resources WHERE state = ? ORDER BY created_at", (state,)
+            ).fetchall()
+        return [_resource_from_row(row) for row in rows]
+
+    def touch_resource(self, resource_id: str) -> None:
+        self.conn.execute(
+            "UPDATE resources SET last_used = ? WHERE id = ?", (self.clock.now(), resource_id)
+        )
+
+    def set_resource_state(self, resource_id: str, state: str) -> None:
+        self.conn.execute("UPDATE resources SET state = ? WHERE id = ?", (state, resource_id))
+
+    def remove_resource(self, resource_id: str) -> None:
+        self.conn.execute("DELETE FROM resources WHERE id = ?", (resource_id,))
+        self.log_event("resource.removed", resource_id)
+
+    # -- leases ------------------------------------------------------------
+
+    def acquire_lease(
+        self,
+        resource_id: str,
+        *,
+        pid: int,
+        proc_start: float,
+        ttl_seconds: float = 900.0,
+    ) -> Lease:
+        now = self.clock.now()
+        lease_id = str(uuid.uuid4())
+        self.conn.execute(
+            "INSERT INTO leases"
+            "(id, resource_id, pid, proc_start, acquired_at, heartbeat_at, ttl_seconds)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (lease_id, resource_id, pid, proc_start, now, now, ttl_seconds),
+        )
+        self.log_event("lease.acquired", resource_id)
+        lease = self.get_lease(lease_id)
+        assert lease is not None
+        return lease
+
+    def get_lease(self, lease_id: str) -> Lease | None:
+        row = self.conn.execute("SELECT * FROM leases WHERE id = ?", (lease_id,)).fetchone()
+        return _lease_from_row(row) if row else None
+
+    def leases_for(self, resource_id: str) -> list[Lease]:
+        rows = self.conn.execute(
+            "SELECT * FROM leases WHERE resource_id = ?", (resource_id,)
+        ).fetchall()
+        return [_lease_from_row(row) for row in rows]
+
+    def heartbeat(self, lease_id: str) -> None:
+        self.conn.execute(
+            "UPDATE leases SET heartbeat_at = ? WHERE id = ?", (self.clock.now(), lease_id)
+        )
+
+    def release_lease(self, lease_id: str) -> None:
+        self.conn.execute("DELETE FROM leases WHERE id = ?", (lease_id,))
+        self.log_event("lease.released", lease_id)
+
+    # -- generations -------------------------------------------------------
+
+    def record_generation(self, digest: str, stack: str) -> None:
+        self.conn.execute(
+            "INSERT OR IGNORE INTO generations(digest, stack, created_at) VALUES (?, ?, ?)",
+            (digest, stack, self.clock.now()),
+        )
+
+    def supersede_generations(self, stack: str, keep_digest: str) -> int:
+        cur = self.conn.execute(
+            "UPDATE generations SET superseded_at = ?"
+            " WHERE stack = ? AND digest != ? AND superseded_at IS NULL",
+            (self.clock.now(), stack, keep_digest),
+        )
+        return cur.rowcount
+
+    def generation_superseded_at(self, digest: str) -> float | None:
+        row = self.conn.execute(
+            "SELECT superseded_at FROM generations WHERE digest = ?", (digest,)
+        ).fetchone()
+        return row["superseded_at"] if row else None
+
+    # -- events ------------------------------------------------------------
+
+    def log_event(self, kind: str, detail: str = "") -> None:
+        self.conn.execute(
+            "INSERT INTO events(at, kind, detail) VALUES (?, ?, ?)",
+            (self.clock.now(), kind, detail),
+        )
+
+    def events(self, limit: int = 100) -> list[sqlite3.Row]:
+        return self.conn.execute(
+            "SELECT * FROM events ORDER BY id DESC LIMIT ?", (limit,)
+        ).fetchall()
+
+
+def _resource_from_row(row: sqlite3.Row) -> Resource:
+    return Resource(
+        id=row["id"],
+        kind=row["kind"],
+        name=row["name"],
+        stack=row["stack"],
+        generation=row["generation"],
+        scope=row["scope"],
+        workspace=row["workspace"],
+        created_at=row["created_at"],
+        last_used=row["last_used"],
+        state=row["state"],
+    )
+
+
+def _lease_from_row(row: sqlite3.Row) -> Lease:
+    return Lease(
+        id=row["id"],
+        resource_id=row["resource_id"],
+        pid=row["pid"],
+        proc_start=row["proc_start"],
+        acquired_at=row["acquired_at"],
+        heartbeat_at=row["heartbeat_at"],
+        ttl_seconds=row["ttl_seconds"],
+    )

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,71 @@
+"""Phase 2: the label contract is ownership proof; nothing weaker is."""
+
+from __future__ import annotations
+
+import pytest
+
+from bosn import labels
+from bosn.labels import LabelError, ResourceLabels
+
+
+def make_labels(**overrides: str) -> ResourceLabels:
+    base = dict(
+        registry="reg-uuid-1",
+        kind="volume",
+        stack="test",
+        generation="sha256:abc",
+        scope="spec",
+        workspace="/w/one",
+        created="2026-08-13T00:00:00Z",
+    )
+    base.update(overrides)
+    return ResourceLabels(**base)  # type: ignore[arg-type]
+
+
+def test_round_trip_through_dict() -> None:
+    original = make_labels()
+    assert ResourceLabels.from_dict(original.to_dict()) == original
+
+
+def test_docker_args_render_every_required_label() -> None:
+    args = make_labels().to_docker_args()
+    assert args.count("--label") == len(labels.REQUIRED_LABELS)
+    rendered = " ".join(args)
+    for key in labels.REQUIRED_LABELS:
+        assert f"{key}=" in rendered
+
+
+@pytest.mark.parametrize("field", ["kind", "scope"])
+def test_unknown_enum_values_are_rejected(field: str) -> None:
+    with pytest.raises(LabelError):
+        make_labels(**{field: "nonsense"})
+
+
+def test_empty_registry_id_is_rejected() -> None:
+    with pytest.raises(LabelError):
+        make_labels(registry="")
+
+
+@pytest.mark.parametrize("missing", labels.REQUIRED_LABELS)
+def test_incomplete_label_set_is_never_ownership_proof(missing: str) -> None:
+    raw = make_labels().to_dict()
+    del raw[missing]
+    assert not labels.is_complete(raw)
+    # even with a matching registry id, an incomplete set is not proof
+    assert not labels.is_owned_by(raw, "reg-uuid-1")
+    with pytest.raises(LabelError):
+        ResourceLabels.from_dict(raw)
+
+
+def test_foreign_registry_is_not_owned() -> None:
+    raw = make_labels(registry="someone-elses-uuid").to_dict()
+    assert labels.is_complete(raw)
+    assert not labels.is_owned_by(raw, "reg-uuid-1")
+
+
+def test_name_prefix_is_not_ownership_proof() -> None:
+    assert not labels.is_owned_by({"com.zackees.bosn.name": "bosn-cache-x"}, "reg-uuid-1")
+
+
+def test_own_complete_labels_are_owned() -> None:
+    assert labels.is_owned_by(make_labels().to_dict(), "reg-uuid-1")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,149 @@
+"""Phase 2: the sqlite registry — WAL mode, round-trips, leases, generations.
+
+No Docker needed; these are pure unit tests and run on every platform.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bosn.clock import FakeClock
+from bosn.registry import Registry
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def registry(tmp_path: Path, clock: FakeClock):
+    with Registry(tmp_path / "registry.sqlite3", clock=clock) as reg:
+        yield reg
+
+
+def test_database_is_wal_mode(registry: Registry) -> None:
+    assert registry.journal_mode == "wal"
+
+
+def test_registry_id_is_a_stable_uuid(tmp_path: Path) -> None:
+    path = tmp_path / "r.sqlite3"
+    with Registry(path) as first:
+        original = first.registry_id
+    with Registry(path) as second:
+        assert second.registry_id == original
+    assert len(original) == 36
+
+
+def test_registry_ids_differ_across_databases(tmp_path: Path) -> None:
+    with Registry(tmp_path / "a.sqlite3") as a, Registry(tmp_path / "b.sqlite3") as b:
+        assert a.registry_id != b.registry_id
+
+
+def test_resource_round_trip(registry: Registry) -> None:
+    resource = registry.register_resource(
+        kind="volume",
+        name="bosn-target-abc",
+        stack="test",
+        generation="sha256:abc",
+        scope="spec",
+        workspace="/w/one",
+    )
+    fetched = registry.get_resource(resource.id)
+    assert fetched == resource
+    assert fetched is not None
+    assert fetched.state == "active"
+    assert [r.id for r in registry.list_resources()] == [resource.id]
+
+
+def test_touch_resource_advances_last_used(registry: Registry, clock: FakeClock) -> None:
+    resource = registry.register_resource(
+        kind="container",
+        name="c1",
+        stack="test",
+        generation="g",
+        scope="stack",
+        workspace="/w",
+    )
+    assert resource.last_used == resource.created_at
+    clock.advance(3600)
+    registry.touch_resource(resource.id)
+    updated = registry.get_resource(resource.id)
+    assert updated is not None
+    assert updated.last_used == resource.created_at + 3600
+
+
+def test_lease_expiry_is_driven_by_the_injected_clock(registry: Registry, clock: FakeClock) -> None:
+    resource = registry.register_resource(
+        kind="volume", name="v", stack="s", generation="g", scope="spec", workspace="/w"
+    )
+    lease = registry.acquire_lease(resource.id, pid=4242, proc_start=1.0, ttl_seconds=900)
+    assert not lease.expired_by_time(clock.now())
+
+    clock.advance(899)
+    assert not lease.expired_by_time(clock.now())
+
+    clock.advance(2)
+    assert lease.expired_by_time(clock.now())
+
+
+def test_heartbeat_defers_expiry(registry: Registry, clock: FakeClock) -> None:
+    resource = registry.register_resource(
+        kind="volume", name="v", stack="s", generation="g", scope="spec", workspace="/w"
+    )
+    lease = registry.acquire_lease(resource.id, pid=1, proc_start=1.0, ttl_seconds=100)
+    clock.advance(90)
+    registry.heartbeat(lease.id)
+    clock.advance(90)
+    refreshed = registry.get_lease(lease.id)
+    assert refreshed is not None
+    assert not refreshed.expired_by_time(clock.now())
+
+
+def test_removing_a_resource_cascades_to_its_leases(registry: Registry) -> None:
+    resource = registry.register_resource(
+        kind="volume", name="v", stack="s", generation="g", scope="spec", workspace="/w"
+    )
+    registry.acquire_lease(resource.id, pid=1, proc_start=1.0)
+    assert registry.leases_for(resource.id)
+    registry.remove_resource(resource.id)
+    assert registry.leases_for(resource.id) == []
+
+
+def test_generations_supersede_all_but_the_current_digest(
+    registry: Registry, clock: FakeClock
+) -> None:
+    registry.record_generation("sha256:old", "test")
+    clock.advance(60)
+    registry.record_generation("sha256:new", "test")
+    assert registry.supersede_generations("test", keep_digest="sha256:new") == 1
+    assert registry.generation_superseded_at("sha256:old") == clock.now()
+    assert registry.generation_superseded_at("sha256:new") is None
+
+
+def test_events_are_recorded_for_lifecycle_actions(registry: Registry) -> None:
+    resource = registry.register_resource(
+        kind="volume", name="v", stack="s", generation="g", scope="spec", workspace="/w"
+    )
+    registry.acquire_lease(resource.id, pid=1, proc_start=1.0)
+    kinds = [row["kind"] for row in registry.events()]
+    assert "resource.registered" in kinds
+    assert "lease.acquired" in kinds
+
+
+def test_a_second_reader_sees_writes_and_is_not_blocked(tmp_path: Path) -> None:
+    """WAL readers never block behind a writer -- that is why WAL was chosen."""
+    path = tmp_path / "shared.sqlite3"
+    with Registry(path) as writer:
+        writer.register_resource(
+            kind="volume", name="v", stack="s", generation="g", scope="spec", workspace="/w"
+        )
+        # open a reader while the writer connection is still live
+        with Registry(path, read_only=True) as reader:
+            assert len(reader.list_resources()) == 1
+            writer.register_resource(
+                kind="volume", name="v2", stack="s", generation="g", scope="spec", workspace="/w"
+            )
+            assert len(reader.list_resources()) == 2


### PR DESCRIPTION
Phase 2 of #3.

- `labels.py`: complete label contract with a `registry` UUID. `is_owned_by` requires a complete set *and* a matching registry id; incomplete sets and name prefixes are never ownership proof (tested per-label).
- `registry.py`: WAL sqlite with resources/leases/generations/events, stable registry UUID, cascade delete of leases, generation supersede.
- `clock.py`: injectable time source (`FakeClock`) so retention tests never sleep out real TTLs.
- All Phase 2 tests are pure unit tests — no Docker, run on every platform.
- 46 passed locally, lint clean.

Refs #3