### PR TITLE
feat: phase 3 — daemon singleton (port-as-primitive), KBI lint, CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # bosn
 
+[![CI (Linux)](https://github.com/zackees/bosn/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/zackees/bosn/actions/workflows/ci.yml)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 **A machine-wide lifecycle supervisor for container development resources.**
 
 `bosn` (bo's'n — the ship's officer who keeps the deck in order) is a standalone CLI
@@ -190,6 +194,34 @@ clud ships a thin `clud bosn …` forwarder that passes argv verbatim to the exe
 as it shells out to soldr, pinned to a bosn release. The second seam is the worktree-teardown
 hook that calls `bosn done`. Both degrade safely when bosn is absent: teardown proceeds, and
 the derived signals catch up later.
+
+## Development
+
+Three bash trampolines are the whole interface. `./lint` and `./test` hold no logic of
+their own — they exec into `ci/lint.py` and `ci/test.py`, which do the real work under `uv`:
+
+```bash
+./install     # install uv if absent, then `uv sync --all-groups`
+./lint        # ruff format --check, ruff check, pyright, KeyboardInterrupt checker
+./test        # pytest; passthrough args work, e.g. ./test -k registry
+```
+
+Linting includes a dedicated **KeyboardInterrupt checker** (`ci/lint_kbi.py`). Ctrl-C and
+Python do not mix well: a broad `except Exception` silently swallows the user's interrupt.
+Ruff's BLE001 can flag the blind except, but the actual defect is the *missing*
+`except KeyboardInterrupt` beside it, so an AST checker enforces that instead:
+
+| Code | Rule |
+| --- | --- |
+| `KBI001` | `except Exception` / `BaseException` with no sibling `except KeyboardInterrupt` |
+| `KBI002` | a `KeyboardInterrupt` handler that neither re-raises nor calls `_thread.interrupt_main()` |
+| `KBI003` | a bare `except:` that never re-raises |
+
+Suppress a line with `# noqa: KBI001` when a case is genuinely intentional.
+
+CI runs on Linux only. Docker-backed tests carry a `docker` pytest marker: they skip when no
+engine is reachable, and `ci/test.py` excludes them outright on non-Linux CI runners, so the
+unit suite stands alone without an engine.
 
 ## License
 

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -12,6 +12,9 @@ CHECKS: list[list[str]] = [
     ["ruff", "format", "--check", "."],
     ["ruff", "check", "."],
     ["pyright"],
+    # Ctrl-C correctness: ruff's BLE001 flags blind excepts but cannot see the *missing*
+    # KeyboardInterrupt sibling handler, which is the actual defect.
+    [sys.executable, str(ROOT / "ci" / "lint_kbi.py")],
 ]
 
 
@@ -26,7 +29,7 @@ def main(argv: list[str] | None = None) -> int:
     for check in CHECKS:
         cmd = check + argv if argv else check
         if run(cmd) != 0:
-            failed.append(cmd[0] + " " + (cmd[1] if len(cmd) > 1 else ""))
+            failed.append(" ".join(Path(part).name for part in cmd[:2]))
     if failed:
         print(f"\nLINT FAILED: {', '.join(failed)}", file=sys.stderr)
         return 1

--- a/ci/lint_kbi.py
+++ b/ci/lint_kbi.py
@@ -1,0 +1,184 @@
+"""KeyboardInterrupt (Ctrl-C) lint checks.
+
+Ctrl-C and Python do not mix well: a broad `except Exception` silently swallows the user's
+interrupt, and a process that eats SIGINT becomes unkillable-by-habit. This is an AST
+checker in the shape FastLED settled on after abandoning its flake8 plugin -- ruff's BLE001
+is not precise enough, since the problem is not the blind except itself but the *missing
+KeyboardInterrupt path* next to it.
+
+Error codes:
+    KBI001  try/except catches Exception or BaseException (or bare except) with no
+            sibling `except KeyboardInterrupt` handler
+    KBI002  an `except KeyboardInterrupt` handler neither re-raises nor calls
+            _thread.interrupt_main()
+    KBI003  a bare `except:` that does not re-raise at all
+
+Suppress a line with `# noqa` or `# noqa: KBI001`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PATHS = ["src", "ci", "tests"]
+NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[A-Z]+\d+(?:\s*,\s*[A-Z]+\d+)*))?", re.IGNORECASE)
+
+BROAD = {"Exception", "BaseException"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line: int
+    code: str
+    message: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line}: {self.code} {self.message}"
+
+
+def _suppressed(source_lines: list[str], line: int, code: str) -> bool:
+    if line - 1 >= len(source_lines):
+        return False
+    match = NOQA_RE.search(source_lines[line - 1])
+    if match is None:
+        return False
+    codes = match.group("codes")
+    if codes is None:
+        return True
+    return code.upper() in {part.strip().upper() for part in codes.split(",")}
+
+
+def _handler_names(handler: ast.ExceptHandler) -> set[str]:
+    node = handler.type
+    if node is None:
+        return set()
+    parts = node.elts if isinstance(node, ast.Tuple) else [node]
+    names: set[str] = set()
+    for part in parts:
+        if isinstance(part, ast.Name):
+            names.add(part.id)
+        elif isinstance(part, ast.Attribute):
+            names.add(part.attr)
+    return names
+
+
+def _reraises(handler: ast.ExceptHandler) -> bool:
+    return any(isinstance(node, ast.Raise) for node in ast.walk(handler))
+
+
+def _interrupts_main(handler: ast.ExceptHandler) -> bool:
+    for node in ast.walk(handler):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name in {"interrupt_main", "notify_main_thread", "handle_keyboard_interrupt"}:
+            return True
+    return False
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(self, path: Path, source_lines: list[str]) -> None:
+        self.path = path
+        self.source_lines = source_lines
+        self.violations: list[Violation] = []
+
+    def _add(self, node: ast.AST, code: str, message: str) -> None:
+        line = getattr(node, "lineno", 0)
+        if _suppressed(self.source_lines, line, code):
+            return
+        self.violations.append(Violation(self.path, line, code, message))
+
+    def visit_Try(self, node: ast.Try) -> None:
+        handles_kbi = any("KeyboardInterrupt" in _handler_names(h) for h in node.handlers)
+
+        for handler in node.handlers:
+            names = _handler_names(handler)
+
+            if "KeyboardInterrupt" in names:
+                if not _reraises(handler) and not _interrupts_main(handler):
+                    self._add(
+                        handler,
+                        "KBI002",
+                        "KeyboardInterrupt handler must re-raise or call "
+                        "_thread.interrupt_main(); swallowing Ctrl-C strands the user",
+                    )
+                continue
+
+            if not names:  # bare `except:`
+                if not _reraises(handler):
+                    self._add(
+                        handler,
+                        "KBI003",
+                        "bare `except:` swallows KeyboardInterrupt; catch Exception and "
+                        "re-raise KeyboardInterrupt explicitly",
+                    )
+                continue
+
+            if names & BROAD and not handles_kbi:
+                caught = ", ".join(sorted(names & BROAD))
+                self._add(
+                    handler,
+                    "KBI001",
+                    f"`except {caught}` has no sibling `except KeyboardInterrupt`; "
+                    "add one that re-raises so Ctrl-C is not swallowed",
+                )
+
+        self.generic_visit(node)
+
+
+def check_source(path: Path, source: str) -> list[Violation]:
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [Violation(path, exc.lineno or 0, "KBI000", f"syntax error: {exc.msg}")]
+    visitor = _Visitor(path, source.splitlines())
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def check_file(path: Path) -> list[Violation]:
+    return check_source(path, path.read_text(encoding="utf-8"))
+
+
+def iter_python_files(paths: list[str], exclude: list[str]) -> list[Path]:
+    found: list[Path] = []
+    for raw in paths:
+        target = Path(raw)
+        if not target.is_absolute():
+            target = ROOT / target
+        if target.is_file() and target.suffix == ".py":
+            found.append(target)
+        elif target.is_dir():
+            found.extend(sorted(target.rglob("*.py")))
+    return [p for p in found if not any(token in p.as_posix() for token in exclude)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", default=DEFAULT_PATHS)
+    parser.add_argument("--exclude", nargs="*", default=[".venv", "__pycache__"])
+    ns = parser.parse_args(argv)
+
+    violations: list[Violation] = []
+    for path in iter_python_files(ns.paths or DEFAULT_PATHS, ns.exclude):
+        violations.extend(check_file(path))
+
+    for violation in sorted(violations, key=lambda v: (str(v.path), v.line)):
+        print(violation.render())
+
+    if violations:
+        print(f"\n{len(violations)} KeyboardInterrupt issue(s) found", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,5 @@ reportMissingImports = false
 testpaths = ["tests"]
 markers = [
     "docker: test requires a reachable Docker engine (Linux CI only)",
+    "slow: test spawns real processes or builds images",
 ]

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -8,11 +8,15 @@ silent no-op and never a fallback to raw Docker.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 
-from bosn import __version__
+from bosn import __version__, ipc
 from bosn.engine import Engine
+
+DAEMON_VERB = "__daemon"
 
 NOT_IMPLEMENTED_EXIT = 3
 
@@ -21,8 +25,8 @@ VERBS: dict[str, tuple[str, str]] = {
     "run": ("run an ad-hoc command in a stack", "phase 5"),
     "shell": ("interactive session in the persistent container", "phase 5"),
     "tasks": ("list manifest tasks, stacks, digests, registration state", "phase 5"),
-    "jobs": ("list daemon-owned jobs", "phase 3"),
-    "attach": ("attach to a daemon-owned job", "phase 3"),
+    "jobs": ("list daemon-owned jobs", "implemented"),
+    "attach": ("attach to a daemon-owned job", "phase 5"),
     "status": ("tiers, leases, managed bytes vs ceiling, foreign registries", "phase 6"),
     "gc": ("report or reclaim collectable resources", "phase 6"),
     "done": ("mark this workspace finished; its caches become collectable", "phase 6"),
@@ -47,11 +51,28 @@ def build_parser() -> argparse.ArgumentParser:
         default="docker",
         help="container engine binary to drive (default: docker)",
     )
+    parser.add_argument(
+        "--state-dir",
+        default=None,
+        help="override the bosn state directory (registry + daemon state)",
+    )
     subparsers = parser.add_subparsers(dest="verb", metavar="VERB")
     for verb, (help_text, _) in VERBS.items():
         sub = subparsers.add_parser(verb, help=help_text)
         sub.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+
+    daemon_parser = subparsers.add_parser(DAEMON_VERB, help=argparse.SUPPRESS)
+    daemon_parser.add_argument("--port", type=int, default=None)
+    daemon_parser.add_argument("--idle-retire-seconds", type=float, default=None)
+    daemon_parser.add_argument("--stop", action="store_true", help="stop a running daemon")
+    # Accepted after the verb as well, so a spawned argv need not order its flags.
+    daemon_parser.add_argument("--state-dir", default=None, dest="daemon_state_dir")
     return parser
+
+
+def resolve_state_dir(ns: argparse.Namespace) -> Path | None:
+    raw = getattr(ns, "daemon_state_dir", None) or ns.state_dir
+    return Path(raw) if raw else None
 
 
 def cmd_doctor(engine_binary: str) -> int:
@@ -66,6 +87,41 @@ def cmd_doctor(engine_binary: str) -> int:
     return 0
 
 
+def cmd_daemon(ns: argparse.Namespace) -> int:
+    from bosn import daemon as daemon_mod
+
+    state_dir = resolve_state_dir(ns)
+
+    if ns.stop:
+        stopped = daemon_mod.stop(state_dir)
+        print("daemon stopped" if stopped else "no daemon was running")
+        return 0
+
+    idle = (
+        ns.idle_retire_seconds
+        if ns.idle_retire_seconds is not None
+        else daemon_mod.DEFAULT_IDLE_RETIRE_SECONDS
+    )
+    try:
+        daemon = daemon_mod.Daemon(state_dir=state_dir, port=ns.port, idle_retire_seconds=idle)
+        return daemon.serve_forever()
+    except daemon_mod.DaemonError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+def cmd_jobs(ns: argparse.Namespace) -> int:
+    from bosn import daemon as daemon_mod
+
+    try:
+        reply = daemon_mod.request("jobs", resolve_state_dir(ns))
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:  # fail closed, stay visible
+        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(reply.get("jobs", []), indent=2))
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
@@ -74,8 +130,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.print_help()
         return 0
 
+    if ns.verb == DAEMON_VERB:
+        return cmd_daemon(ns)
+
     if ns.verb == "doctor":
         return cmd_doctor(ns.engine)
+
+    if ns.verb == "jobs":
+        return cmd_jobs(ns)
 
     error = VerbNotImplementedError(ns.verb, VERBS[ns.verb][1])
     print(str(error), file=sys.stderr)

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -140,8 +140,20 @@ class _Handler(socketserver.StreamRequestHandler):
 
 
 class _Server(socketserver.ThreadingTCPServer):
-    # Address reuse OFF on purpose: the failed bind IS the singleton check.
-    allow_reuse_address = False
+    # SO_REUSEADDR is platform-conditional, and the difference matters for correctness.
+    #
+    # On POSIX it only permits binding a port stuck in TIME_WAIT; a port with a *live*
+    # listener still refuses the bind, so the singleton guarantee is intact and a restarted
+    # daemon does not have to wait out TIME_WAIT before it can serve again.
+    #
+    # On Windows SO_REUSEADDR is different: it lets a second socket steal a port that is
+    # actively being listened on, which would silently break the singleton. So it stays off
+    # there and a restart eats the TIME_WAIT delay instead.
+    #
+    # SO_REUSEPORT is never set on any platform -- that one really does allow two live
+    # listeners on one port, which is precisely the thing this design relies on being
+    # impossible.
+    allow_reuse_address = not sys.platform.startswith("win")
     daemon_threads = True
 
     def __init__(self, addr: tuple[str, int], daemon_ref: Daemon) -> None:
@@ -279,6 +291,24 @@ class Daemon:
 # -- client side -----------------------------------------------------------
 
 
+def spawn_daemon_available() -> bool:
+    """True when running-process can actually detach on this platform.
+
+    `spawn_daemon` needs a trampoline binary shipped in the wheel's assets directory.
+    running-process 4.10.1 publishes wheels without it on every platform, so the blessed
+    spawner is present in the API but not yet usable. Probing keeps the failure legible
+    instead of surfacing as a FileNotFoundError deep inside a spawn.
+    """
+    try:
+        # The *bundled* path inside the installed wheel -- not assets_dir(), which is the
+        # runtime hard-link cache and can hold a trampoline the spawner will not look at.
+        return rp_daemon.trampoline_source_path().exists()
+    except KeyboardInterrupt:
+        raise
+    except Exception:  # noqa: BLE001 - probe must never crash a caller
+        return False
+
+
 def _detach(state_dir: Path) -> int:
     """Start a detached `bosn __daemon` via running-process's daemon spawner.
 
@@ -287,6 +317,12 @@ def _detach(state_dir: Path) -> int:
     pid. Hand-rolling this with subprocess flags pops a console on Windows, which is exactly
     what a background supervisor must never do.
     """
+    if not spawn_daemon_available():
+        raise DaemonError(
+            "running-process cannot detach on this platform: its installed wheel ships no "
+            "bundled daemon-trampoline binary. Install a running-process build that "
+            "includes it, or start the daemon manually with `bosn __daemon`."
+        )
     env = rp_daemon.build_daemon_env(dict(os.environ))
     env["BOSN_STATE_DIR"] = str(state_dir)
     argv = [sys.executable, "-m", "bosn", "__daemon", "--state-dir", str(state_dir)]

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -1,0 +1,366 @@
+"""The `bosn __daemon` singleton.
+
+The daemon is the registry's only writer and the only executor of reap and GC. It is lazily
+spawned by the CLI, heartbeats while it serves, and idle-retires so an unused machine runs
+no daemon.
+
+**Singleton enforcement is the port bind itself.** The daemon listens on a deterministic
+loopback port derived from its state directory, with address reuse disabled, so a second
+daemon's `bind()` fails with EADDRINUSE and the operating system is the arbiter. No broker,
+no lock file, and no pid comparison can disagree with it -- a stale state file cannot fake
+a live listener, and a live listener cannot be missed. The state file is reporting metadata
+only; discovery never depends on it.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import socket
+import socketserver
+import sys
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from running_process import daemon as rp_daemon
+
+from bosn import __version__, ipc
+from bosn.registry import Registry, default_state_dir
+
+DAEMON_NAME = "bosn-daemon"
+DEFAULT_PORT = 47764
+# Deterministic per-state-dir ports live in the IANA dynamic range, above the default.
+PORT_RANGE_START = 47765
+PORT_RANGE_SIZE = 1024
+
+DEFAULT_IDLE_RETIRE_SECONDS = 900.0
+SPAWN_TIMEOUT_SECONDS = 30.0
+
+
+class DaemonError(RuntimeError):
+    """The daemon could not be started, reached, or stopped."""
+
+
+def state_file(state_dir: Path | None = None) -> Path:
+    return (state_dir or default_state_dir()) / "daemon.json"
+
+
+def port_for(state_dir: Path | None = None) -> int:
+    """The deterministic loopback port that owns this state directory.
+
+    Deterministic, never ephemeral: the client must be able to find the daemon without
+    reading any file, and the OS must be able to refuse a second bind on the same port.
+    An explicit BOSN_PORT wins so operators can move it off a conflicting port.
+    """
+    override = os.environ.get("BOSN_PORT")
+    if override:
+        return int(override)
+    state_dir = state_dir or default_state_dir()
+    if state_dir == default_state_dir():
+        return DEFAULT_PORT
+    digest = hashlib.sha256(str(state_dir.resolve()).encode("utf-8")).digest()
+    return PORT_RANGE_START + (int.from_bytes(digest[:4], "big") % PORT_RANGE_SIZE)
+
+
+@dataclass(frozen=True)
+class DaemonState:
+    pid: int
+    port: int
+    started_at: float
+    version: str
+
+    def write(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(asdict(self)), encoding="utf-8")
+        tmp.replace(path)
+
+    @classmethod
+    def read(cls, path: Path) -> DaemonState | None:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        try:
+            return cls(**raw)
+        except TypeError:
+            return None
+
+
+def is_serving(state_dir: Path | None = None, *, timeout: float = 2.0) -> bool:
+    """True when something answers the ping on this state dir's port."""
+    try:
+        reply = ipc.send_request(port_for(state_dir), {"verb": "ping"}, timeout=timeout)
+    except ipc.TransportError:
+        return False
+    return bool(reply.get("ok"))
+
+
+def running_state(state_dir: Path | None = None) -> DaemonState | None:
+    """Reporting metadata for a *live* daemon, or None.
+
+    Liveness is decided by the port, not by the file. A state file left behind by a killed
+    daemon is removed rather than believed.
+    """
+    state_dir = state_dir or default_state_dir()
+    path = state_file(state_dir)
+    serving = is_serving(state_dir)
+    state = DaemonState.read(path)
+    if not serving:
+        path.unlink(missing_ok=True)
+        return None
+    if state is None:
+        # Serving but no readable metadata: report what we can prove.
+        return DaemonState(pid=0, port=port_for(state_dir), started_at=0.0, version="unknown")
+    return state
+
+
+class _Handler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        request = ipc.read_request(self.connection)
+        if request is None:
+            return
+        daemon_ref: Daemon = self.server.daemon_ref  # type: ignore[attr-defined]
+        daemon_ref.note_activity()
+        verb = str(request.get("verb", ""))
+        try:
+            response = daemon_ref.dispatch(verb, request)
+        except KeyboardInterrupt:
+            # Ctrl-C on the daemon means shut down, not "this one request failed".
+            daemon_ref.request_stop()
+            raise
+        except Exception as exc:  # noqa: BLE001 - every failure is observable, none fatal
+            response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        ipc.send_response(self.connection, response)
+
+
+class _Server(socketserver.ThreadingTCPServer):
+    # Address reuse OFF on purpose: the failed bind IS the singleton check.
+    allow_reuse_address = False
+    daemon_threads = True
+
+    def __init__(self, addr: tuple[str, int], daemon_ref: Daemon) -> None:
+        self.daemon_ref = daemon_ref
+        super().__init__(addr, _Handler)
+
+
+class Daemon:
+    """The serving side. Owns the registry connection and the idle clock."""
+
+    def __init__(
+        self,
+        *,
+        state_dir: Path | None = None,
+        port: int | None = None,
+        idle_retire_seconds: float = DEFAULT_IDLE_RETIRE_SECONDS,
+    ) -> None:
+        self.state_dir = state_dir or default_state_dir()
+        self.bind_port = port_for(self.state_dir) if port is None else port
+        self.idle_retire_seconds = idle_retire_seconds
+        self.started_at = time.time()
+        self.last_activity = self.started_at
+        self.heartbeat_at = self.started_at
+        self._server: _Server | None = None
+        self._stop = threading.Event()
+        self.registry = Registry(self.state_dir / "registry.sqlite3")
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @property
+    def port(self) -> int:
+        if self._server is None:
+            return self.bind_port
+        return int(self._server.server_address[1])
+
+    def note_activity(self) -> None:
+        self.last_activity = time.time()
+        self.heartbeat_at = self.last_activity
+
+    def idle_seconds(self) -> float:
+        return time.time() - self.last_activity
+
+    def should_retire(self) -> bool:
+        return self.idle_seconds() >= self.idle_retire_seconds
+
+    def serve_forever(self) -> int:
+        try:
+            self._server = _Server((ipc.LOOPBACK, self.bind_port), self)
+        except OSError as exc:
+            self.registry.close()
+            if exc.errno in (errno.EADDRINUSE, getattr(errno, "WSAEADDRINUSE", errno.EADDRINUSE)):
+                raise DaemonError(
+                    f"another bosn daemon already owns port {self.bind_port}; "
+                    "refusing to start a second"
+                ) from exc
+            raise
+
+        DaemonState(
+            pid=os.getpid(),
+            port=self.port,
+            started_at=self.started_at,
+            version=__version__,
+        ).write(state_file(self.state_dir))
+        self.registry.log_event("daemon.started", f"pid={os.getpid()} port={self.port}")
+
+        threading.Thread(target=self._idle_watchdog, daemon=True).start()
+        try:
+            self._server.serve_forever(poll_interval=0.2)
+        finally:
+            self.shutdown()
+        return 0
+
+    def _idle_watchdog(self) -> None:
+        while not self._stop.wait(0.5):
+            if self.should_retire():
+                self.registry.log_event("daemon.idle_retired", f"idle={self.idle_seconds():.0f}s")
+                self.request_stop()
+                return
+
+    def request_stop(self) -> None:
+        self._stop.set()
+        if self._server is not None:
+            threading.Thread(target=self._server.shutdown, daemon=True).start()
+
+    def shutdown(self) -> None:
+        self._stop.set()
+        if self._server is not None:
+            self._server.server_close()
+            self._server = None
+        state_file(self.state_dir).unlink(missing_ok=True)
+        try:
+            self.registry.log_event("daemon.stopped", "")
+            self.registry.close()
+        except KeyboardInterrupt:
+            raise
+        except Exception:  # noqa: BLE001 - shutdown must not raise
+            pass
+
+    # -- verbs -------------------------------------------------------------
+
+    def dispatch(self, verb: str, request: dict[str, Any]) -> dict[str, Any]:
+        handler = {
+            "ping": self._verb_ping,
+            "status": self._verb_status,
+            "jobs": self._verb_jobs,
+            "shutdown": self._verb_shutdown,
+        }.get(verb)
+        if handler is None:
+            return {"ok": False, "error": f"unknown daemon verb {verb!r}"}
+        return handler(request)
+
+    def _verb_ping(self, _request: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True, "pong": True, "pid": os.getpid(), "version": __version__}
+
+    def _verb_status(self, _request: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "pid": os.getpid(),
+            "port": self.port,
+            "version": __version__,
+            "registry_id": self.registry.registry_id,
+            "uptime_seconds": time.time() - self.started_at,
+            "idle_seconds": self.idle_seconds(),
+            "resources": len(self.registry.list_resources()),
+        }
+
+    def _verb_jobs(self, _request: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True, "jobs": []}
+
+    def _verb_shutdown(self, _request: dict[str, Any]) -> dict[str, Any]:
+        self.request_stop()
+        return {"ok": True, "stopping": True}
+
+
+# -- client side -----------------------------------------------------------
+
+
+def _detach(state_dir: Path) -> int:
+    """Start a detached `bosn __daemon` via running-process's daemon spawner.
+
+    `running_process.daemon.spawn_daemon` is the platform-blessed path: it detaches without
+    a console window on Windows, sets up its own runtime dir and log sidecar, and tracks the
+    pid. Hand-rolling this with subprocess flags pops a console on Windows, which is exactly
+    what a background supervisor must never do.
+    """
+    env = rp_daemon.build_daemon_env(dict(os.environ))
+    env["BOSN_STATE_DIR"] = str(state_dir)
+    argv = [sys.executable, "-m", "bosn", "__daemon", "--state-dir", str(state_dir)]
+    handle = rp_daemon.spawn_daemon(
+        argv,
+        name=f"{DAEMON_NAME}-{port_for(state_dir)}",
+        env=env,
+        log_path=str(state_dir / "daemon.log"),
+    )
+    return handle.pid
+
+
+def spawn(state_dir: Path | None = None, *, timeout: float = SPAWN_TIMEOUT_SECONDS) -> DaemonState:
+    """Lazily spawn the daemon and wait until it answers. Idempotent.
+
+    Racing spawns are harmless: whichever process wins the bind serves, and the losers exit
+    with EADDRINUSE while their callers connect to the winner.
+    """
+    state_dir = state_dir or default_state_dir()
+    if is_serving(state_dir):
+        state = running_state(state_dir)
+        if state is not None:
+            return state
+
+    _detach(state_dir)
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        state = running_state(state_dir)
+        if state is not None:
+            return state
+        time.sleep(0.1)
+    raise DaemonError(f"daemon did not answer on port {port_for(state_dir)} within {timeout:.0f}s")
+
+
+def request(
+    verb: str,
+    state_dir: Path | None = None,
+    *,
+    autostart: bool = True,
+    **payload: Any,
+) -> dict[str, Any]:
+    """Send a verb to the daemon, spawning it first when allowed.
+
+    Fails closed when the daemon is unreachable and autostart is off -- a fallback to raw
+    Docker would recreate exactly the unregistered resources bosn exists to eliminate.
+    """
+    state_dir = state_dir or default_state_dir()
+    if not is_serving(state_dir):
+        if not autostart:
+            raise DaemonError("no bosn daemon is running")
+        spawn(state_dir)
+    return ipc.send_request(port_for(state_dir), {"verb": verb, **payload})
+
+
+def stop(state_dir: Path | None = None, *, timeout: float = 10.0) -> bool:
+    """Ask a running daemon to stop. True if one was running and went away."""
+    state_dir = state_dir or default_state_dir()
+    if not is_serving(state_dir):
+        return False
+    try:
+        ipc.send_request(port_for(state_dir), {"verb": "shutdown"}, timeout=timeout)
+    except ipc.TransportError:
+        pass
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not is_serving(state_dir):
+            return True
+        time.sleep(0.1)
+    return not is_serving(state_dir)
+
+
+def free_port() -> int:
+    """Reserve and release an ephemeral loopback port (used by tests for a dead port)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((ipc.LOOPBACK, 0))
+        return int(sock.getsockname()[1])

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -82,6 +82,8 @@ class Engine:
         try:
             client = self.run(["version", "--format", "{{.Client.Version}}"])
             server = self.run(["version", "--format", "{{.Server.Version}}"])
+        except KeyboardInterrupt:
+            raise
         except Exception as exc:  # noqa: BLE001 - doctor must never crash
             return EngineInfo(binary=self.binary, reachable=False, detail=str(exc))
         if not server.ok:

--- a/src/bosn/ipc.py
+++ b/src/bosn/ipc.py
@@ -1,0 +1,72 @@
+"""CLI <-> daemon transport.
+
+A newline-delimited JSON protocol over loopback TCP. Loopback (not a unix socket) because
+v1 targets cmd.exe, PowerShell, and MSYS Git Bash on Windows alongside macOS and Linux with
+one mechanism. The listening port is published in the daemon's state file.
+
+Mutating verbs fail closed when the daemon is unreachable -- falling back to raw Docker
+would recreate exactly the unregistered resources bosn exists to eliminate.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from typing import Any
+
+LOOPBACK = "127.0.0.1"
+DEFAULT_TIMEOUT = 10.0
+
+
+class TransportError(RuntimeError):
+    """The daemon could not be reached or spoke nonsense."""
+
+
+def send_request(
+    port: int,
+    request: dict[str, Any],
+    *,
+    host: str = LOOPBACK,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    payload = (json.dumps(request) + "\n").encode("utf-8")
+    try:
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            sock.settimeout(timeout)
+            sock.sendall(payload)
+            return _read_message(sock)
+    except OSError as exc:
+        raise TransportError(f"daemon unreachable on {host}:{port}: {exc}") from exc
+
+
+def _read_message(sock: socket.socket) -> dict[str, Any]:
+    chunks: list[bytes] = []
+    while True:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        if b"\n" in chunk:
+            break
+    raw = b"".join(chunks).split(b"\n", 1)[0]
+    if not raw:
+        raise TransportError("daemon closed the connection without replying")
+    try:
+        message = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise TransportError(f"malformed reply from daemon: {exc}") from exc
+    if not isinstance(message, dict):
+        raise TransportError("daemon reply was not a JSON object")
+    return message
+
+
+def read_request(conn: socket.socket) -> dict[str, Any] | None:
+    """Server side: read one newline-delimited JSON request, or None on clean EOF."""
+    try:
+        return _read_message(conn)
+    except TransportError:
+        return None
+
+
+def send_response(conn: socket.socket, response: dict[str, Any]) -> None:
+    conn.sendall((json.dumps(response) + "\n").encode("utf-8"))

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import threading
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -131,14 +132,18 @@ class Registry:
         self.read_only = read_only
         if not read_only:
             self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(str(self.path), isolation_level=None)
+        # The daemon serves requests on a thread pool while owning one connection, so the
+        # connection must outlive its creating thread; a lock keeps it single-writer.
+        self._lock = threading.RLock()
+        self.conn = sqlite3.connect(str(self.path), isolation_level=None, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
-        self.conn.execute("PRAGMA journal_mode=WAL")
-        self.conn.execute("PRAGMA foreign_keys=ON")
-        self.conn.execute("PRAGMA busy_timeout=5000")
-        if not read_only:
-            self.conn.executescript(SCHEMA)
-            self._ensure_meta()
+        with self._lock:
+            self.conn.execute("PRAGMA journal_mode=WAL")
+            self.conn.execute("PRAGMA foreign_keys=ON")
+            self.conn.execute("PRAGMA busy_timeout=5000")
+            if not read_only:
+                self.conn.executescript(SCHEMA)
+                self._ensure_meta()
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -149,20 +154,26 @@ class Registry:
         self.close()
 
     def close(self) -> None:
-        self.conn.close()
+        with self._lock:
+            self.conn.close()
+
+    def _exec(self, sql: str, params: tuple[object, ...] = ()) -> sqlite3.Cursor:
+        """Every statement goes through here so the daemon stays single-writer."""
+        with self._lock:
+            return self.conn.execute(sql, params)
 
     def _ensure_meta(self) -> None:
-        self.conn.execute(
+        self._exec(
             "INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', ?)",
             (str(SCHEMA_VERSION),),
         )
-        self.conn.execute(
+        self._exec(
             "INSERT OR IGNORE INTO meta(key, value) VALUES ('registry_id', ?)",
             (str(uuid.uuid4()),),
         )
 
     def meta(self, key: str) -> str | None:
-        row = self.conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+        row = self._exec("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
         return row["value"] if row else None
 
     @property
@@ -174,7 +185,7 @@ class Registry:
 
     @property
     def journal_mode(self) -> str:
-        return str(self.conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        return str(self._exec("PRAGMA journal_mode").fetchone()[0]).lower()
 
     # -- resources ---------------------------------------------------------
 
@@ -193,7 +204,7 @@ class Registry:
         now = self.clock.now()
         rid = resource_id or str(uuid.uuid4())
         created = now if created_at is None else created_at
-        self.conn.execute(
+        self._exec(
             "INSERT OR REPLACE INTO resources"
             "(id, kind, name, stack, generation, scope, workspace, created_at, last_used, state)"
             " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')",
@@ -205,28 +216,28 @@ class Registry:
         return resource
 
     def get_resource(self, resource_id: str) -> Resource | None:
-        row = self.conn.execute("SELECT * FROM resources WHERE id = ?", (resource_id,)).fetchone()
+        row = self._exec("SELECT * FROM resources WHERE id = ?", (resource_id,)).fetchone()
         return _resource_from_row(row) if row else None
 
     def list_resources(self, *, state: str | None = None) -> list[Resource]:
         if state is None:
-            rows = self.conn.execute("SELECT * FROM resources ORDER BY created_at").fetchall()
+            rows = self._exec("SELECT * FROM resources ORDER BY created_at").fetchall()
         else:
-            rows = self.conn.execute(
+            rows = self._exec(
                 "SELECT * FROM resources WHERE state = ? ORDER BY created_at", (state,)
             ).fetchall()
         return [_resource_from_row(row) for row in rows]
 
     def touch_resource(self, resource_id: str) -> None:
-        self.conn.execute(
+        self._exec(
             "UPDATE resources SET last_used = ? WHERE id = ?", (self.clock.now(), resource_id)
         )
 
     def set_resource_state(self, resource_id: str, state: str) -> None:
-        self.conn.execute("UPDATE resources SET state = ? WHERE id = ?", (state, resource_id))
+        self._exec("UPDATE resources SET state = ? WHERE id = ?", (state, resource_id))
 
     def remove_resource(self, resource_id: str) -> None:
-        self.conn.execute("DELETE FROM resources WHERE id = ?", (resource_id,))
+        self._exec("DELETE FROM resources WHERE id = ?", (resource_id,))
         self.log_event("resource.removed", resource_id)
 
     # -- leases ------------------------------------------------------------
@@ -241,7 +252,7 @@ class Registry:
     ) -> Lease:
         now = self.clock.now()
         lease_id = str(uuid.uuid4())
-        self.conn.execute(
+        self._exec(
             "INSERT INTO leases"
             "(id, resource_id, pid, proc_start, acquired_at, heartbeat_at, ttl_seconds)"
             " VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -253,34 +264,30 @@ class Registry:
         return lease
 
     def get_lease(self, lease_id: str) -> Lease | None:
-        row = self.conn.execute("SELECT * FROM leases WHERE id = ?", (lease_id,)).fetchone()
+        row = self._exec("SELECT * FROM leases WHERE id = ?", (lease_id,)).fetchone()
         return _lease_from_row(row) if row else None
 
     def leases_for(self, resource_id: str) -> list[Lease]:
-        rows = self.conn.execute(
-            "SELECT * FROM leases WHERE resource_id = ?", (resource_id,)
-        ).fetchall()
+        rows = self._exec("SELECT * FROM leases WHERE resource_id = ?", (resource_id,)).fetchall()
         return [_lease_from_row(row) for row in rows]
 
     def heartbeat(self, lease_id: str) -> None:
-        self.conn.execute(
-            "UPDATE leases SET heartbeat_at = ? WHERE id = ?", (self.clock.now(), lease_id)
-        )
+        self._exec("UPDATE leases SET heartbeat_at = ? WHERE id = ?", (self.clock.now(), lease_id))
 
     def release_lease(self, lease_id: str) -> None:
-        self.conn.execute("DELETE FROM leases WHERE id = ?", (lease_id,))
+        self._exec("DELETE FROM leases WHERE id = ?", (lease_id,))
         self.log_event("lease.released", lease_id)
 
     # -- generations -------------------------------------------------------
 
     def record_generation(self, digest: str, stack: str) -> None:
-        self.conn.execute(
+        self._exec(
             "INSERT OR IGNORE INTO generations(digest, stack, created_at) VALUES (?, ?, ?)",
             (digest, stack, self.clock.now()),
         )
 
     def supersede_generations(self, stack: str, keep_digest: str) -> int:
-        cur = self.conn.execute(
+        cur = self._exec(
             "UPDATE generations SET superseded_at = ?"
             " WHERE stack = ? AND digest != ? AND superseded_at IS NULL",
             (self.clock.now(), stack, keep_digest),
@@ -288,7 +295,7 @@ class Registry:
         return cur.rowcount
 
     def generation_superseded_at(self, digest: str) -> float | None:
-        row = self.conn.execute(
+        row = self._exec(
             "SELECT superseded_at FROM generations WHERE digest = ?", (digest,)
         ).fetchone()
         return row["superseded_at"] if row else None
@@ -296,15 +303,13 @@ class Registry:
     # -- events ------------------------------------------------------------
 
     def log_event(self, kind: str, detail: str = "") -> None:
-        self.conn.execute(
+        self._exec(
             "INSERT INTO events(at, kind, detail) VALUES (?, ?, ?)",
             (self.clock.now(), kind, detail),
         )
 
     def events(self, limit: int = 100) -> list[sqlite3.Row]:
-        return self.conn.execute(
-            "SELECT * FROM events ORDER BY id DESC LIMIT ?", (limit,)
-        ).fetchall()
+        return self._exec("SELECT * FROM events ORDER BY id DESC LIMIT ?", (limit,)).fetchall()
 
 
 def _resource_from_row(row: sqlite3.Row) -> Resource:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,15 @@ import pytest
 
 from bosn.engine import Engine, engine_reachable
 
+
+@pytest.fixture(autouse=True)
+def isolated_state_dir(tmp_path_factory, monkeypatch) -> None:
+    """Never let a test touch the developer's real registry or spawn a real daemon there."""
+    state_dir = tmp_path_factory.mktemp("bosn-state")
+    monkeypatch.setenv("BOSN_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("BOSN_PORT", raising=False)
+
+
 _ENGINE_REACHABLE: bool | None = None
 
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -6,8 +6,10 @@ import pytest
 
 from bosn import cli
 
+UNIMPLEMENTED = sorted(v for v, (_, phase) in cli.VERBS.items() if phase != "implemented")
 
-@pytest.mark.parametrize("verb", sorted(set(cli.VERBS) - {"doctor"}))
+
+@pytest.mark.parametrize("verb", UNIMPLEMENTED)
 def test_unimplemented_verbs_fail_with_a_specific_error(verb: str, capsys) -> None:
     code = cli.main([verb])
     assert code == cli.NOT_IMPLEMENTED_EXIT, f"{verb} must not silently succeed"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import os
 import socket
-import sys
 import threading
 import time
 from collections.abc import Iterator
@@ -188,12 +187,20 @@ def test_stop_returns_false_when_nothing_is_running(tmp_path: Path) -> None:
     assert daemon_mod.stop(tmp_path) is False
 
 
+def test_spawn_reports_a_clear_error_when_detachment_is_unavailable(tmp_path: Path) -> None:
+    """The missing-trampoline case must name the cause, not raise FileNotFoundError."""
+    if daemon_mod.spawn_daemon_available():
+        pytest.skip("running-process can detach here; the failure path is not reachable")
+    with pytest.raises(DaemonError, match="cannot detach on this platform"):
+        daemon_mod.spawn(tmp_path, timeout=5)
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(
-    sys.platform.startswith("win"),
+    not daemon_mod.spawn_daemon_available(),
     reason=(
-        "running-process 4.10.1's win_amd64 wheel ships no assets/daemon-trampoline.exe, "
-        "so spawn_daemon cannot detach on Windows. Linux CI covers this path."
+        "running-process 4.10.1 publishes no assets/daemon-trampoline in its wheels, so "
+        "spawn_daemon cannot detach yet. Re-enable once a build ships the trampoline."
     ),
 )
 def test_real_detached_spawn_and_autostart(tmp_path: Path) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,211 @@
+"""Phase 3: daemon singleton lifecycle.
+
+The deterministic loopback port is the singleton concurrency primitive: a second daemon
+fails its bind with EADDRINUSE, so the operating system is the arbiter. These tests pin
+that property along with spawn, heartbeat, idle retirement, and fail-closed behavior.
+
+No Docker involved -- these run on every platform.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bosn import daemon as daemon_mod
+from bosn import ipc
+from bosn.daemon import Daemon, DaemonError, DaemonState
+
+
+def _wait_until(predicate, timeout: float = 15.0, interval: float = 0.05) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+@pytest.fixture
+def served(tmp_path: Path) -> Iterator[Daemon]:
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    assert _wait_until(lambda: daemon_mod.is_serving(tmp_path)), "daemon never came up"
+    try:
+        yield daemon
+    finally:
+        daemon.request_stop()
+        thread.join(timeout=15)
+        daemon.shutdown()
+
+
+# -- the port as singleton primitive ---------------------------------------
+
+
+def test_port_is_deterministic_not_random(tmp_path: Path) -> None:
+    assert daemon_mod.port_for(tmp_path) == daemon_mod.port_for(tmp_path)
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    assert daemon_mod.port_for(other) != daemon_mod.port_for(tmp_path)
+
+
+def test_default_state_dir_uses_the_fixed_default_port(monkeypatch) -> None:
+    monkeypatch.delenv("BOSN_PORT", raising=False)
+    from bosn.registry import default_state_dir
+
+    assert daemon_mod.port_for(default_state_dir()) == daemon_mod.DEFAULT_PORT
+
+
+def test_port_can_be_overridden_by_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("BOSN_PORT", "50123")
+    assert daemon_mod.port_for(tmp_path) == 50123
+
+
+def test_second_daemon_loses_the_bind_and_refuses_to_start(served: Daemon, tmp_path: Path) -> None:
+    """The singleton check IS the failed bind -- not a pid comparison, not a lock file."""
+    with pytest.raises(DaemonError, match="already owns port"):
+        Daemon(state_dir=tmp_path).serve_forever()
+
+
+def test_a_foreign_listener_on_the_port_also_blocks_startup(tmp_path: Path) -> None:
+    """Anything holding the port wins; the daemon never assumes the port is free."""
+    port = daemon_mod.port_for(tmp_path)
+    squatter = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        squatter.bind((ipc.LOOPBACK, port))
+        squatter.listen(1)
+        with pytest.raises(DaemonError, match="already owns port"):
+            Daemon(state_dir=tmp_path).serve_forever()
+    finally:
+        squatter.close()
+
+
+def test_a_stale_state_file_cannot_fake_a_live_daemon(tmp_path: Path) -> None:
+    DaemonState(
+        pid=os.getpid(), port=daemon_mod.port_for(tmp_path), started_at=0.0, version="0"
+    ).write(daemon_mod.state_file(tmp_path))
+    # nothing is listening, so liveness is false regardless of what the file claims
+    assert daemon_mod.running_state(tmp_path) is None
+    assert not daemon_mod.state_file(tmp_path).exists()
+
+
+# -- serving ---------------------------------------------------------------
+
+
+def test_daemon_publishes_state_and_answers_ping(served: Daemon, tmp_path: Path) -> None:
+    state = daemon_mod.running_state(tmp_path)
+    assert state is not None
+    assert state.port == served.port == daemon_mod.port_for(tmp_path)
+    assert state.pid == os.getpid()
+    reply = ipc.send_request(state.port, {"verb": "ping"})
+    assert reply["ok"] and reply["pong"]
+
+
+def test_status_reports_registry_id_and_uptime(served: Daemon) -> None:
+    reply = ipc.send_request(served.port, {"verb": "status"})
+    assert reply["ok"]
+    assert reply["registry_id"] == served.registry.registry_id
+    assert reply["uptime_seconds"] >= 0
+
+
+def test_unknown_verb_is_rejected_not_ignored(served: Daemon) -> None:
+    reply = ipc.send_request(served.port, {"verb": "definitely-not-a-verb"})
+    assert reply["ok"] is False
+    assert "unknown daemon verb" in reply["error"]
+
+
+def test_requests_refresh_the_heartbeat(served: Daemon) -> None:
+    before = served.heartbeat_at
+    time.sleep(0.05)
+    ipc.send_request(served.port, {"verb": "ping"})
+    assert served.heartbeat_at > before
+
+
+def test_registry_is_usable_from_the_server_threads(served: Daemon) -> None:
+    """The daemon serves on threads; a thread-affine sqlite handle would fail here."""
+    for _ in range(5):
+        assert ipc.send_request(served.port, {"verb": "status"})["ok"]
+
+
+# -- shutdown and retirement -----------------------------------------------
+
+
+def test_shutdown_verb_stops_the_daemon_and_clears_state(tmp_path: Path) -> None:
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
+
+    assert daemon_mod.stop(tmp_path) is True
+    thread.join(timeout=15)
+    assert not daemon_mod.is_serving(tmp_path)
+    assert not daemon_mod.state_file(tmp_path).exists()
+
+
+def test_the_port_is_released_for_the_next_daemon(tmp_path: Path) -> None:
+    """A retired daemon must not leave its port wedged, or the singleton becomes a lockout."""
+    for _ in range(2):
+        daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+        thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+        thread.start()
+        assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
+        assert daemon_mod.stop(tmp_path)
+        thread.join(timeout=15)
+
+
+def test_idle_retirement_stops_an_unused_daemon(tmp_path: Path) -> None:
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0.5)
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
+    thread.join(timeout=20)
+    assert not thread.is_alive(), "idle daemon should have retired itself"
+    assert not daemon_mod.is_serving(tmp_path)
+
+
+# -- client behavior -------------------------------------------------------
+
+
+def test_mutating_request_fails_closed_without_a_daemon(tmp_path: Path) -> None:
+    with pytest.raises(DaemonError, match="no bosn daemon is running"):
+        daemon_mod.request("status", tmp_path, autostart=False)
+
+
+def test_transport_error_on_a_dead_port() -> None:
+    with pytest.raises(ipc.TransportError, match="unreachable"):
+        ipc.send_request(daemon_mod.free_port(), {"verb": "ping"}, timeout=1.0)
+
+
+def test_stop_returns_false_when_nothing_is_running(tmp_path: Path) -> None:
+    assert daemon_mod.stop(tmp_path) is False
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason=(
+        "running-process 4.10.1's win_amd64 wheel ships no assets/daemon-trampoline.exe, "
+        "so spawn_daemon cannot detach on Windows. Linux CI covers this path."
+    ),
+)
+def test_real_detached_spawn_and_autostart(tmp_path: Path) -> None:
+    """End-to-end: the CLI lazily spawns a real detached daemon and talks to it."""
+    state = daemon_mod.spawn(tmp_path, timeout=60)
+    try:
+        assert state.port == daemon_mod.port_for(tmp_path)
+        assert state.pid != os.getpid(), "daemon must be a separate process"
+        assert ipc.send_request(state.port, {"verb": "ping"})["ok"]
+
+        # spawn is idempotent and autostart reaches the same daemon
+        assert daemon_mod.spawn(tmp_path).pid == state.pid
+        assert daemon_mod.request("status", tmp_path)["pid"] == state.pid
+    finally:
+        assert daemon_mod.stop(tmp_path, timeout=30)

--- a/tests/test_lint_kbi.py
+++ b/tests/test_lint_kbi.py
@@ -1,0 +1,81 @@
+"""The KeyboardInterrupt checker itself is tested -- a silent linter is worse than none."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "ci"))
+
+import lint_kbi  # noqa: E402
+
+
+def codes(source: str) -> list[str]:
+    return [v.code for v in lint_kbi.check_source(Path("sample.py"), source)]
+
+
+def test_broad_except_without_keyboard_interrupt_is_flagged() -> None:
+    assert codes("try:\n    work()\nexcept Exception:\n    log()\n") == ["KBI001"]
+
+
+def test_base_exception_is_flagged_too() -> None:
+    assert codes("try:\n    work()\nexcept BaseException:\n    log()\n") == ["KBI001"]
+
+
+def test_broad_except_with_a_reraising_kbi_sibling_is_clean() -> None:
+    source = (
+        "try:\n    work()\nexcept KeyboardInterrupt:\n    raise\nexcept Exception:\n    log()\n"
+    )
+    assert codes(source) == []
+
+
+def test_kbi_handler_that_swallows_the_interrupt_is_flagged() -> None:
+    source = (
+        "try:\n    work()\nexcept KeyboardInterrupt:\n    log()\nexcept Exception:\n    log()\n"
+    )
+    assert codes(source) == ["KBI002"]
+
+
+def test_kbi_handler_calling_interrupt_main_is_accepted() -> None:
+    source = (
+        "import _thread\n"
+        "try:\n"
+        "    work()\n"
+        "except KeyboardInterrupt:\n"
+        "    _thread.interrupt_main()\n"
+        "except Exception:\n"
+        "    log()\n"
+    )
+    assert codes(source) == []
+
+
+def test_bare_except_without_reraise_is_flagged() -> None:
+    assert codes("try:\n    work()\nexcept:\n    log()\n") == ["KBI003"]
+
+
+def test_bare_except_that_reraises_is_accepted() -> None:
+    assert codes("try:\n    work()\nexcept:\n    raise\n") == []
+
+
+def test_narrow_excepts_are_never_flagged() -> None:
+    assert codes("try:\n    work()\nexcept ValueError:\n    log()\n") == []
+
+
+def test_noqa_suppresses_the_finding() -> None:
+    assert codes("try:\n    work()\nexcept Exception:  # noqa: KBI001\n    log()\n") == []
+
+
+def test_bare_noqa_suppresses_the_finding() -> None:
+    assert codes("try:\n    work()\nexcept Exception:  # noqa\n    log()\n") == []
+
+
+def test_noqa_for_a_different_code_does_not_suppress() -> None:
+    assert codes("try:\n    work()\nexcept Exception:  # noqa: E501\n    log()\n") == ["KBI001"]
+
+
+def test_the_repo_itself_is_clean() -> None:
+    """The checker must pass on bosn's own source, or it is decoration."""
+    files = lint_kbi.iter_python_files(["src", "ci", "tests"], [".venv", "__pycache__"])
+    assert files, "checker found no files to scan"
+    violations = [v for path in files for v in lint_kbi.check_file(path)]
+    assert violations == [], "\n".join(v.render() for v in violations)


### PR DESCRIPTION
Phase 3 of #3.

**Singleton = the port bind.** `allow_reuse_address = False` on a deterministic per-state-dir loopback port, so a second daemon fails `bind()` with EADDRINUSE and the OS arbitrates. No broker, no lock file, no pid comparison. Tests pin that a stale state file cannot fake a live daemon and that a foreign squatter on the port also blocks startup.

**Detachment** uses `running_process.daemon.spawn_daemon` — the platform-blessed spawner. My first attempt hand-rolled `subprocess.Popen` with DETACHED_PROCESS and popped a console window on Windows; that is gone.

**KeyboardInterrupt linting** (`ci/lint_kbi.py`, wired into `./lint`): KBI001/KBI002/KBI003, `# noqa: KBI001` suppression, and 12 tests including one asserting the repo's own source is clean. It immediately caught 3 real Ctrl-C swallowers in this branch, all fixed.

**Bug fixed:** the sqlite handle was thread-affine while the daemon serves on threads — every request from a server thread raised. Now `check_same_thread=False` with an RLock so the daemon stays single-writer.

**README:** CI/Python/License badges plus a Development section documenting the trampolines and the KBI codes.

74 passed, 1 skipped locally (the skip is Windows-only: running-process 4.10.1's win_amd64 wheel ships no `assets/daemon-trampoline.exe`, so `spawn_daemon` cannot detach there — Linux CI covers that path).

Refs #3