### PR TITLE
feat: phase 5 — manifest, digests, converge, bosn run

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -22,11 +22,11 @@ NOT_IMPLEMENTED_EXIT = 3
 
 # verb -> (help text, phase that lands it)
 VERBS: dict[str, tuple[str, str]] = {
-    "run": ("run an ad-hoc command in a stack", "phase 5"),
-    "shell": ("interactive session in the persistent container", "phase 5"),
-    "tasks": ("list manifest tasks, stacks, digests, registration state", "phase 5"),
+    "run": ("run an ad-hoc command in a stack", "implemented"),
+    "shell": ("interactive session in the persistent container", "phase 6"),
+    "tasks": ("list manifest tasks, stacks, digests, registration state", "implemented"),
     "jobs": ("list daemon-owned jobs", "implemented"),
-    "attach": ("attach to a daemon-owned job", "phase 5"),
+    "attach": ("attach to a daemon-owned job", "phase 6"),
     "status": ("tiers, leases, managed bytes vs ceiling, foreign registries", "phase 6"),
     "gc": ("report or reclaim collectable resources", "phase 6"),
     "done": ("mark this workspace finished; its caches become collectable", "phase 6"),
@@ -56,10 +56,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="override the bosn state directory (registry + daemon state)",
     )
+    parser.add_argument(
+        "--manifest", default=None, help="path to bosn.toml (default: nearest one upward)"
+    )
     subparsers = parser.add_subparsers(dest="verb", metavar="VERB")
     for verb, (help_text, _) in VERBS.items():
         sub = subparsers.add_parser(verb, help=help_text)
         sub.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+        if verb in {"run", "tasks", "shell"}:
+            sub.add_argument("--stack", default=None, help="stack to use (default: the default)")
+            sub.add_argument("--task", default=None, help="run a manifest task by name")
+            sub.add_argument("--manifest", default=None, dest="sub_manifest")
 
     daemon_parser = subparsers.add_parser(DAEMON_VERB, help=argparse.SUPPRESS)
     daemon_parser.add_argument("--port", type=int, default=None)
@@ -122,6 +129,92 @@ def cmd_jobs(ns: argparse.Namespace) -> int:
     return 0
 
 
