### PR TITLE
feat: phase 4 — enumeration, leases, adoption

### DIFF
--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -1,0 +1,250 @@
+"""Resource enumeration and adoption.
+
+Ownership lives in the Docker labels, so enumeration is the recovery path for a lost
+registry as well as the input to every lifecycle decision. Three buckets come out of a
+scan, and the distinction is the whole safety property:
+
+- **owned**    complete label set carrying our registry id -- eligible for collection
+- **foreign**  complete label set carrying someone else's registry id -- counted, never touched
+- **unlabeled** incomplete or absent labels -- invisible to every decision, never touched
+
+Automatic deletion requires complete ownership proof, which is why there is no `gc --force`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+from bosn import labels
+from bosn.clock import Clock, SystemClock
+from bosn.engine import Engine
+from bosn.registry import Registry
+
+# Docker CLI list commands per resource kind, formatted as one JSON object per line.
+_LIST_COMMANDS: dict[str, list[str]] = {
+    "container": ["ps", "--all", "--format", "{{json .}}"],
+    "volume": ["volume", "ls", "--format", "{{json .}}"],
+    "image": ["images", "--format", "{{json .}}"],
+}
+
+_INSPECT_COMMANDS: dict[str, list[str]] = {
+    "container": ["inspect", "--format", "{{json .Config.Labels}}"],
+    "volume": ["volume", "inspect", "--format", "{{json .Labels}}"],
+    "image": ["image", "inspect", "--format", "{{json .Config.Labels}}"],
+}
+
+
+@dataclass(frozen=True)
+class DiscoveredResource:
+    kind: str
+    name: str
+    raw_labels: dict[str, str]
+
+    def owned_by(self, registry_id: str) -> bool:
+        return labels.is_owned_by(self.raw_labels, registry_id)
+
+    @property
+    def complete(self) -> bool:
+        return labels.is_complete(self.raw_labels)
+
+    @property
+    def registry(self) -> str | None:
+        return self.raw_labels.get(labels.REGISTRY)
+
+    def parsed(self) -> labels.ResourceLabels:
+        return labels.ResourceLabels.from_dict(self.raw_labels)
+
+
+@dataclass
+class ScanResult:
+    owned: list[DiscoveredResource] = field(default_factory=list)
+    foreign: list[DiscoveredResource] = field(default_factory=list)
+    unlabeled: list[DiscoveredResource] = field(default_factory=list)
+
+    @property
+    def foreign_registries(self) -> set[str]:
+        return {r.registry for r in self.foreign if r.registry}
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "owned": len(self.owned),
+            "foreign": len(self.foreign),
+            "unlabeled": len(self.unlabeled),
+        }
+
+
+def _parse_labels(blob: str) -> dict[str, str]:
+    """Docker renders labels either as a JSON object or as a comma-joined k=v string."""
+    blob = (blob or "").strip()
+    if not blob or blob in {"null", "<no value>", "map[]"}:
+        return {}
+    if blob.startswith("{"):
+        try:
+            parsed = json.loads(blob)
+        except json.JSONDecodeError:
+            return {}
+        if not isinstance(parsed, dict):
+            return {}
+        return {str(k): str(v) for k, v in parsed.items() if v is not None}
+    result: dict[str, str] = {}
+    for pair in blob.split(","):
+        key, sep, value = pair.partition("=")
+        if sep:
+            result[key.strip()] = value.strip()
+    return result
+
+
+def _name_of(kind: str, row: dict[str, object]) -> str:
+    if kind == "volume":
+        return str(row.get("Name", ""))
+    if kind == "image":
+        return str(row.get("ID", ""))
+    return str(row.get("Names") or row.get("Name") or row.get("ID", ""))
+
+
+class ResourceScanner:
+    """Enumerates engine resources and sorts them by ownership proof."""
+
+    def __init__(self, engine: Engine | None = None) -> None:
+        self.engine = engine or Engine()
+
+    def discover(self, kind: str) -> list[DiscoveredResource]:
+        args = _LIST_COMMANDS.get(kind)
+        if args is None:
+            raise ValueError(f"cannot enumerate unknown kind {kind!r}")
+        result = self.engine.run(args)
+        if not result.ok:
+            return []
+
+        discovered: list[DiscoveredResource] = []
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            name = _name_of(kind, row)
+            if not name:
+                continue
+            raw = _parse_labels(str(row.get("Labels", "")))
+            if not labels.is_complete(raw):
+                # The list format truncates labels for some kinds; confirm via inspect
+                # before concluding a resource is unlabeled.
+                raw = self.inspect_labels(kind, name) or raw
+            discovered.append(DiscoveredResource(kind=kind, name=name, raw_labels=raw))
+        return discovered
+
+    def inspect_labels(self, kind: str, name: str) -> dict[str, str]:
+        args = _INSPECT_COMMANDS.get(kind)
+        if args is None:
+            return {}
+        result = self.engine.run([*args, name])
+        if not result.ok:
+            return {}
+        return _parse_labels(result.stdout)
+
+    def scan(self, registry_id: str, kinds: list[str] | None = None) -> ScanResult:
+        scan = ScanResult()
+        for kind in kinds or list(_LIST_COMMANDS):
+            for resource in self.discover(kind):
+                if not resource.complete:
+                    scan.unlabeled.append(resource)
+                elif resource.owned_by(registry_id):
+                    scan.owned.append(resource)
+                else:
+                    scan.foreign.append(resource)
+        return scan
+
+
+# -- leases ----------------------------------------------------------------
+
+
+def process_alive(pid: int, proc_start: float | None = None) -> bool:
+    """Liveness probe for a lease holder.
+
+    A lease expires only when its TTL elapses *and* this probe fails, so a killed client
+    releases within one TTL while a live 40-minute build is never collected out from
+    under itself.
+    """
+    if pid <= 0:
+        return False
+    try:
+        import os
+
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def lease_is_expired(
+    lease,
+    now: float,
+    *,
+    alive_probe=process_alive,
+) -> bool:
+    """True only when the TTL has elapsed AND the holder is gone."""
+    if not lease.expired_by_time(now):
+        return False
+    return not alive_probe(lease.pid, lease.proc_start)
+
+
+def resource_is_leased(registry: Registry, resource_id: str, *, alive_probe=process_alive) -> bool:
+    now = registry.clock.now()
+    return any(
+        not lease_is_expired(lease, now, alive_probe=alive_probe)
+        for lease in registry.leases_for(resource_id)
+    )
+
+
+# -- adoption --------------------------------------------------------------
+
+QUIET_PERIOD_SECONDS = 24 * 3600
+
+
+def adopt(
+    registry: Registry,
+    scan: ScanResult,
+    *,
+    clock: Clock | None = None,
+) -> list[str]:
+    """Rebuild registry rows from labels after the database is lost.
+
+    Adoption time becomes last-use, and the caller applies a 24 h quiet period on top, so
+    recovery is never followed by a mass age-out of caches that were merely un-tracked.
+    """
+    clock = clock or SystemClock()
+    now = clock.now()
+    adopted: list[str] = []
+    known = {(r.kind, r.name) for r in registry.list_resources()}
+
+    for resource in scan.owned:
+        if (resource.kind, resource.name) in known:
+            continue
+        parsed = resource.parsed()
+        registry.register_resource(
+            kind=resource.kind,
+            name=resource.name,
+            stack=parsed.stack,
+            generation=parsed.generation,
+            scope=parsed.scope,
+            workspace=parsed.workspace,
+            created_at=now,
+        )
+        registry.log_event("resource.adopted", f"{resource.kind}:{resource.name}")
+        adopted.append(resource.name)
+    return adopted
+
+
+def within_quiet_period(adopted_at: float, now: float) -> bool:
+    """Adopted resources are protected from age-out for the quiet period."""
+    return (now - adopted_at) < QUIET_PERIOD_SECONDS

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,225 @@
+"""Phase 4: enumeration, ownership bucketing, leases, adoption.
+
+Unit tests drive a fake engine, so they run everywhere without Docker.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bosn import labels, resources
+from bosn.clock import FakeClock
+from bosn.engine import EngineResult
+from bosn.registry import Registry
+from bosn.resources import DiscoveredResource, ResourceScanner, ScanResult
+
+OURS = "our-registry-uuid"
+THEIRS = "someone-elses-uuid"
+
+
+def label_dict(registry: str = OURS, **overrides: str) -> dict[str, str]:
+    base = labels.ResourceLabels(
+        registry=registry,
+        kind="volume",
+        stack="test",
+        generation="sha256:abc",
+        scope="spec",
+        workspace="/w",
+        created="2026-08-13T00:00:00Z",
+    ).to_dict()
+    base.update(overrides)
+    return base
+
+
+class FakeEngine:
+    """Records commands and replays canned output."""
+
+    def __init__(self, listings: dict[str, list[dict]], inspects: dict[str, dict] | None = None):
+        self.listings = listings
+        self.inspects = inspects or {}
+        self.commands: list[list[str]] = []
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        self.commands.append(list(args))
+        if "inspect" in args:
+            name = args[-1]
+            return EngineResult(0, json.dumps(self.inspects.get(name, {})), "")
+        kind = (
+            "volume"
+            if args[0] == "volume"
+            else "image"
+            if args[0] == "images"
+            else "container"
+            if args[0] == "ps"
+            else None
+        )
+        rows = self.listings.get(kind or "", [])
+        return EngineResult(0, "\n".join(json.dumps(row) for row in rows), "")
+
+
+# -- ownership bucketing ---------------------------------------------------
+
+
+def test_scan_sorts_resources_into_owned_foreign_and_unlabeled() -> None:
+    engine = FakeEngine(
+        {
+            "volume": [
+                {"Name": "ours", "Labels": json.dumps(label_dict())},
+                {"Name": "theirs", "Labels": json.dumps(label_dict(registry=THEIRS))},
+                {"Name": "naked", "Labels": ""},
+            ]
+        }
+    )
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+
+    assert [r.name for r in scan.owned] == ["ours"]
+    assert [r.name for r in scan.foreign] == ["theirs"]
+    assert [r.name for r in scan.unlabeled] == ["naked"]
+    assert scan.foreign_registries == {THEIRS}
+    assert scan.counts() == {"owned": 1, "foreign": 1, "unlabeled": 1}
+
+
+def test_partially_labeled_resources_are_unlabeled_not_owned() -> None:
+    """An incomplete label set is never ownership proof, even with our registry id."""
+    partial = label_dict()
+    del partial[labels.STACK]
+    engine = FakeEngine({"volume": [{"Name": "partial", "Labels": json.dumps(partial)}]})
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+
+    assert scan.owned == []
+    assert [r.name for r in scan.unlabeled] == ["partial"]
+
+
+def test_a_bosn_name_prefix_alone_is_not_ownership() -> None:
+    engine = FakeEngine({"volume": [{"Name": "bosn-target-cache", "Labels": ""}]})
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+    assert scan.owned == []
+    assert len(scan.unlabeled) == 1
+
+
+def test_labels_are_confirmed_by_inspect_when_the_listing_truncates_them() -> None:
+    engine = FakeEngine(
+        {"volume": [{"Name": "ours", "Labels": ""}]},
+        inspects={"ours": label_dict()},
+    )
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+    assert [r.name for r in scan.owned] == ["ours"]
+    assert any("inspect" in cmd for cmd in engine.commands)
+
+
+@pytest.mark.parametrize(
+    "blob",
+    ["", "null", "<no value>", "map[]", "not json at all {", "[1,2,3]"],
+)
+def test_unparseable_label_blobs_never_produce_ownership(blob: str) -> None:
+    assert resources._parse_labels(blob) == {} or not labels.is_owned_by(
+        resources._parse_labels(blob), OURS
+    )
+
+
+def test_comma_separated_label_format_is_parsed() -> None:
+    raw = ",".join(f"{k}={v}" for k, v in label_dict().items())
+    parsed = resources._parse_labels(raw)
+    assert labels.is_owned_by(parsed, OURS)
+
+
+def test_engine_failure_yields_no_resources_rather_than_guesses() -> None:
+    class Failing:
+        def run(self, args, *, check=False):
+            return EngineResult(1, "", "engine down")
+
+    scan = ResourceScanner(Failing()).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+    assert scan.counts() == {"owned": 0, "foreign": 0, "unlabeled": 0}
+
+
+# -- leases ----------------------------------------------------------------
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def registry(tmp_path: Path, clock: FakeClock):
+    with Registry(tmp_path / "r.sqlite3", clock=clock) as reg:
+        yield reg
+
+
+def _resource(registry: Registry):
+    return registry.register_resource(
+        kind="volume", name="v", stack="s", generation="g", scope="spec", workspace="/w"
+    )
+
+
+def test_a_live_holder_keeps_its_lease_past_the_ttl(registry: Registry, clock: FakeClock) -> None:
+    """A 40-minute build is never collected out from under itself."""
+    resource = _resource(registry)
+    lease = registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
+    clock.advance(10_000)
+
+    assert lease.expired_by_time(clock.now())  # TTL elapsed...
+    assert not resources.lease_is_expired(  # ...but the holder is alive
+        lease, clock.now(), alive_probe=lambda pid, start=None: True
+    )
+    assert resources.resource_is_leased(
+        registry, resource.id, alive_probe=lambda pid, start=None: True
+    )
+
+
+def test_a_dead_holder_releases_after_one_ttl(registry: Registry, clock: FakeClock) -> None:
+    resource = _resource(registry)
+    lease = registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
+    dead = lambda pid, start=None: False  # noqa: E731
+
+    clock.advance(59)
+    assert not resources.lease_is_expired(lease, clock.now(), alive_probe=dead)
+
+    clock.advance(2)
+    assert resources.lease_is_expired(lease, clock.now(), alive_probe=dead)
+    assert not resources.resource_is_leased(registry, resource.id, alive_probe=dead)
+
+
+def test_process_alive_probe_is_true_for_this_process() -> None:
+    import os
+
+    assert resources.process_alive(os.getpid())
+    assert not resources.process_alive(2**31 - 1)
+    assert not resources.process_alive(0)
+
+
+# -- adoption --------------------------------------------------------------
+
+
+def test_adoption_rebuilds_registry_rows_from_labels(registry: Registry, clock: FakeClock) -> None:
+    """Losing the database is survivable: ownership lives in the labels."""
+    scan = ScanResult(
+        owned=[
+            DiscoveredResource("volume", "ours-1", label_dict()),
+            DiscoveredResource("volume", "ours-2", label_dict()),
+        ],
+        foreign=[DiscoveredResource("volume", "theirs", label_dict(registry=THEIRS))],
+        unlabeled=[DiscoveredResource("volume", "naked", {})],
+    )
+    adopted = resources.adopt(registry, scan, clock=clock)
+
+    assert sorted(adopted) == ["ours-1", "ours-2"]
+    names = {r.name for r in registry.list_resources()}
+    assert names == {"ours-1", "ours-2"}, "foreign and unlabeled must never be adopted"
+
+
+def test_adoption_is_idempotent(registry: Registry, clock: FakeClock) -> None:
+    scan = ScanResult(owned=[DiscoveredResource("volume", "ours-1", label_dict())])
+    assert resources.adopt(registry, scan, clock=clock) == ["ours-1"]
+    assert resources.adopt(registry, scan, clock=clock) == []
+    assert len(registry.list_resources()) == 1
+
+
+def test_adopted_resources_are_protected_by_the_quiet_period(clock: FakeClock) -> None:
+    """Recovery is never followed by a mass age-out."""
+    adopted_at = clock.now()
+    assert resources.within_quiet_period(adopted_at, clock.advance(23 * 3600))
+    assert not resources.within_quiet_period(adopted_at, clock.advance(2 * 3600))

