### PR TITLE
feat: phase 6 — tiered GC, status, done, typed CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ records your development workflow creates. It knows what each resource belongs t
 which ones are in active use, and when the rest may be deleted — so build caches
 stay warm while total storage stays bounded, without anyone remembering to clean up.
 
-> **Status: design complete, implementation not started.** The full v3 design lives in
-> [issue #1](https://github.com/zackees/bosn/issues/1). That text predates the rename and
-> refers to the project as *dockhand*; the design is unchanged, the name is not.
+> **Status: base functionality implemented and validated.** The manifest, generation
+> digests, converge-then-run, the sqlite registry, the daemon singleton, leases, adoption,
+> and tiered GC are all in place and covered end to end against a real Docker engine on
+> Linux CI. The full v3 design lives in
+> [issue #1](https://github.com/zackees/bosn/issues/1) and the bringup plan in
+> [issue #3](https://github.com/zackees/bosn/issues/3). Issue #1's text predates the rename
+> and refers to the project as *dockhand*; the design is unchanged, the name is not.
+>
+> Not yet built: the `bosn-docker` compatibility subset, `bosn init` from `compose.yaml`,
+> daemon-owned background jobs (`bosn attach`), macOS/Windows CI, and podman.
 
 ## Why this exists
 

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Sequence
-from pathlib import Path
+from collections.abc import Callable, Sequence
 
 from bosn import __version__, ipc
 from bosn.engine import Engine
+from bosn.options import Options, from_namespace
 
 DAEMON_VERB = "__daemon"
 
@@ -23,13 +23,13 @@ NOT_IMPLEMENTED_EXIT = 3
 # verb -> (help text, phase that lands it)
 VERBS: dict[str, tuple[str, str]] = {
     "run": ("run an ad-hoc command in a stack", "implemented"),
-    "shell": ("interactive session in the persistent container", "phase 6"),
+    "shell": ("interactive session in the persistent container", "implemented"),
     "tasks": ("list manifest tasks, stacks, digests, registration state", "implemented"),
     "jobs": ("list daemon-owned jobs", "implemented"),
     "attach": ("attach to a daemon-owned job", "phase 6"),
-    "status": ("tiers, leases, managed bytes vs ceiling, foreign registries", "phase 6"),
-    "gc": ("report or reclaim collectable resources", "phase 6"),
-    "done": ("mark this workspace finished; its caches become collectable", "phase 6"),
+    "status": ("tiers, leases, managed bytes vs ceiling, foreign registries", "implemented"),
+    "gc": ("report or reclaim collectable resources", "implemented"),
+    "done": ("mark this workspace finished; its caches become collectable", "implemented"),
     "doctor": ("engine health and reachability", "implemented"),
 }
 
@@ -63,10 +63,26 @@ def build_parser() -> argparse.ArgumentParser:
     for verb, (help_text, _) in VERBS.items():
         sub = subparsers.add_parser(verb, help=help_text)
         sub.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
-        if verb in {"run", "tasks", "shell"}:
+        if verb in {"run", "tasks", "shell", "done"}:
             sub.add_argument("--stack", default=None, help="stack to use (default: the default)")
             sub.add_argument("--task", default=None, help="run a manifest task by name")
             sub.add_argument("--manifest", default=None, dest="sub_manifest")
+        if verb == "gc":
+            group = sub.add_mutually_exclusive_group()
+            group.add_argument(
+                "--dry-run",
+                dest="dry_run",
+                action="store_true",
+                default=True,
+                help="report what would be reclaimed (default)",
+            )
+            group.add_argument(
+                "--apply",
+                dest="dry_run",
+                action="store_false",
+                help="actually reclaim. There is deliberately no --force: automatic "
+                "deletion always requires complete ownership proof",
+            )
 
     daemon_parser = subparsers.add_parser(DAEMON_VERB, help=argparse.SUPPRESS)
     daemon_parser.add_argument("--port", type=int, default=None)
@@ -75,11 +91,6 @@ def build_parser() -> argparse.ArgumentParser:
     # Accepted after the verb as well, so a spawned argv need not order its flags.
     daemon_parser.add_argument("--state-dir", default=None, dest="daemon_state_dir")
     return parser
-
-
-def resolve_state_dir(ns: argparse.Namespace) -> Path | None:
-    raw = getattr(ns, "daemon_state_dir", None) or ns.state_dir
-    return Path(raw) if raw else None
 
 
 def cmd_doctor(engine_binary: str) -> int:
@@ -94,34 +105,34 @@ def cmd_doctor(engine_binary: str) -> int:
     return 0
 
 
-def cmd_daemon(ns: argparse.Namespace) -> int:
+def cmd_daemon(opts: Options) -> int:
     from bosn import daemon as daemon_mod
 
-    state_dir = resolve_state_dir(ns)
+    state_dir = opts.state_dir
 
-    if ns.stop:
+    if opts.stop:
         stopped = daemon_mod.stop(state_dir)
         print("daemon stopped" if stopped else "no daemon was running")
         return 0
 
     idle = (
-        ns.idle_retire_seconds
-        if ns.idle_retire_seconds is not None
+        opts.idle_retire_seconds
+        if opts.idle_retire_seconds is not None
         else daemon_mod.DEFAULT_IDLE_RETIRE_SECONDS
     )
     try:
-        daemon = daemon_mod.Daemon(state_dir=state_dir, port=ns.port, idle_retire_seconds=idle)
+        daemon = daemon_mod.Daemon(state_dir=state_dir, port=opts.port, idle_retire_seconds=idle)
         return daemon.serve_forever()
     except daemon_mod.DaemonError as exc:
         print(str(exc), file=sys.stderr)
         return 1
 
 
-def cmd_jobs(ns: argparse.Namespace) -> int:
+def cmd_jobs(opts: Options) -> int:
     from bosn import daemon as daemon_mod
 
     try:
-        reply = daemon_mod.request("jobs", resolve_state_dir(ns))
+        reply = daemon_mod.request("jobs", opts.state_dir)
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:  # fail closed, stay visible
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
         return 1
@@ -129,27 +140,26 @@ def cmd_jobs(ns: argparse.Namespace) -> int:
     return 0
 
 
-def _open_manifest_and_registry(ns: argparse.Namespace):
+def _open_manifest_and_registry(opts: Options):
     from bosn.manifest import ManifestError, find_manifest, load
     from bosn.registry import Registry, default_db_path
 
-    raw_manifest = getattr(ns, "sub_manifest", None) or getattr(ns, "manifest", None)
-    manifest_path = Path(raw_manifest) if raw_manifest else find_manifest()
+    manifest_path = opts.manifest or find_manifest()
     if manifest_path is None:
         raise ManifestError(
             "no bosn.toml found in this directory or any parent; create one or pass --manifest"
         )
     manifest = load(manifest_path)
-    state_dir = resolve_state_dir(ns)
+    state_dir = opts.state_dir
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
     return manifest, Registry(db_path)
 
 
-def cmd_tasks(ns: argparse.Namespace) -> int:
+def cmd_tasks(opts: Options) -> int:
     from bosn.manifest import ManifestError, generation_digest
 
     try:
-        manifest, registry = _open_manifest_and_registry(ns)
+        manifest, registry = _open_manifest_and_registry(opts)
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -180,30 +190,32 @@ def cmd_tasks(ns: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_run(ns: argparse.Namespace) -> int:
+def cmd_run(opts: Options) -> int:
     from bosn.converge import Converger
     from bosn.engine import EngineError
     from bosn.manifest import ManifestError
 
-    command = [a for a in (ns.args or []) if a != "--"]
-    if not command and not ns.task:
+    command = opts.command
+    if not command and not opts.task:
         print("nothing to run: pass a command after `--`, or name a task", file=sys.stderr)
         return 2
 
     try:
-        manifest, registry = _open_manifest_and_registry(ns)
+        manifest, registry = _open_manifest_and_registry(opts)
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
 
     try:
-        if ns.task:
+        if opts.task:
             from bosn.converge import run_task
 
-            _result, code, output = run_task(manifest, registry, ns.task, engine=Engine(ns.engine))
+            _result, code, output = run_task(
+                manifest, registry, opts.task, engine=Engine(opts.engine)
+            )
         else:
-            converger = Converger(manifest, registry, Engine(ns.engine))
-            _result, code, output = converger.run(command, stack_name=ns.stack)
+            converger = Converger(manifest, registry, Engine(opts.engine))
+            _result, code, output = converger.run(command, stack_name=opts.stack)
     except (ManifestError, EngineError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -215,29 +227,82 @@ def cmd_run(ns: argparse.Namespace) -> int:
     return code
 
 
+def cmd_status(opts: Options) -> int:
+    from bosn.gc import status
+    from bosn.registry import Registry, default_db_path
+
+    state_dir = opts.state_dir
+    db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
+    with Registry(db_path) as registry:
+        print(json.dumps(status(registry, Engine(opts.engine)), indent=2))
+    return 0
+
+
+def cmd_gc(opts: Options) -> int:
+    from bosn.gc import Collector, done_workspaces
+    from bosn.registry import Registry, default_db_path
+
+    state_dir = opts.state_dir
+    db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
+    with Registry(db_path) as registry:
+        collector = Collector(registry, Engine(opts.engine))
+        result = collector.collect(dry_run=opts.dry_run, done_workspaces=done_workspaces(registry))
+
+    print(json.dumps({**result.summary(), "dry_run": result.dry_run}, indent=2))
+    for name in result.removed:
+        print(("would remove " if result.dry_run else "removed ") + name)
+    for message in result.errors:
+        print(f"error: {message}", file=sys.stderr)
+    return 1 if result.errors else 0
+
+
+def cmd_done(opts: Options) -> int:
+    from bosn.gc import mark_done
+    from bosn.manifest import ManifestError
+
+    try:
+        manifest, registry = _open_manifest_and_registry(opts)
+    except ManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    try:
+        marked = mark_done(registry, str(manifest.root))
+    finally:
+        registry.close()
+    print(f"marked {marked} resource(s) in {manifest.root} as done")
+    return 0
+
+
+def cmd_shell(opts: Options) -> int:
+    from dataclasses import replace
+
+    return cmd_run(replace(opts, args=("sh",), task=None))
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    opts = from_namespace(ns)
 
-    if ns.verb is None:
+    if opts.verb is None:
         parser.print_help()
         return 0
 
-    if ns.verb == DAEMON_VERB:
-        return cmd_daemon(ns)
+    handlers: dict[str, Callable[[Options], int]] = {
+        DAEMON_VERB: cmd_daemon,
+        "doctor": lambda o: cmd_doctor(o.engine),
+        "jobs": cmd_jobs,
+        "tasks": cmd_tasks,
+        "run": cmd_run,
+        "shell": cmd_shell,
+        "status": cmd_status,
+        "gc": cmd_gc,
+        "done": cmd_done,
+    }
+    handler = handlers.get(opts.verb)
+    if handler is not None:
+        return handler(opts)
 
-    if ns.verb == "doctor":
-        return cmd_doctor(ns.engine)
-
-    if ns.verb == "jobs":
-        return cmd_jobs(ns)
-
-    if ns.verb == "tasks":
-        return cmd_tasks(ns)
-
-    if ns.verb == "run":
-        return cmd_run(ns)
-
-    error = VerbNotImplementedError(ns.verb, VERBS[ns.verb][1])
+    error = VerbNotImplementedError(opts.verb, VERBS[opts.verb][1])
     print(str(error), file=sys.stderr)
     return NOT_IMPLEMENTED_EXIT

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -1,0 +1,145 @@
+"""Garbage collection and status.
+
+Design commitments enforced here:
+
+- **Never `docker system prune`.** Never prune the default builder. Resources are removed
+  one at a time, by name, and only after re-confirming complete ownership proof from the
+  engine's own labels -- the registry is a hint, the labels are the authority.
+- **No `gc --force`.** Automatic deletion requires complete ownership proof, so there is no
+  flag that skips it.
+- **Every failure is observable.** A removal error lands in the event log and in the result
+  counters. A discarded prune error is how you come to believe storage is bounded when it
+  is not.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from bosn import labels
+from bosn.engine import Engine
+from bosn.registry import Registry
+from bosn.resources import ResourceScanner
+from bosn.retention import Pressure, Verdict, collectable, plan
+
+_REMOVE_COMMANDS: dict[str, list[str]] = {
+    "container": ["rm", "--force"],
+    "volume": ["volume", "rm", "--force"],
+    "image": ["image", "rm", "--force"],
+}
+
+
+@dataclass
+class GCResult:
+    dry_run: bool
+    removed: list[str] = field(default_factory=list)
+    kept: list[str] = field(default_factory=list)
+    skipped_unproven: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "removed": len(self.removed),
+            "kept": len(self.kept),
+            "skipped_unproven": len(self.skipped_unproven),
+            "errors": len(self.errors),
+        }
+
+
+class Collector:
+    def __init__(self, registry: Registry, engine: Engine | None = None) -> None:
+        self.registry = registry
+        self.engine = engine or Engine()
+        self.scanner = ResourceScanner(self.engine)
+
+    def _ownership_proven(self, kind: str, name: str) -> bool:
+        """Re-confirm from the engine's labels before deleting anything.
+
+        The registry can be stale or restored from a backup; the labels cannot lie about
+        who created a resource. Automatic deletion requires this proof.
+        """
+        raw = self.scanner.inspect_labels(kind, name)
+        return labels.is_owned_by(raw, self.registry.registry_id)
+
+    def collect(
+        self,
+        *,
+        dry_run: bool = True,
+        done_workspaces: set[str] | None = None,
+        pressure: Pressure | None = None,
+    ) -> GCResult:
+        verdicts: list[Verdict] = plan(
+            self.registry, done_workspaces=done_workspaces, pressure=pressure
+        )
+        result = GCResult(dry_run=dry_run)
+
+        for verdict in verdicts:
+            if not verdict.collect:
+                result.kept.append(verdict.name)
+
+        for verdict in collectable(verdicts):
+            resource = verdict.resource
+            if not self._ownership_proven(resource.kind, resource.name):
+                result.skipped_unproven.append(resource.name)
+                self.registry.log_event("gc.skipped_unproven", resource.name)
+                continue
+
+            if dry_run:
+                result.removed.append(resource.name)
+                continue
+
+            args = _REMOVE_COMMANDS.get(resource.kind)
+            if args is None:
+                result.errors.append(f"{resource.name}: unknown kind {resource.kind}")
+                continue
+
+            removal = self.engine.run([*args, resource.name])
+            if removal.ok:
+                self.registry.remove_resource(resource.id)
+                self.registry.log_event("gc.removed", f"{resource.kind}:{resource.name}")
+                result.removed.append(resource.name)
+            else:
+                message = f"{resource.name}: {removal.stderr or removal.stdout}"
+                result.errors.append(message)
+                self.registry.log_event("gc.error", message)
+
+        return result
+
+
+def status(registry: Registry, engine: Engine | None = None) -> dict:
+    """Tiers, leases, and foreign registries. Read-only: works with the daemon dead."""
+    engine = engine or Engine()
+    verdicts = plan(registry)
+    scan = ResourceScanner(engine).scan(registry.registry_id)
+
+    by_reason: dict[str, int] = {}
+    for verdict in verdicts:
+        by_reason[verdict.reason] = by_reason.get(verdict.reason, 0) + 1
+
+    return {
+        "registry_id": registry.registry_id,
+        "registered": len(verdicts),
+        "collectable": len(collectable(verdicts)),
+        "by_reason": by_reason,
+        "engine": scan.counts(),
+        "foreign_registries": sorted(scan.foreign_registries),
+    }
+
+
+def mark_done(registry: Registry, workspace: str) -> int:
+    """Mark a workspace finished so its non-machine caches become collectable.
+
+    Dirty work is never destroyed on inference: this is the first-party signal, the
+    strongest one there is. Derived signals are the caller's responsibility.
+    """
+    marked = 0
+    for resource in registry.list_resources():
+        if resource.workspace == workspace and resource.scope != "machine":
+            registry.set_resource_state(resource.id, "done")
+            marked += 1
+    registry.log_event("workspace.done", f"{workspace} ({marked} resources)")
+    return marked
+
+
+def done_workspaces(registry: Registry) -> set[str]:
+    return {r.workspace for r in registry.list_resources() if r.state == "done"}

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -1,0 +1,104 @@
+"""Fully typed CLI options.
+
+`argparse.Namespace` is a bag of dynamically attached attributes: every read is
+`Any`, a typo is an `AttributeError` at runtime rather than a type error, and whether a
+field exists at all depends on which subparser ran. That gets worse as verbs accumulate
+their own flags.
+
+So argparse is confined to one function. It parses, and its Namespace is immediately
+converted into a frozen dataclass with concrete types and real defaults. Everything
+downstream takes `Options` and is fully checkable by pyright.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Options:
+    """One fully resolved, fully typed value per CLI input."""
+
+    verb: str | None = None
+
+    # global
+    engine: str = "docker"
+    state_dir: Path | None = None
+    manifest: Path | None = None
+
+    # stack-facing verbs
+    stack: str | None = None
+    task: str | None = None
+    args: tuple[str, ...] = ()
+
+    # gc
+    dry_run: bool = True
+
+    # daemon
+    port: int | None = None
+    idle_retire_seconds: float | None = None
+    stop: bool = False
+
+    extras: tuple[str, ...] = field(default=())
+
+    @property
+    def command(self) -> list[str]:
+        """The ad-hoc command, with any argparse `--` separator stripped."""
+        return [arg for arg in self.args if arg != "--"]
+
+    def with_command(self, command: list[str]) -> Options:
+        from dataclasses import replace
+
+        return replace(self, args=tuple(command))
+
+
+def _as_path(value: object) -> Path | None:
+    if value is None or value == "":
+        return None
+    return Path(str(value))
+
+
+def _as_str(value: object) -> str | None:
+    return None if value is None else str(value)
+
+
+def from_namespace(ns: argparse.Namespace) -> Options:
+    """Collapse argparse's dynamic Namespace into a typed Options.
+
+    This is the only place that reads attributes off a Namespace, and it uses getattr with
+    explicit defaults because which attributes exist depends on the subparser that ran.
+    """
+    raw: dict[str, object] = dict(vars(ns))
+
+    def get(name: str, default: object = None) -> object:
+        return raw.get(name, default)
+
+    def get_list(name: str) -> tuple[str, ...]:
+        value = raw.get(name)
+        if not isinstance(value, (list, tuple)):
+            return ()
+        return tuple(str(item) for item in value)
+
+    # --state-dir and --manifest are accepted both globally and after some verbs; the
+    # verb-local spelling wins when present.
+    state_dir = get("daemon_state_dir") or get("state_dir")
+    manifest = get("sub_manifest") or get("manifest")
+
+    idle = get("idle_retire_seconds")
+    port = get("port")
+
+    return Options(
+        verb=_as_str(get("verb")),
+        engine=str(get("engine") or "docker"),
+        state_dir=_as_path(state_dir),
+        manifest=_as_path(manifest),
+        stack=_as_str(get("stack")),
+        task=_as_str(get("task")),
+        args=get_list("args"),
+        dry_run=bool(get("dry_run", True)),
+        port=None if port is None else int(str(port)),
+        idle_retire_seconds=None if idle is None else float(str(idle)),
+        stop=bool(get("stop", False)),
+    )

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -1,0 +1,151 @@
+"""Tiered retention.
+
+Retention is tiered because containers are not volumes. A container is disposable --
+seconds to recreate from a warm image. A cache volume is the asset that turns a 20-minute
+cold build into 30 seconds. They get separate clocks:
+
+- containers idle-stop at 1 h and are removed at 24 h
+- warm volumes live 72 h
+- superseded generations are capped at 24 h
+- machine-shared caches age only under pressure
+
+Nothing here deletes anything. This module decides; `gc` executes, and only against
+resources carrying complete ownership proof.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bosn.registry import Lease, Registry, Resource
+from bosn.resources import (
+    QUIET_PERIOD_SECONDS,
+    lease_is_expired,
+    process_alive,
+)
+
+HOUR = 3600.0
+DAY = 24 * HOUR
+
+CONTAINER_IDLE_STOP = 1 * HOUR
+CONTAINER_REMOVE = 1 * DAY
+VOLUME_WARM_TTL = 3 * DAY
+SUPERSEDED_CAP = 1 * DAY
+
+# Reasons a resource is kept. Ordered by how strongly they bind.
+KEPT_LEASED = "leased"
+KEPT_QUIET_PERIOD = "quiet-period"
+KEPT_WARM = "warm"
+KEPT_MACHINE_SCOPE = "machine-scope"
+
+# Reasons a resource is collectable.
+COLLECT_SUPERSEDED = "superseded"
+COLLECT_IDLE = "idle"
+COLLECT_DONE = "workspace-done"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    resource: Resource
+    collect: bool
+    reason: str
+
+    @property
+    def name(self) -> str:
+        return self.resource.name
+
+
+@dataclass(frozen=True)
+class Pressure:
+    """Free-space pressure on the engine's backing store."""
+
+    under_pressure: bool = False
+
+
+def container_should_stop(resource: Resource, now: float) -> bool:
+    return resource.kind == "container" and (now - resource.last_used) >= CONTAINER_IDLE_STOP
+
+
+def _ttl_for(resource: Resource) -> float:
+    if resource.kind == "container":
+        return CONTAINER_REMOVE
+    return VOLUME_WARM_TTL
+
+
+def evaluate(
+    registry: Registry,
+    resource: Resource,
+    *,
+    now: float | None = None,
+    superseded: bool = False,
+    workspace_done: bool = False,
+    pressure: Pressure | None = None,
+    alive_probe=process_alive,
+) -> Verdict:
+    """Decide a single resource's fate. Never mutates anything."""
+    now = registry.clock.now() if now is None else now
+    pressure = pressure or Pressure()
+
+    leases: list[Lease] = registry.leases_for(resource.id)
+    if any(not lease_is_expired(lease, now, alive_probe=alive_probe) for lease in leases):
+        # Leased resources are untouchable, full stop -- this outranks every other signal,
+        # including an explicit `done`.
+        return Verdict(resource, False, KEPT_LEASED)
+
+    age = now - resource.last_used
+
+    if resource.state == "adopted" and age < QUIET_PERIOD_SECONDS:
+        return Verdict(resource, False, KEPT_QUIET_PERIOD)
+
+    if superseded:
+        if age >= SUPERSEDED_CAP:
+            return Verdict(resource, True, COLLECT_SUPERSEDED)
+        return Verdict(resource, False, KEPT_WARM)
+
+    if workspace_done and resource.scope != "machine":
+        return Verdict(resource, True, COLLECT_DONE)
+
+    if resource.scope == "machine" and not pressure.under_pressure:
+        # Machine-shared caches age only under pressure.
+        return Verdict(resource, False, KEPT_MACHINE_SCOPE)
+
+    if age >= _ttl_for(resource):
+        return Verdict(resource, True, COLLECT_IDLE)
+
+    return Verdict(resource, False, KEPT_WARM)
+
+
+def plan(
+    registry: Registry,
+    *,
+    now: float | None = None,
+    done_workspaces: set[str] | None = None,
+    pressure: Pressure | None = None,
+    alive_probe=process_alive,
+) -> list[Verdict]:
+    """Evaluate every registered resource. Pure: the registry is not modified."""
+    now = registry.clock.now() if now is None else now
+    done_workspaces = done_workspaces or set()
+
+    verdicts: list[Verdict] = []
+    for resource in registry.list_resources():
+        verdicts.append(
+            evaluate(
+                registry,
+                resource,
+                now=now,
+                superseded=registry.generation_superseded_at(resource.generation) is not None,
+                workspace_done=resource.workspace in done_workspaces,
+                pressure=pressure,
+                alive_probe=alive_probe,
+            )
+        )
+    return verdicts
+
+
+def collectable(verdicts: list[Verdict]) -> list[Verdict]:
+    return [v for v in verdicts if v.collect]
+
+
+def kept(verdicts: list[Verdict]) -> list[Verdict]:
+    return [v for v in verdicts if not v.collect]

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -1,0 +1,195 @@
+"""Phase 6: GC safety properties. Fake engine, clock-injected, no Docker."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bosn import labels
+from bosn.clock import FakeClock
+from bosn.engine import EngineResult
+from bosn.gc import Collector, done_workspaces, mark_done, status
+from bosn.registry import Registry
+from bosn.retention import DAY
+
+OURS = "our-registry"
+
+
+class FakeEngine:
+    """Serves labels per resource name and records removals."""
+
+    def __init__(self, label_map: dict[str, dict[str, str]]):
+        self.label_map = label_map
+        self.commands: list[list[str]] = []
+        self.fail_on: set[str] = set()
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        self.commands.append(list(args))
+        if "inspect" in args:
+            return EngineResult(0, json.dumps(self.label_map.get(args[-1], {})), "")
+        if args[0] in {"rm", "volume", "image"} and "rm" in args:
+            name = args[-1]
+            if name in self.fail_on:
+                return EngineResult(1, "", "device or resource busy")
+            return EngineResult(0, "", "")
+        return EngineResult(0, "", "")
+
+    def removals(self) -> list[str]:
+        return [c[-1] for c in self.commands if "rm" in c]
+
+
+def label_dict(registry: str = OURS, **overrides: str) -> dict[str, str]:
+    base = labels.ResourceLabels(
+        registry=registry,
+        kind="volume",
+        stack="s",
+        generation="g",
+        scope="spec",
+        workspace="/w",
+        created="2026-08-13T00:00:00Z",
+    ).to_dict()
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def registry(tmp_path: Path, clock: FakeClock):
+    with Registry(tmp_path / "r.sqlite3", clock=clock) as reg:
+        yield reg
+
+
+def add(registry: Registry, name: str, scope="spec", workspace="/w"):
+    return registry.register_resource(
+        kind="volume", name=name, stack="s", generation="g", scope=scope, workspace=workspace
+    )
+
+
+# -- ownership proof is required at delete time ----------------------------
+
+
+def test_gc_reconfirms_ownership_from_the_engine_labels(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """The registry is a hint; the labels are the authority."""
+    add(registry, "ours")
+    add(registry, "not-really-ours")
+    engine = FakeEngine(
+        {
+            "ours": label_dict(registry=registry.registry_id),
+            "not-really-ours": label_dict(registry="someone-else"),
+        }
+    )
+    clock.advance(10 * DAY)
+
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.removed == ["ours"]
+    assert result.skipped_unproven == ["not-really-ours"]
+    assert "not-really-ours" not in engine.removals()
+
+
+def test_a_resource_with_incomplete_labels_is_never_removed(
+    registry: Registry, clock: FakeClock
+) -> None:
+    add(registry, "partial")
+    partial = label_dict(registry=registry.registry_id)
+    del partial[labels.STACK]
+    engine = FakeEngine({"partial": partial})
+    clock.advance(10 * DAY)
+
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+    assert result.removed == []
+    assert result.skipped_unproven == ["partial"]
+
+
+def test_gc_never_issues_a_system_prune(registry: Registry, clock: FakeClock) -> None:
+    add(registry, "ours")
+    engine = FakeEngine({"ours": label_dict(registry=registry.registry_id)})
+    clock.advance(10 * DAY)
+
+    Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    flat = [" ".join(cmd) for cmd in engine.commands]
+    assert not any("prune" in cmd for cmd in flat)
+    assert not any("system" in cmd for cmd in flat)
+
+
+def test_there_is_no_force_flag_on_gc() -> None:
+    """Automatic deletion requires ownership proof, so no flag may skip it."""
+    from bosn.cli import build_parser
+
+    help_text = build_parser().parse_args(["gc"]).__dict__
+    assert "force" not in help_text
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["gc", "--force"])
+
+
+# -- dry run ---------------------------------------------------------------
+
+
+def test_dry_run_removes_nothing(registry: Registry, clock: FakeClock) -> None:
+    add(registry, "ours")
+    engine = FakeEngine({"ours": label_dict(registry=registry.registry_id)})
+    clock.advance(10 * DAY)
+
+    result = Collector(registry, engine).collect(dry_run=True)  # type: ignore[arg-type]
+
+    assert result.removed == ["ours"], "dry run still reports what would go"
+    assert engine.removals() == []
+    assert len(registry.list_resources()) == 1
+
+
+# -- errors are observable -------------------------------------------------
+
+
+def test_removal_errors_are_recorded_not_discarded(registry: Registry, clock: FakeClock) -> None:
+    """A discarded error is how you come to believe storage is bounded when it is not."""
+    add(registry, "stubborn")
+    engine = FakeEngine({"stubborn": label_dict(registry=registry.registry_id)})
+    engine.fail_on.add("stubborn")
+    clock.advance(10 * DAY)
+
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.removed == []
+    assert len(result.errors) == 1
+    assert "busy" in result.errors[0]
+    assert any(row["kind"] == "gc.error" for row in registry.events())
+    assert len(registry.list_resources()) == 1, "a failed removal must not deregister"
+
+
+# -- done ------------------------------------------------------------------
+
+
+def test_done_marks_only_this_workspace(registry: Registry) -> None:
+    add(registry, "mine", workspace="/w1")
+    add(registry, "theirs", workspace="/w2")
+    add(registry, "shared", scope="machine", workspace="/w1")
+
+    assert mark_done(registry, "/w1") == 1
+    assert done_workspaces(registry) == {"/w1"}
+    states = {r.name: r.state for r in registry.list_resources()}
+    assert states["mine"] == "done"
+    assert states["theirs"] == "active"
+    assert states["shared"] == "active", "machine caches are never workspace-owned"
+
+
+# -- status ----------------------------------------------------------------
+
+
+def test_status_reports_counts_and_foreign_registries(registry: Registry) -> None:
+    add(registry, "ours")
+    engine = FakeEngine({"ours": label_dict(registry=registry.registry_id)})
+    report = status(registry, engine)  # type: ignore[arg-type]
+
+    assert report["registry_id"] == registry.registry_id
+    assert report["registered"] == 1
+    assert "by_reason" in report
+    assert isinstance(report["foreign_registries"], list)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,87 @@
+"""Options is the fully typed replacement for argparse's dynamic Namespace."""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from bosn.cli import build_parser
+from bosn.options import Options, from_namespace
+
+
+def opts(argv: list[str]) -> Options:
+    return from_namespace(build_parser().parse_args(argv))
+
+
+def test_defaults_are_concrete_for_every_field() -> None:
+    """No field is left undefined, whichever subparser ran."""
+    parsed = opts(["doctor"])
+    for f in fields(Options):
+        assert hasattr(parsed, f.name)
+
+
+def test_every_verb_produces_a_complete_options_object() -> None:
+    """A Namespace's attributes depend on the subparser; Options' never do."""
+    from bosn.cli import VERBS
+
+    for verb in VERBS:
+        parsed = opts([verb])
+        assert parsed.verb == verb
+        assert isinstance(parsed.engine, str)
+        assert parsed.dry_run in (True, False)
+
+
+def test_paths_are_paths_not_strings(tmp_path: Path) -> None:
+    parsed = opts(["--state-dir", str(tmp_path), "status"])
+    assert isinstance(parsed.state_dir, Path)
+
+
+def test_absent_paths_are_none_not_empty_strings() -> None:
+    parsed = opts(["status"])
+    assert parsed.state_dir is None
+    assert parsed.manifest is None
+
+
+def test_verb_local_state_dir_wins_over_the_global_one(tmp_path: Path) -> None:
+    global_dir = tmp_path / "global"
+    local_dir = tmp_path / "local"
+    parsed = from_namespace(
+        build_parser().parse_args(
+            ["--state-dir", str(global_dir), "__daemon", "--state-dir", str(local_dir)]
+        )
+    )
+    assert parsed.state_dir == local_dir
+
+
+def test_command_strips_the_argparse_separator() -> None:
+    parsed = opts(["run", "--", "echo", "hi"])
+    assert parsed.command == ["echo", "hi"]
+    assert "--" not in parsed.command
+
+
+def test_options_are_frozen() -> None:
+    parsed = opts(["run"])
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        parsed.verb = "gc"  # type: ignore[misc]
+
+
+def test_with_command_returns_a_new_object() -> None:
+    parsed = opts(["run"])
+    replaced = parsed.with_command(["sh"])
+    assert replaced.command == ["sh"]
+    assert parsed is not replaced
+
+
+def test_daemon_numeric_flags_are_typed() -> None:
+    parsed = opts(["__daemon", "--port", "5000", "--idle-retire-seconds", "2.5"])
+    assert parsed.port == 5000 and isinstance(parsed.port, int)
+    assert parsed.idle_retire_seconds == 2.5
+    assert isinstance(parsed.idle_retire_seconds, float)
+
+
+def test_gc_apply_flips_dry_run() -> None:
+    assert opts(["gc"]).dry_run is True
+    assert opts(["gc", "--apply"]).dry_run is False

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,201 @@
+"""Phase 6: tiered retention. Clock-injected, no sleeps, no Docker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bosn import retention
+from bosn.clock import FakeClock
+from bosn.registry import Registry
+from bosn.retention import (
+    COLLECT_DONE,
+    COLLECT_IDLE,
+    COLLECT_SUPERSEDED,
+    KEPT_LEASED,
+    KEPT_MACHINE_SCOPE,
+    KEPT_QUIET_PERIOD,
+    KEPT_WARM,
+    Pressure,
+    evaluate,
+)
+
+ALIVE = lambda pid, start=None: True  # noqa: E731
+DEAD = lambda pid, start=None: False  # noqa: E731
+
+HOUR = retention.HOUR
+DAY = retention.DAY
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def registry(tmp_path: Path, clock: FakeClock):
+    with Registry(tmp_path / "r.sqlite3", clock=clock) as reg:
+        yield reg
+
+
+def make(registry: Registry, kind="volume", scope="spec", workspace="/w", generation="g"):
+    return registry.register_resource(
+        kind=kind,
+        name=f"{kind}-1",
+        stack="s",
+        generation=generation,
+        scope=scope,
+        workspace=workspace,
+    )
+
+
+# -- leases outrank everything ---------------------------------------------
+
+
+def test_a_leased_resource_is_untouchable(registry: Registry, clock: FakeClock) -> None:
+    resource = make(registry)
+    registry.acquire_lease(resource.id, pid=1, proc_start=1.0, ttl_seconds=60)
+    clock.advance(10 * DAY)
+
+    verdict = evaluate(registry, resource, alive_probe=ALIVE)
+    assert not verdict.collect
+    assert verdict.reason == KEPT_LEASED
+
+
+def test_a_lease_outranks_an_explicit_done(registry: Registry, clock: FakeClock) -> None:
+    resource = make(registry)
+    registry.acquire_lease(resource.id, pid=1, proc_start=1.0, ttl_seconds=60)
+    clock.advance(10 * DAY)
+
+    verdict = evaluate(registry, resource, workspace_done=True, alive_probe=ALIVE)
+    assert not verdict.collect, "a live lease must beat every other signal"
+
+
+def test_a_dead_holders_lease_stops_protecting(registry: Registry, clock: FakeClock) -> None:
+    resource = make(registry)
+    registry.acquire_lease(resource.id, pid=1, proc_start=1.0, ttl_seconds=60)
+    clock.advance(10 * DAY)
+
+    verdict = evaluate(registry, resource, workspace_done=True, alive_probe=DEAD)
+    assert verdict.collect
+
+
+# -- container vs volume clocks --------------------------------------------
+
+
+def test_containers_idle_stop_at_one_hour(registry: Registry, clock: FakeClock) -> None:
+    resource = make(registry, kind="container")
+    assert not retention.container_should_stop(resource, clock.now())
+    clock.advance(HOUR + 1)
+    assert retention.container_should_stop(resource, clock.now())
+
+
+def test_containers_are_removed_at_one_day(registry: Registry, clock: FakeClock) -> None:
+    resource = make(registry, kind="container")
+    clock.advance(23 * HOUR)
+    assert not evaluate(registry, resource, alive_probe=DEAD).collect
+    clock.advance(2 * HOUR)
+    assert evaluate(registry, resource, alive_probe=DEAD).reason == COLLECT_IDLE
+
+
+def test_warm_volumes_survive_far_longer_than_containers(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """A cache volume is the asset; a container is disposable."""
+    volume = make(registry, kind="volume")
+    clock.advance(2 * DAY)
+    assert evaluate(registry, volume, alive_probe=DEAD).reason == KEPT_WARM
+
+    clock.advance(2 * DAY)  # now past 72 h
+    assert evaluate(registry, volume, alive_probe=DEAD).reason == COLLECT_IDLE
+
+
+# -- superseded generations ------------------------------------------------
+
+
+def test_superseded_generations_are_capped_at_one_day(registry: Registry, clock: FakeClock) -> None:
+    resource = make(registry)
+    clock.advance(23 * HOUR)
+    assert not evaluate(registry, resource, superseded=True, alive_probe=DEAD).collect
+
+    clock.advance(2 * HOUR)
+    verdict = evaluate(registry, resource, superseded=True, alive_probe=DEAD)
+    assert verdict.collect and verdict.reason == COLLECT_SUPERSEDED
+
+
+def test_a_superseded_generation_still_serving_a_lease_is_kept(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """The old generation keeps serving its live leases, then ages out."""
+    resource = make(registry)
+    registry.acquire_lease(resource.id, pid=1, proc_start=1.0, ttl_seconds=60)
+    clock.advance(10 * DAY)
+    assert not evaluate(registry, resource, superseded=True, alive_probe=ALIVE).collect
+
+
+# -- machine scope ---------------------------------------------------------
+
+
+def test_machine_scoped_caches_age_only_under_pressure(
+    registry: Registry, clock: FakeClock
+) -> None:
+    resource = make(registry, scope="machine")
+    clock.advance(100 * DAY)
+
+    assert evaluate(registry, resource, alive_probe=DEAD).reason == KEPT_MACHINE_SCOPE
+    under = evaluate(registry, resource, pressure=Pressure(under_pressure=True), alive_probe=DEAD)
+    assert under.collect
+
+
+def test_done_never_collects_machine_scoped_caches(registry: Registry, clock: FakeClock) -> None:
+    """One workspace finishing must not evict the machine-wide cargo registry."""
+    resource = make(registry, scope="machine")
+    clock.advance(DAY)
+    verdict = evaluate(registry, resource, workspace_done=True, alive_probe=DEAD)
+    assert not verdict.collect
+
+
+# -- done ------------------------------------------------------------------
+
+
+def test_done_makes_this_workspaces_caches_collectable(
+    registry: Registry, clock: FakeClock
+) -> None:
+    resource = make(registry, scope="spec")
+    verdict = evaluate(registry, resource, workspace_done=True, alive_probe=DEAD)
+    assert verdict.collect and verdict.reason == COLLECT_DONE
+
+
+# -- adoption quiet period -------------------------------------------------
+
+
+def test_adopted_resources_are_protected_for_the_quiet_period(
+    registry: Registry, clock: FakeClock
+) -> None:
+    resource = make(registry)
+    registry.set_resource_state(resource.id, "adopted")
+    refreshed = registry.get_resource(resource.id)
+    assert refreshed is not None
+
+    clock.advance(23 * HOUR)
+    assert evaluate(registry, refreshed, alive_probe=DEAD).reason == KEPT_QUIET_PERIOD
+
+    # Past the quiet period the resource is not collected on the spot -- it simply rejoins
+    # the normal tiers, and a warm volume still has its 72 h.
+    clock.advance(2 * HOUR)
+    assert evaluate(registry, refreshed, alive_probe=DEAD).reason == KEPT_WARM
+
+    clock.advance(3 * DAY)
+    assert evaluate(registry, refreshed, alive_probe=DEAD).collect
+
+
+# -- planning --------------------------------------------------------------
+
+
+def test_plan_is_pure(registry: Registry, clock: FakeClock) -> None:
+    make(registry, kind="volume")
+    clock.advance(10 * DAY)
+    before = len(registry.list_resources())
+    retention.plan(registry, alive_probe=DEAD)
+    assert len(registry.list_resources()) == before, "planning must not mutate the registry"

--- a/tests/test_scenario_docker.py
+++ b/tests/test_scenario_docker.py
@@ -1,0 +1,190 @@
+"""Phase 6 exit criteria: the full lifecycle against a real engine.
+
+run -> lease held -> done -> TTL elapse (clock injection, not sleeps) -> gc reclaims
+exactly the owned resources while foreign and unlabeled ones are provably untouched.
+
+Docker-marked: Linux CI only.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bosn import labels
+from bosn.clock import FakeClock
+from bosn.converge import Converger
+from bosn.engine import Engine
+from bosn.gc import Collector, done_workspaces, mark_done, status
+from bosn.manifest import load
+from bosn.registry import Registry
+from bosn.resources import ResourceScanner
+from bosn.retention import DAY
+
+pytestmark = pytest.mark.docker
+
+MANIFEST = """
+[stack.test]
+dockerfile = "Dockerfile"
+family = "scenario"
+default = true
+
+[stack.test.volumes]
+work  = { scope = "spec" }
+cache = { scope = "machine" }
+"""
+
+FOREIGN_REGISTRY = f"foreign-{uuid.uuid4()}"
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "Dockerfile").write_text(
+        f"FROM alpine:3.20\nRUN echo {uuid.uuid4().hex[:8]} > /m\n", encoding="utf-8"
+    )
+    (tmp_path / "bosn.toml").write_text(MANIFEST, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def bystanders(engine: Engine) -> Iterator[dict[str, str]]:
+    """A foreign-registry volume and a totally unlabeled one, created by 'someone else'."""
+    names = {
+        "foreign": f"bosn-foreign-{uuid.uuid4().hex[:8]}",
+        "unlabeled": f"unrelated-{uuid.uuid4().hex[:8]}",
+    }
+    foreign_labels = labels.ResourceLabels(
+        registry=FOREIGN_REGISTRY,
+        kind="volume",
+        stack="theirs",
+        generation="g",
+        scope="spec",
+        workspace="/their/w",
+        created="2026-08-13T00:00:00Z",
+    )
+    engine.run(["volume", "create", *foreign_labels.to_docker_args(), names["foreign"]], check=True)
+    engine.run(["volume", "create", names["unlabeled"]], check=True)
+    try:
+        yield names
+    finally:
+        for name in names.values():
+            engine.run(["volume", "rm", "--force", name])
+
+
+@pytest.fixture
+def registry(tmp_path: Path, clock: FakeClock) -> Iterator[Registry]:
+    with Registry(tmp_path / "state" / "r.sqlite3", clock=clock) as reg:
+        yield reg
+
+
+def _cleanup(registry: Registry, engine: Engine) -> None:
+    for resource in registry.list_resources():
+        if resource.kind == "volume":
+            engine.run(["volume", "rm", "--force", resource.name])
+        elif resource.kind == "image":
+            engine.run(["image", "rm", "--force", resource.name])
+
+
+def test_full_lifecycle_run_lease_done_ttl_gc(
+    project: Path,
+    registry: Registry,
+    engine: Engine,
+    clock: FakeClock,
+    bystanders: dict[str, str],
+) -> None:
+    converger = Converger(load(project), registry, engine)
+    try:
+        # -- run: converge, build, execute -----------------------------------
+        result, code, output = converger.run(["echo", "scenario-ok"])
+        assert code == 0, output
+        assert "scenario-ok" in output
+
+        spec_volumes = [r for r in registry.list_resources() if r.scope == "spec"]
+        machine_volumes = [r for r in registry.list_resources() if r.scope == "machine"]
+        assert spec_volumes and machine_volumes
+
+        # -- lease held: nothing is collectable, however old ------------------
+        target = next(r for r in spec_volumes if r.kind == "volume")
+        # This process is the lease holder, so the liveness probe genuinely succeeds.
+        lease = registry.acquire_lease(target.id, pid=os.getpid(), proc_start=1.0, ttl_seconds=900)
+        clock.advance(10 * DAY)
+
+        collector = Collector(registry, engine)
+        held = collector.collect(dry_run=True, done_workspaces=done_workspaces(registry))
+        assert target.name not in held.removed, "a live lease must protect its resource"
+
+        # -- release the lease, then mark the workspace done ------------------
+        registry.release_lease(lease.id)
+        assert mark_done(registry, str(load(project).root)) >= 1
+
+        planned = collector.collect(dry_run=True, done_workspaces=done_workspaces(registry))
+        assert target.name in planned.removed
+        assert all(m.name not in planned.removed for m in machine_volumes), (
+            "done must never collect machine-scoped caches"
+        )
+
+        # -- apply: exactly the owned resources go ----------------------------
+        applied = collector.collect(dry_run=False, done_workspaces=done_workspaces(registry))
+        assert target.name in applied.removed
+        assert applied.errors == []
+
+        # -- the bystanders are provably untouched ----------------------------
+        scan = ResourceScanner(engine).scan(registry.registry_id, kinds=["volume"])
+        surviving = {r.name for r in scan.foreign} | {r.name for r in scan.unlabeled}
+        assert bystanders["foreign"] in surviving
+        assert bystanders["unlabeled"] in surviving
+        assert FOREIGN_REGISTRY in scan.foreign_registries, "foreign registries stay reported"
+
+        # a removed resource is deregistered, not merely marked
+        assert target.name not in {r.name for r in registry.list_resources()}
+    finally:
+        _cleanup(registry, engine)
+
+
+def test_status_sees_the_engine_and_reports_foreign_registries(
+    project: Path, registry: Registry, engine: Engine, bystanders: dict[str, str]
+) -> None:
+    converger = Converger(load(project), registry, engine)
+    try:
+        converger.run(["true"])
+        report = status(registry, engine)
+
+        assert report["registered"] > 0
+        assert report["engine"]["foreign"] >= 1
+        assert FOREIGN_REGISTRY in report["foreign_registries"]
+    finally:
+        _cleanup(registry, engine)
+
+
+def test_a_lost_registry_rebuilds_from_labels(
+    project: Path, registry: Registry, engine: Engine, tmp_path: Path, clock: FakeClock
+) -> None:
+    """Losing the database is survivable: ownership lives in the labels."""
+    from bosn.resources import adopt
+
+    converger = Converger(load(project), registry, engine)
+    try:
+        converger.run(["true"])
+        original = {r.name for r in registry.list_resources() if r.kind == "volume"}
+        registry_id = registry.registry_id
+
+        # wipe every row, keeping the registry id -- the database is "lost"
+        for resource in registry.list_resources():
+            registry.remove_resource(resource.id)
+        assert registry.list_resources() == []
+
+        scan = ResourceScanner(engine).scan(registry_id, kinds=["volume"])
+        adopted = adopt(registry, scan, clock=clock)
+
+        assert original <= set(adopted), "every owned volume must be rediscovered from labels"
+    finally:
+        _cleanup(registry, engine)


### PR DESCRIPTION
Final phase of #3.

- `retention.py`: separate clocks per tier (container idle-stop 1 h / remove 24 h, warm volumes 72 h, superseded cap 24 h, machine caches only under pressure). A live lease outranks every signal including `done`; `done` never collects machine-scoped caches.
- `gc.py`: re-confirms ownership **from the engine's labels** before deleting — the registry is a hint, the labels are the authority. Tests assert no `system prune` is ever issued, that `--force` does not exist, that incomplete labels are never removed, and that removal errors are recorded rather than discarded.
- CLI: `status`, `gc --dry-run`/`--apply`, `done`, `shell`.
- **Typed options** (per your note on Namespace): argparse is confined to `build_parser` + `from_namespace`; everything downstream takes a frozen `Options` dataclass with real types and complete defaults, so pyright checks it. 10 tests cover it.
- **End-to-end scenario** (`test_scenario_docker.py`): run → lease held → done → TTL elapse via injected clock → gc reclaims exactly the owned resources, while a foreign-registry volume and an unlabeled volume are provably untouched and still reported. Plus a lost-registry rebuild from labels.

160 passed, 1 skipped locally. Lint clean (ruff, pyright, KBI).

README status updated from "implementation not started".

Closes #3