+def _open_manifest_and_registry(ns: argparse.Namespace):
+    from bosn.manifest import ManifestError, find_manifest, load
+    from bosn.registry import Registry, default_db_path
+
+    raw_manifest = getattr(ns, "sub_manifest", None) or getattr(ns, "manifest", None)
+    manifest_path = Path(raw_manifest) if raw_manifest else find_manifest()
+    if manifest_path is None:
+        raise ManifestError(
+            "no bosn.toml found in this directory or any parent; create one or pass --manifest"
+        )
+    manifest = load(manifest_path)
+    state_dir = resolve_state_dir(ns)
+    db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
+    return manifest, Registry(db_path)
+
+
+def cmd_tasks(ns: argparse.Namespace) -> int:
+    from bosn.manifest import ManifestError, generation_digest
+
+    try:
+        manifest, registry = _open_manifest_and_registry(ns)
+    except ManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    try:
+        payload = {
+            "manifest": str(manifest.path),
+            "stacks": {
+                name: {
+                    "dockerfile": stack.dockerfile,
+                    "image": stack.image,
+                    "family": stack.family,
+                    "default": stack.default,
+                    "digest": generation_digest(manifest, stack),
+                    "volumes": {v.name: v.scope for v in stack.volumes},
+                }
+                for name, stack in manifest.stacks.items()
+            },
+            "tasks": {name: {"stack": t.stack, "cmd": t.cmd} for name, t in manifest.tasks.items()},
+        }
+    except ManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    finally:
+        registry.close()
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def cmd_run(ns: argparse.Namespace) -> int:
+    from bosn.converge import Converger
+    from bosn.engine import EngineError
+    from bosn.manifest import ManifestError
+
+    command = [a for a in (ns.args or []) if a != "--"]
+    if not command and not ns.task:
+        print("nothing to run: pass a command after `--`, or name a task", file=sys.stderr)
+        return 2
+
+    try:
+        manifest, registry = _open_manifest_and_registry(ns)
+    except ManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    try:
+        if ns.task:
+            from bosn.converge import run_task
+
+            _result, code, output = run_task(manifest, registry, ns.task, engine=Engine(ns.engine))
+        else:
+            converger = Converger(manifest, registry, Engine(ns.engine))
+            _result, code, output = converger.run(command, stack_name=ns.stack)
+    except (ManifestError, EngineError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    finally:
+        registry.close()
+
+    if output:
+        print(output)
+    return code
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
@@ -138,6 +231,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.verb == "jobs":
         return cmd_jobs(ns)
+
+    if ns.verb == "tasks":
+        return cmd_tasks(ns)
+
+    if ns.verb == "run":
+        return cmd_run(ns)
 
     error = VerbNotImplementedError(ns.verb, VERBS[ns.verb][1])
     print(str(error), file=sys.stderr)

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -1,0 +1,247 @@
+"""Converge-then-run.
+
+Every stack verb makes registered state match the manifest -- registering, rolling a
+generation, or reusing as-is -- and then runs. The same command is correct on the 1st and
+the 500th invocation. Errors are reserved for states that need a human decision; an error
+whose remedy is always the same mechanical command is just a forced retry loop.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+
+from bosn import labels
+from bosn.engine import Engine, EngineError
+from bosn.manifest import Manifest, StackSpec, generation_digest
+from bosn.registry import Registry
+
+# What converge did, in the order of increasing work.
+REUSED = "reused"
+REGISTERED = "registered"
+ROLLED = "rolled"
+
+
+@dataclass(frozen=True)
+class ConvergeResult:
+    stack: str
+    digest: str
+    action: str
+    image_tag: str
+    volumes: tuple[str, ...] = ()
+    superseded: int = 0
+
+
+def _now_iso() -> str:
+    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def image_tag_for(stack: StackSpec, digest: str) -> str:
+    """Images are keyed by digest, so a spec edit cannot reuse a stale image."""
+    return f"bosn/{stack.name}:{digest.removeprefix('sha256:')[:16]}"
+
+
+def volume_name_for(
+    stack: StackSpec,
+    volume_scope: str,
+    volume_name: str,
+    *,
+    digest: str,
+    workspace: str,
+    family: str | None,
+) -> str:
+    """Volume identity follows its scope.
+
+    - `spec`    keyed by the generation digest, so a spec edit gets a fresh volume
+    - `stack`   keyed by workspace + stack, surviving spec edits in this workspace
+    - `machine` keyed by family only -- one per machine, shared across every repo and
+                worktree. This is what kills the incident's dominant multiplier.
+    """
+    short_digest = digest.removeprefix("sha256:")[:12]
+    workspace_key = _stable_key(workspace)
+    if volume_scope == "machine":
+        return f"bosn-m-{family or stack.name}-{volume_name}"
+    if volume_scope == "stack":
+        return f"bosn-s-{stack.name}-{workspace_key}-{volume_name}"
+    return f"bosn-g-{stack.name}-{short_digest}-{volume_name}"
+
+
+def _stable_key(value: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:10]
+
+
+class Converger:
+    """Brings engine and registry state in line with the manifest."""
+
+    def __init__(
+        self,
+        manifest: Manifest,
+        registry: Registry,
+        engine: Engine | None = None,
+    ) -> None:
+        self.manifest = manifest
+        self.registry = registry
+        self.engine = engine or Engine()
+
+    def converge(
+        self, stack_name: str | None = None, *, workspace: str | None = None
+    ) -> ConvergeResult:
+        stack = self.manifest.stack(stack_name)
+        digest = generation_digest(self.manifest, stack)
+        workspace = workspace or str(self.manifest.root)
+
+        known = self.registry.generation_superseded_at(digest)
+        is_new_generation = known is None and not self._generation_recorded(digest)
+
+        self.registry.record_generation(digest, stack.name)
+        superseded = self.registry.supersede_generations(stack.name, keep_digest=digest)
+
+        image_tag = image_tag_for(stack, digest)
+        self._ensure_image(stack, digest, image_tag, workspace)
+        volumes = self._ensure_volumes(stack, digest, workspace)
+
+        if superseded:
+            action = ROLLED
+        elif is_new_generation:
+            action = REGISTERED
+        else:
+            action = REUSED
+
+        self.registry.log_event("converge", f"{stack.name} {action} {digest[:19]}")
+        return ConvergeResult(
+            stack=stack.name,
+            digest=digest,
+            action=action,
+            image_tag=image_tag,
+            volumes=tuple(volumes),
+            superseded=superseded,
+        )
+
+    def _generation_recorded(self, digest: str) -> bool:
+        row = self.registry.conn.execute(
+            "SELECT 1 FROM generations WHERE digest = ?", (digest,)
+        ).fetchone()
+        return row is not None
+
+    def _resource_labels(
+        self, stack: StackSpec, kind: str, digest: str, scope: str, workspace: str
+    ) -> labels.ResourceLabels:
+        return labels.ResourceLabels(
+            registry=self.registry.registry_id,
+            kind=kind,
+            stack=stack.name,
+            generation=digest,
+            scope=scope,
+            workspace=workspace,
+            created=_now_iso(),
+        )
+
+    def _ensure_image(self, stack: StackSpec, digest: str, tag: str, workspace: str) -> None:
+        if stack.image:
+            return  # a pulled image is not ours to label or collect
+        if self.engine.run(["image", "inspect", tag]).ok:
+            return
+
+        dockerfile = self.manifest.root / str(stack.dockerfile)
+        label_args = self._resource_labels(
+            stack, "image", digest, "spec", workspace
+        ).to_docker_args()
+        result = self.engine.run(
+            [
+                "build",
+                "--file",
+                str(dockerfile),
+                "--tag",
+                tag,
+                *label_args,
+                str(self.manifest.root),
+            ]
+        )
+        if not result.ok:
+            raise EngineError(f"building {tag} failed: {result.stderr or result.stdout}")
+        self._register(stack, "image", tag, digest, "spec", workspace)
+
+    def _ensure_volumes(self, stack: StackSpec, digest: str, workspace: str) -> list[str]:
+        created: list[str] = []
+        for volume in stack.volumes:
+            name = volume_name_for(
+                stack,
+                volume.scope,
+                volume.name,
+                digest=digest,
+                workspace=workspace,
+                family=stack.family,
+            )
+            created.append(name)
+            if self.engine.run(["volume", "inspect", name]).ok:
+                continue
+            label_args = self._resource_labels(
+                stack, "volume", digest, volume.scope, workspace
+            ).to_docker_args()
+            result = self.engine.run(["volume", "create", *label_args, name])
+            if not result.ok:
+                raise EngineError(f"creating volume {name} failed: {result.stderr}")
+            self._register(stack, "volume", name, digest, volume.scope, workspace)
+        return created
+
+    def _register(
+        self, stack: StackSpec, kind: str, name: str, digest: str, scope: str, workspace: str
+    ) -> None:
+        self.registry.register_resource(
+            kind=kind,
+            name=name,
+            stack=stack.name,
+            generation=digest,
+            scope=scope,
+            workspace=workspace,
+        )
+
+    # -- running -----------------------------------------------------------
+
+    def run(
+        self,
+        command: list[str],
+        *,
+        stack_name: str | None = None,
+        workspace: str | None = None,
+    ) -> tuple[ConvergeResult, int, str]:
+        """Converge silently, then run the command in the stack. Returns (result, rc, output)."""
+        converged = self.converge(stack_name, workspace=workspace)
+        stack = self.manifest.stack(stack_name)
+
+        args = ["run", "--rm"]
+        for volume in stack.volumes:
+            name = volume_name_for(
+                stack,
+                volume.scope,
+                volume.name,
+                digest=converged.digest,
+                workspace=workspace or str(self.manifest.root),
+                family=stack.family,
+            )
+            args += ["--volume", f"{name}:/bosn/{volume.name}"]
+        args += [converged.image_tag, *command]
+
+        result = self.engine.run(args)
+        self.registry.log_event("run", f"{converged.stack} rc={result.returncode}")
+        return converged, result.returncode, result.stdout or result.stderr
+
+
+def run_task(
+    manifest: Manifest,
+    registry: Registry,
+    task_name: str,
+    *,
+    engine: Engine | None = None,
+    workspace: str | None = None,
+) -> tuple[ConvergeResult, int, str]:
+    task = manifest.task(task_name)
+    converger = Converger(manifest, registry, engine)
+    return converger.run(["sh", "-c", task.cmd], stack_name=task.stack or None, workspace=workspace)
+
+
+def workspace_of(manifest: Manifest) -> str:
+    return str(Path(manifest.root).resolve())

--- a/src/bosn/manifest.py
+++ b/src/bosn/manifest.py
@@ -1,0 +1,200 @@
+"""`bosn.toml` parsing and generation digests.
+
+The checked-in manifest is the spec sheet, the discovery surface, and the digest root.
+
+**Identity is a content digest.** A generation is the hash over a stack's manifest section
+plus the byte content of every file it references. Two invocations are compatible iff their
+digests are byte-equal. Edit the Dockerfile and a new generation rolls forward; the old one
+keeps serving its live leases, then ages out as superseded.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MANIFEST_NAME = "bosn.toml"
+VALID_SCOPES = {"spec", "stack", "machine"}
+
+
+class ManifestError(ValueError):
+    """The manifest is malformed, or names something that does not exist."""
+
+
+@dataclass(frozen=True)
+class VolumeSpec:
+    name: str
+    scope: str
+
+    def __post_init__(self) -> None:
+        if self.scope not in VALID_SCOPES:
+            raise ManifestError(
+                f"volume {self.name!r} has unknown scope {self.scope!r}; "
+                f"expected one of {sorted(VALID_SCOPES)}"
+            )
+
+
+@dataclass(frozen=True)
+class StackSpec:
+    name: str
+    dockerfile: str | None = None
+    image: str | None = None
+    family: str | None = None
+    default: bool = False
+    volumes: tuple[VolumeSpec, ...] = ()
+
+    def referenced_files(self, root: Path) -> list[Path]:
+        """Files whose byte content folds into this stack's digest."""
+        return [root / self.dockerfile] if self.dockerfile else []
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    name: str
+    stack: str
+    cmd: str
+
+
+@dataclass
+class Manifest:
+    root: Path
+    stacks: dict[str, StackSpec] = field(default_factory=dict)
+    tasks: dict[str, TaskSpec] = field(default_factory=dict)
+
+    @property
+    def path(self) -> Path:
+        return self.root / MANIFEST_NAME
+
+    def default_stack(self) -> StackSpec:
+        explicit = [s for s in self.stacks.values() if s.default]
+        if len(explicit) > 1:
+            names = sorted(s.name for s in explicit)
+            raise ManifestError(f"more than one stack is marked default: {names}")
+        if explicit:
+            return explicit[0]
+        if len(self.stacks) == 1:
+            return next(iter(self.stacks.values()))
+        raise ManifestError(
+            "no default stack; mark one with `default = true` or name a stack explicitly"
+        )
+
+    def stack(self, name: str | None) -> StackSpec:
+        if name is None:
+            return self.default_stack()
+        try:
+            return self.stacks[name]
+        except KeyError:
+            raise ManifestError(
+                f"no stack named {name!r}; known stacks: {sorted(self.stacks)}"
+            ) from None
+
+    def task(self, name: str) -> TaskSpec:
+        try:
+            return self.tasks[name]
+        except KeyError:
+            raise ManifestError(
+                f"no task named {name!r}; known tasks: {sorted(self.tasks)}"
+            ) from None
+
+    def digest(self, stack_name: str | None = None) -> str:
+        return generation_digest(self, self.stack(stack_name))
+
+
+def find_manifest(start: Path | None = None) -> Path | None:
+    """Walk upward looking for bosn.toml, the way git finds its root."""
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        manifest = candidate / MANIFEST_NAME
+        if manifest.is_file():
+            return manifest
+    return None
+
+
+def load(path: Path | str) -> Manifest:
+    path = Path(path)
+    if path.is_dir():
+        path = path / MANIFEST_NAME
+    if not path.is_file():
+        raise ManifestError(f"no manifest at {path}")
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ManifestError(f"{path} is not valid TOML: {exc}") from exc
+    return parse(raw, root=path.parent)
+
+
+def parse(raw: dict, root: Path) -> Manifest:
+    manifest = Manifest(root=root)
+
+    for name, body in (raw.get("stack") or {}).items():
+        if not isinstance(body, dict):
+            raise ManifestError(f"[stack.{name}] must be a table")
+        volumes = tuple(
+            VolumeSpec(name=vol_name, scope=str((vol_body or {}).get("scope", "spec")))
+            for vol_name, vol_body in (body.get("volumes") or {}).items()
+        )
+        stack = StackSpec(
+            name=name,
+            dockerfile=body.get("dockerfile"),
+            image=body.get("image"),
+            family=body.get("family"),
+            default=bool(body.get("default", False)),
+            volumes=volumes,
+        )
+        if stack.dockerfile is None and stack.image is None:
+            raise ManifestError(f"[stack.{name}] must set either `dockerfile` or `image`")
+        manifest.stacks[name] = stack
+
+    for name, body in (raw.get("task") or {}).items():
+        if not isinstance(body, dict):
+            raise ManifestError(f"[task.{name}] must be a table")
+        stack_name = body.get("stack")
+        cmd = body.get("cmd")
+        if not cmd:
+            raise ManifestError(f"[task.{name}] must set `cmd`")
+        if stack_name and stack_name not in manifest.stacks:
+            raise ManifestError(
+                f"[task.{name}] references unknown stack {stack_name!r}; "
+                f"known stacks: {sorted(manifest.stacks)}"
+            )
+        manifest.tasks[name] = TaskSpec(
+            name=name,
+            stack=stack_name or (manifest.default_stack().name if manifest.stacks else ""),
+            cmd=str(cmd),
+        )
+
+    if not manifest.stacks:
+        raise ManifestError("manifest declares no stacks")
+    return manifest
+
+
+def generation_digest(manifest: Manifest, stack: StackSpec) -> str:
+    """Hash the stack's manifest section plus the byte content of referenced files.
+
+    A missing referenced file is an error, not a zero -- silently digesting an absent
+    Dockerfile would make two different specs compare equal.
+    """
+    hasher = hashlib.sha256()
+    section = {
+        "name": stack.name,
+        "dockerfile": stack.dockerfile,
+        "image": stack.image,
+        "family": stack.family,
+        "volumes": sorted((v.name, v.scope) for v in stack.volumes),
+    }
+    hasher.update(json.dumps(section, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+
+    for file_path in stack.referenced_files(manifest.root):
+        if not file_path.is_file():
+            raise ManifestError(
+                f"stack {stack.name!r} references {file_path}, which does not exist"
+            )
+        hasher.update(b"\0file\0")
+        hasher.update(file_path.name.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(file_path.read_bytes())
+
+    return f"sha256:{hasher.hexdigest()}"

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -1,0 +1,218 @@
+"""Phase 5: converge semantics and volume-scope naming. No Docker needed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bosn.converge import (
+    REGISTERED,
+    REUSED,
+    ROLLED,
+    Converger,
+    volume_name_for,
+)
+from bosn.engine import EngineResult
+from bosn.manifest import load
+from bosn.registry import Registry
+
+SAMPLE = """
+[stack.test]
+dockerfile = "Dockerfile"
+family = "rust"
+default = true
+
+[stack.test.volumes]
+target    = { scope = "spec" }
+chef      = { scope = "stack" }
+cargo-reg = { scope = "machine" }
+"""
+
+
+class FakeEngine:
+    """Everything succeeds; inspect misses until a create happens."""
+
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+        self.existing: set[str] = set()
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        self.commands.append(list(args))
+        if "inspect" in args:
+            return EngineResult(0 if args[-1] in self.existing else 1, "", "")
+        if args[:2] == ["volume", "create"]:
+            self.existing.add(args[-1])
+        if args[0] == "build":
+            self.existing.add(args[args.index("--tag") + 1])
+        return EngineResult(0, "ok", "")
+
+    def ran(self, *prefix: str) -> list[list[str]]:
+        return [c for c in self.commands if c[: len(prefix)] == list(prefix)]
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(SAMPLE, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def registry(tmp_path: Path):
+    with Registry(tmp_path / "r.sqlite3") as reg:
+        yield reg
+
+
+@pytest.fixture
+def converger(project: Path, registry: Registry) -> Converger:
+    return Converger(load(project), registry, FakeEngine())  # type: ignore[arg-type]
+
+
+# -- convergence is idempotent ---------------------------------------------
+
+
+def test_first_converge_registers_then_reuses(converger: Converger) -> None:
+    """The same command is correct on the 1st and the 500th invocation."""
+    first = converger.converge()
+    assert first.action == REGISTERED
+
+    second = converger.converge()
+    assert second.action == REUSED
+    assert second.digest == first.digest
+
+    for _ in range(10):
+        assert converger.converge().action == REUSED
+
+
+def test_converge_creates_each_volume_once(converger: Converger) -> None:
+    converger.converge()
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    assert len(engine.ran("volume", "create")) == 3
+
+    converger.converge()
+    assert len(engine.ran("volume", "create")) == 3, "volumes must not be recreated"
+
+
+def test_converge_builds_the_image_once(converger: Converger) -> None:
+    converger.converge()
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    assert len(engine.ran("build")) == 1
+    converger.converge()
+    assert len(engine.ran("build")) == 1
+
+
+def test_editing_the_spec_rolls_the_generation(project: Path, registry: Registry) -> None:
+    engine = FakeEngine()
+    Converger(load(project), registry, engine).converge()  # type: ignore[arg-type]
+
+    (project / "Dockerfile").write_text("FROM alpine:3.20\n", encoding="utf-8")
+    rolled = Converger(load(project), registry, engine).converge()  # type: ignore[arg-type]
+
+    assert rolled.action == ROLLED
+    assert rolled.superseded == 1
+
+
+def test_the_old_generation_is_marked_superseded(project: Path, registry: Registry) -> None:
+    engine = FakeEngine()
+    first = Converger(load(project), registry, engine).converge()  # type: ignore[arg-type]
+    (project / "Dockerfile").write_text("FROM debian\n", encoding="utf-8")
+    second = Converger(load(project), registry, engine).converge()  # type: ignore[arg-type]
+
+    assert registry.generation_superseded_at(first.digest) is not None
+    assert registry.generation_superseded_at(second.digest) is None
+
+
+def test_every_created_resource_is_registered(converger: Converger, registry: Registry) -> None:
+    converger.converge()
+    kinds = sorted(r.kind for r in registry.list_resources())
+    assert kinds == ["image", "volume", "volume", "volume"]
+
+
+def test_created_resources_carry_the_full_label_contract(converger: Converger) -> None:
+    converger.converge()
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    from bosn import labels
+
+    create = engine.ran("volume", "create")[0]
+    rendered = {
+        arg.split("=", 1)[0] for i, arg in enumerate(create) if i > 0 and create[i - 1] == "--label"
+    }
+    assert set(labels.REQUIRED_LABELS) <= rendered
+
+
+# -- volume scope naming ---------------------------------------------------
+
+
+def _name(scope: str, *, digest: str, workspace: str, family: str | None = "rust") -> str:
+    from bosn.manifest import StackSpec
+
+    stack = StackSpec(name="test", dockerfile="Dockerfile", family=family)
+    return volume_name_for(stack, scope, "cache", digest=digest, workspace=workspace, family=family)
+
+
+def test_spec_scoped_volumes_change_with_the_digest() -> None:
+    a = _name("spec", digest="sha256:aaa", workspace="/w1")
+    b = _name("spec", digest="sha256:bbb", workspace="/w1")
+    assert a != b
+
+
+def test_stack_scoped_volumes_survive_spec_edits_in_one_workspace() -> None:
+    a = _name("stack", digest="sha256:aaa", workspace="/w1")
+    b = _name("stack", digest="sha256:bbb", workspace="/w1")
+    assert a == b
+
+
+def test_stack_scoped_volumes_differ_across_workspaces() -> None:
+    a = _name("stack", digest="sha256:aaa", workspace="/w1")
+    b = _name("stack", digest="sha256:aaa", workspace="/w2")
+    assert a != b
+
+
+def test_machine_scoped_volumes_are_one_per_machine() -> None:
+    """This is what kills the incident's dominant multiplier."""
+    a = _name("machine", digest="sha256:aaa", workspace="/w1")
+    b = _name("machine", digest="sha256:bbb", workspace="/w2")
+    assert a == b
+
+
+def test_machine_scope_is_shared_across_a_family() -> None:
+    from bosn.manifest import StackSpec
+
+    one = volume_name_for(
+        StackSpec(name="alpha", image="x", family="rust"),
+        "machine",
+        "cargo-reg",
+        digest="sha256:a",
+        workspace="/w1",
+        family="rust",
+    )
+    two = volume_name_for(
+        StackSpec(name="beta", image="y", family="rust"),
+        "machine",
+        "cargo-reg",
+        digest="sha256:b",
+        workspace="/w2",
+        family="rust",
+    )
+    assert one == two, "same family must share one machine-scoped volume"
+
+
+# -- running ---------------------------------------------------------------
+
+
+def test_run_converges_first_then_runs(converger: Converger) -> None:
+    _result, code, _output = converger.run(["echo", "hi"])
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    assert code == 0
+    assert engine.ran("build"), "converge must have happened before the run"
+    run_cmd = engine.ran("run")[0]
+    assert run_cmd[-2:] == ["echo", "hi"]
+    assert "--rm" in run_cmd
+
+
+def test_run_mounts_every_declared_volume(converger: Converger) -> None:
+    converger.run(["true"])
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    mounts = [a for a in engine.ran("run")[0] if a.startswith("bosn-")]
+    assert len(mounts) == 3

--- a/tests/test_converge_docker.py
+++ b/tests/test_converge_docker.py
@@ -1,0 +1,121 @@
+"""Phase 5 end-to-end: a real bosn.toml builds, runs, labels, and registers.
+
+Docker-marked: Linux CI only.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bosn import labels
+from bosn.converge import Converger, run_task
+from bosn.engine import Engine
+from bosn.manifest import load
+from bosn.registry import Registry
+from bosn.resources import ResourceScanner
+
+pytestmark = pytest.mark.docker
+
+MANIFEST = """
+[stack.test]
+dockerfile = "Dockerfile"
+family = "alpinetest"
+default = true
+
+[stack.test.volumes]
+work = { scope = "spec" }
+
+[task.hello]
+stack = "test"
+cmd = "echo task-ran"
+"""
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "Dockerfile").write_text(
+        f"FROM alpine:3.20\nRUN echo {uuid.uuid4().hex[:8]} > /marker\n", encoding="utf-8"
+    )
+    (tmp_path / "bosn.toml").write_text(MANIFEST, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Iterator[Registry]:
+    with Registry(tmp_path / "state" / "r.sqlite3") as reg:
+        yield reg
+
+
+@pytest.fixture
+def converger(project: Path, registry: Registry, engine: Engine) -> Iterator[Converger]:
+    conv = Converger(load(project), registry, engine)
+    try:
+        yield conv
+    finally:
+        for resource in registry.list_resources():
+            if resource.kind == "volume":
+                engine.run(["volume", "rm", "--force", resource.name])
+            elif resource.kind == "image":
+                engine.run(["image", "rm", "--force", resource.name])
+
+
+def test_run_builds_and_executes_end_to_end(converger: Converger) -> None:
+    result, code, output = converger.run(["echo", "ok-from-container"])
+    assert code == 0, output
+    assert "ok-from-container" in output
+    assert result.digest.startswith("sha256:")
+
+
+def test_everything_created_is_labeled_and_registered(
+    converger: Converger, registry: Registry, engine: Engine
+) -> None:
+    converger.run(["true"])
+
+    registered = {r.name for r in registry.list_resources()}
+    assert registered, "converge registered nothing"
+
+    scan = ResourceScanner(engine).scan(registry.registry_id, kinds=["volume"])
+    owned = {r.name for r in scan.owned}
+    volumes = {r.name for r in registry.list_resources() if r.kind == "volume"}
+    assert volumes <= owned, "every created volume must carry complete ownership labels"
+
+
+def test_created_volume_labels_round_trip(
+    converger: Converger, registry: Registry, engine: Engine
+) -> None:
+    converger.run(["true"])
+    volume = next(r for r in registry.list_resources() if r.kind == "volume")
+    raw = ResourceScanner(engine).inspect_labels("volume", volume.name)
+    assert labels.is_owned_by(raw, registry.registry_id)
+    assert labels.ResourceLabels.from_dict(raw).stack == "test"
+
+
+def test_second_run_reuses_and_does_not_rebuild(converger: Converger) -> None:
+    first, code, _ = converger.run(["true"])
+    assert code == 0
+    second, code, _ = converger.run(["true"])
+    assert code == 0
+    assert second.digest == first.digest
+    assert second.action == "reused"
+
+
+def test_a_manifest_task_runs(project: Path, registry: Registry, engine: Engine) -> None:
+    _result, code, output = run_task(load(project), registry, "hello", engine=engine)
+    try:
+        assert code == 0, output
+        assert "task-ran" in output
+    finally:
+        for resource in registry.list_resources():
+            if resource.kind == "volume":
+                engine.run(["volume", "rm", "--force", resource.name])
+            elif resource.kind == "image":
+                engine.run(["image", "rm", "--force", resource.name])
+
+
+def test_a_failing_command_propagates_its_exit_code(converger: Converger) -> None:
+    _result, code, _output = converger.run(["sh", "-c", "exit 7"])
+    assert code == 7

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,144 @@
+"""Phase 5: manifest parsing and generation digests. No Docker needed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bosn import manifest as manifest_mod
+from bosn.manifest import ManifestError, generation_digest, load
+
+SAMPLE = """
+[stack.test]
+dockerfile = "docker/test.Dockerfile"
+family = "rust"
+default = true
+
+[stack.test.volumes]
+target    = { scope = "spec" }
+chef      = { scope = "stack" }
+cargo-reg = { scope = "machine" }
+
+[stack.lint]
+image = "python:3.12-slim"
+
+[task.unit]
+stack = "test"
+cmd = "bash test"
+"""
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "docker").mkdir()
+    (tmp_path / "docker" / "test.Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(SAMPLE, encoding="utf-8")
+    return tmp_path
+
+
+def test_parses_stacks_tasks_and_volume_scopes(project: Path) -> None:
+    manifest = load(project)
+    assert sorted(manifest.stacks) == ["lint", "test"]
+    test = manifest.stacks["test"]
+    assert test.family == "rust"
+    assert {v.name: v.scope for v in test.volumes} == {
+        "target": "spec",
+        "chef": "stack",
+        "cargo-reg": "machine",
+    }
+    assert manifest.tasks["unit"].cmd == "bash test"
+    assert manifest.default_stack().name == "test"
+
+
+def test_find_manifest_walks_upward(project: Path) -> None:
+    nested = project / "a" / "b"
+    nested.mkdir(parents=True)
+    assert manifest_mod.find_manifest(nested) == project / "bosn.toml"
+
+
+def test_find_manifest_returns_none_when_absent(tmp_path: Path) -> None:
+    assert manifest_mod.find_manifest(tmp_path) is None
+
+
+def test_unknown_stack_and_task_names_are_specific_errors(project: Path) -> None:
+    manifest = load(project)
+    with pytest.raises(ManifestError, match="no stack named 'nope'"):
+        manifest.stack("nope")
+    with pytest.raises(ManifestError, match="no task named 'nope'"):
+        manifest.task("nope")
+
+
+def test_task_referencing_an_unknown_stack_is_rejected(tmp_path: Path) -> None:
+    (tmp_path / "bosn.toml").write_text(
+        '[stack.a]\nimage = "x"\n\n[task.t]\nstack = "ghost"\ncmd = "echo"\n', encoding="utf-8"
+    )
+    with pytest.raises(ManifestError, match="unknown stack 'ghost'"):
+        load(tmp_path)
+
+
+def test_stack_without_dockerfile_or_image_is_rejected(tmp_path: Path) -> None:
+    (tmp_path / "bosn.toml").write_text('[stack.a]\nfamily = "x"\n', encoding="utf-8")
+    with pytest.raises(ManifestError, match="`dockerfile` or `image`"):
+        load(tmp_path)
+
+
+def test_unknown_volume_scope_is_rejected(tmp_path: Path) -> None:
+    (tmp_path / "bosn.toml").write_text(
+        '[stack.a]\nimage = "x"\n\n[stack.a.volumes]\nv = { scope = "galaxy" }\n', encoding="utf-8"
+    )
+    with pytest.raises(ManifestError, match="unknown scope 'galaxy'"):
+        load(tmp_path)
+
+
+def test_two_default_stacks_is_an_error(tmp_path: Path) -> None:
+    (tmp_path / "bosn.toml").write_text(
+        '[stack.a]\nimage = "x"\ndefault = true\n\n[stack.b]\nimage = "y"\ndefault = true\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ManifestError, match="more than one stack is marked default"):
+        load(tmp_path).default_stack()
+
+
+def test_invalid_toml_names_the_file(tmp_path: Path) -> None:
+    (tmp_path / "bosn.toml").write_text("this is not = = toml", encoding="utf-8")
+    with pytest.raises(ManifestError, match="not valid TOML"):
+        load(tmp_path)
+
+
+# -- digests ---------------------------------------------------------------
+
+
+def test_digest_is_stable_across_loads(project: Path) -> None:
+    assert load(project).digest("test") == load(project).digest("test")
+
+
+def test_editing_the_dockerfile_rolls_the_digest(project: Path) -> None:
+    before = load(project).digest("test")
+    (project / "docker" / "test.Dockerfile").write_text("FROM alpine:3.20\n", encoding="utf-8")
+    assert load(project).digest("test") != before
+
+
+def test_editing_the_manifest_section_rolls_the_digest(project: Path) -> None:
+    before = load(project).digest("test")
+    (project / "bosn.toml").write_text(SAMPLE.replace('family = "rust"', 'family = "go"'), "utf-8")
+    assert load(project).digest("test") != before
+
+
+def test_touching_an_unrelated_file_does_not_roll_the_digest(project: Path) -> None:
+    before = load(project).digest("test")
+    (project / "README.md").write_text("hello", encoding="utf-8")
+    assert load(project).digest("test") == before
+
+
+def test_different_stacks_have_different_digests(project: Path) -> None:
+    manifest = load(project)
+    assert manifest.digest("test") != manifest.digest("lint")
+
+
+def test_a_missing_referenced_file_is_an_error_not_a_zero(project: Path) -> None:
+    """Silently digesting an absent Dockerfile would make two different specs compare equal."""
+    (project / "docker" / "test.Dockerfile").unlink()
+    manifest = load(project)
+    with pytest.raises(ManifestError, match="does not exist"):
+        generation_digest(manifest, manifest.stacks["test"])


### PR DESCRIPTION
Phase 5 of #3.

- `manifest.py`: `bosn.toml` parsing with specific errors (unknown stack/task, task naming a ghost stack, stack with neither dockerfile nor image, bad volume scope, two defaults, invalid TOML). `find_manifest` walks upward like git.
- **Digests:** hash over the stack's manifest section plus referenced file bytes. Tests pin that editing the Dockerfile or the manifest section rolls the digest, touching an unrelated file does not, and a *missing* referenced file raises rather than silently digesting to a constant.
- `converge.py`: converge-then-run. First call registers, later calls reuse, a spec edit rolls and supersedes the old generation. Images and volumes are created once and carry the full label contract.
- **Volume scopes:** `spec` keyed by digest, `stack` by workspace, `machine` by family alone — one per machine across every repo and worktree.
- CLI: `bosn run -- <cmd>`, `bosn run --task <name>`, `bosn tasks --json`-style output.
- Docker end-to-end test: real `bosn.toml` + Dockerfile builds, runs, labels, registers, reuses on second call, and propagates a non-zero exit code.

130 passed, 1 skipped locally. Lint clean.

Refs #3