--- a/tests/test_resources_docker.py
+++ b/tests/test_resources_docker.py
@@ -1,0 +1,96 @@
+"""Phase 4: enumeration against a real engine. Docker-marked: Linux CI only.
+
+Creates genuinely labeled volumes and proves the scanner sorts them correctly -- most
+importantly that a foreign-registry volume and an unlabeled volume are both untouched by
+every ownership decision.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+from bosn import labels
+from bosn.engine import Engine
+from bosn.resources import ResourceScanner
+
+OURS = f"bosn-test-{uuid.uuid4()}"
+THEIRS = f"bosn-test-{uuid.uuid4()}"
+
+pytestmark = pytest.mark.docker
+
+
+def _labels(registry: str) -> labels.ResourceLabels:
+    return labels.ResourceLabels(
+        registry=registry,
+        kind="volume",
+        stack="test",
+        generation="sha256:deadbeef",
+        scope="spec",
+        workspace="/w/test",
+        created="2026-08-13T00:00:00Z",
+    )
+
+
+@pytest.fixture
+def volumes(engine: Engine) -> Iterator[dict[str, str]]:
+    """Three volumes: ours, a foreign registry's, and one with no labels at all."""
+    names = {
+        "owned": f"bosn-owned-{uuid.uuid4().hex[:8]}",
+        "foreign": f"bosn-foreign-{uuid.uuid4().hex[:8]}",
+        "unlabeled": f"bosn-naked-{uuid.uuid4().hex[:8]}",
+    }
+    engine.run(["volume", "create", *_labels(OURS).to_docker_args(), names["owned"]], check=True)
+    engine.run(
+        ["volume", "create", *_labels(THEIRS).to_docker_args(), names["foreign"]], check=True
+    )
+    engine.run(["volume", "create", names["unlabeled"]], check=True)
+    try:
+        yield names
+    finally:
+        for name in names.values():
+            engine.run(["volume", "rm", "--force", name])
+
+
+def test_scan_finds_our_volume_and_isolates_the_others(
+    engine: Engine, volumes: dict[str, str]
+) -> None:
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])
+
+    owned = {r.name for r in scan.owned}
+    foreign = {r.name for r in scan.foreign}
+    unlabeled = {r.name for r in scan.unlabeled}
+
+    assert volumes["owned"] in owned
+    assert volumes["foreign"] in foreign
+    assert volumes["unlabeled"] in unlabeled
+
+    # the safety property: nothing but ours is ever eligible
+    assert volumes["foreign"] not in owned
+    assert volumes["unlabeled"] not in owned
+
+
+def test_foreign_registries_are_reported_not_hidden(
+    engine: Engine, volumes: dict[str, str]
+) -> None:
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])
+    assert THEIRS in scan.foreign_registries
+
+
+def test_labels_survive_a_round_trip_through_the_engine(
+    engine: Engine, volumes: dict[str, str]
+) -> None:
+    raw = ResourceScanner(engine).inspect_labels("volume", volumes["owned"])
+    assert labels.is_owned_by(raw, OURS)
+    assert labels.ResourceLabels.from_dict(raw) == _labels(OURS)
+
+
+def test_the_other_registrys_scan_sees_ours_as_foreign(
+    engine: Engine, volumes: dict[str, str]
+) -> None:
+    """Ownership is symmetric: from their side, our volume is the foreign one."""
+    scan = ResourceScanner(engine).scan(THEIRS, kinds=["volume"])
+    assert volumes["foreign"] in {r.name for r in scan.owned}
+    assert volumes["owned"] in {r.name for r in scan.foreign}


### PR DESCRIPTION
Phase 4 of #3.

- `resources.py`: `ResourceScanner` sorts containers/volumes/images into **owned / foreign / unlabeled**. Ownership requires a complete label set *and* our registry id; incomplete labels and name prefixes are never proof. Labels are confirmed via `inspect` when a listing truncates them, and an engine failure yields no resources rather than guesses.
- **Leases:** `lease_is_expired` returns true only when the TTL has elapsed *and* the liveness probe fails — a live 40-minute build is never collected out from under itself.
- **Adoption:** rebuilds registry rows from labels after database loss, idempotently, with a 24 h quiet period so recovery is not followed by a mass age-out. Foreign and unlabeled resources are never adopted.
- Docker-backed tests create real labeled volumes (ours / a foreign registry's / unlabeled) and assert the bucketing from both sides.

97 passed, 1 skipped locally (the skip is the known running-process trampoline gap). Lint clean including the KBI checker.

Refs #3