### PR TITLE
fix: detach the daemon without running-process's broker framework

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -20,14 +20,13 @@ import json
 import os
 import socket
 import socketserver
+import subprocess
 import sys
 import threading
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
-
-from running_process import daemon as rp_daemon
 
 from bosn import __version__, ipc
 from bosn.registry import Registry, default_state_dir
@@ -291,48 +290,57 @@ class Daemon:
 # -- client side -----------------------------------------------------------
 
 
-def spawn_daemon_available() -> bool:
-    """True when running-process can actually detach on this platform.
-
-    `spawn_daemon` needs a trampoline binary shipped in the wheel's assets directory.
-    running-process 4.10.1 publishes wheels without it on every platform, so the blessed
-    spawner is present in the API but not yet usable. Probing keeps the failure legible
-    instead of surfacing as a FileNotFoundError deep inside a spawn.
-    """
-    try:
-        # The *bundled* path inside the installed wheel -- not assets_dir(), which is the
-        # runtime hard-link cache and can hold a trampoline the spawner will not look at.
-        return rp_daemon.trampoline_source_path().exists()
-    except KeyboardInterrupt:
-        raise
-    except Exception:  # noqa: BLE001 - probe must never crash a caller
-        return False
-
-
 def _detach(state_dir: Path) -> int:
-    """Start a detached `bosn __daemon` via running-process's daemon spawner.
+    """Start a detached `bosn __daemon`.
 
-    `running_process.daemon.spawn_daemon` is the platform-blessed path: it detaches without
-    a console window on Windows, sets up its own runtime dir and log sidecar, and tracks the
-    pid. Hand-rolling this with subprocess flags pops a console on Windows, which is exactly
-    what a background supervisor must never do.
+    bosn deliberately does **not** use running-process's broker/daemon framework for this.
+    Both of its detachment entry points are clients of that framework rather than plain
+    process launches: `daemon.spawn_daemon` needs a bundled trampoline binary plus its own
+    runtime directory and sidecar JSON, and `launch_detached` dials a broker over
+    `\\\\.\\pipe\\running-process-daemon-<user>`. bosn owns exactly one daemon whose
+    singleton is already enforced by the port bind, so a second supervisor underneath it
+    buys nothing and adds a dependency that must be running before ours can start.
+
+    running-process remains our process API for *running* commands (see `engine.py`); this
+    is only about detaching our own daemon.
+
+    The Windows flag here is `CREATE_NO_WINDOW`, not `DETACHED_PROCESS`. `DETACHED_PROCESS`
+    means "do not inherit the parent's console", and Windows honors it by giving the child a
+    console of its own -- a terminal window pops up on the user's screen. `CREATE_NO_WINDOW`
+    gives it no console at all, which is what a background supervisor wants.
     """
-    if not spawn_daemon_available():
-        raise DaemonError(
-            "running-process cannot detach on this platform: its installed wheel ships no "
-            "bundled daemon-trampoline binary. Install a running-process build that "
-            "includes it, or start the daemon manually with `bosn __daemon`."
-        )
-    env = rp_daemon.build_daemon_env(dict(os.environ))
-    env["BOSN_STATE_DIR"] = str(state_dir)
-    argv = [sys.executable, "-m", "bosn", "__daemon", "--state-dir", str(state_dir)]
-    handle = rp_daemon.spawn_daemon(
-        argv,
-        name=f"{DAEMON_NAME}-{port_for(state_dir)}",
-        env=env,
-        log_path=str(state_dir / "daemon.log"),
-    )
-    return handle.pid
+    # The port is passed explicitly rather than recomputed by the child. port_for() is
+    # relative to default_state_dir(), which reads BOSN_STATE_DIR -- so a child with a
+    # different environment can derive a different port for the same directory and then
+    # bind somewhere the parent is not listening. Passing it makes the two agree by
+    # construction, and for the same reason the child's environment is left alone.
+    env = dict(os.environ)
+    argv = [
+        sys.executable,
+        "-m",
+        "bosn",
+        "__daemon",
+        "--state-dir",
+        str(state_dir),
+        "--port",
+        str(port_for(state_dir)),
+    ]
+
+    kwargs: dict[str, Any] = {
+        "env": env,
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if sys.platform.startswith("win"):
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        # setsid: the daemon leaves our session, so it survives the shell that started it
+        # and never receives the terminal's Ctrl-C.
+        kwargs["start_new_session"] = True
+
+    return subprocess.Popen(argv, **kwargs).pid
 
 
 def spawn(state_dir: Path | None = None, *, timeout: float = SPAWN_TIMEOUT_SECONDS) -> DaemonState:

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -334,7 +334,11 @@ def _detach(state_dir: Path) -> int:
         "close_fds": True,
     }
     if sys.platform.startswith("win"):
-        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
+        # getattr: these constants only exist on Windows, and a type checker running on
+        # Linux does not know them.
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
     else:
         # setsid: the daemon leaves our session, so it survives the shell that started it
         # and never receives the terminal's Ctrl-C.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import socket
+import sys
 import threading
 import time
 from collections.abc import Iterator
@@ -21,6 +22,26 @@ import pytest
 from bosn import daemon as daemon_mod
 from bosn import ipc
 from bosn.daemon import Daemon, DaemonError, DaemonState
+
+
+def _detach_code() -> str:
+    """`_detach`'s body with its docstring stripped, so prose cannot satisfy an assertion."""
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(daemon_mod._detach)))
+    func = tree.body[0]
+    assert isinstance(func, ast.FunctionDef)
+    body = func.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    return "\n".join(ast.unparse(node) for node in body)
 
 
 def _wait_until(predicate, timeout: float = 15.0, interval: float = 0.05) -> bool:
@@ -187,22 +208,29 @@ def test_stop_returns_false_when_nothing_is_running(tmp_path: Path) -> None:
     assert daemon_mod.stop(tmp_path) is False
 
 
-def test_spawn_reports_a_clear_error_when_detachment_is_unavailable(tmp_path: Path) -> None:
-    """The missing-trampoline case must name the cause, not raise FileNotFoundError."""
-    if daemon_mod.spawn_daemon_available():
-        pytest.skip("running-process can detach here; the failure path is not reachable")
-    with pytest.raises(DaemonError, match="cannot detach on this platform"):
-        daemon_mod.spawn(tmp_path, timeout=5)
+def test_detach_does_not_depend_on_the_running_process_broker() -> None:
+    """Detachment must not require a broker daemon or a bundled trampoline binary.
+
+    Both running-process detach entry points are broker clients: spawn_daemon needs a
+    trampoline binary in its wheel assets, and launch_detached dials a named-pipe broker.
+    bosn must be able to start its own daemon with neither present.
+    """
+    code = _detach_code()
+    assert "spawn_daemon" not in code
+    assert "launch_detached" not in code
+    assert "rp_daemon" not in code
+    assert "subprocess.Popen" in code
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows console flags")
+def test_windows_detach_uses_create_no_window_not_detached_process() -> None:
+    """DETACHED_PROCESS gives the child its own console -- a window pops up on screen."""
+    code = _detach_code()
+    assert "CREATE_NO_WINDOW" in code
+    assert "DETACHED_PROCESS" not in code
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    not daemon_mod.spawn_daemon_available(),
-    reason=(
-        "running-process 4.10.1 publishes no assets/daemon-trampoline in its wheels, so "
-        "spawn_daemon cannot detach yet. Re-enable once a build ships the trampoline."
-    ),
-)
 def test_real_detached_spawn_and_autostart(tmp_path: Path) -> None:
     """End-to-end: the CLI lazily spawns a real detached daemon and talks to it."""
     state = daemon_mod.spawn(tmp_path, timeout=60)


### PR DESCRIPTION
Follow-up to #3.

**The framework was leaking in.** Both running-process detach entry points turn out to be clients of its broker/daemon framework, not plain launches:

- `daemon.spawn_daemon` needs a bundled `daemon-trampoline` binary plus its own runtime dir and sidecar JSON.
- `launch_detached` looks like a plain launcher, but the native extension dials a broker over `\.\pipe\running-process-daemon-<user>`, which is where the `daemon I/O error: The system cannot find the file specified` came from.

bosn owns exactly one daemon and its singleton is already enforced by the port bind, so a second supervisor underneath it buys nothing and adds a dependency that must be up before ours can start. running-process remains the process API for *running* commands (`engine.py`); this is only about detaching our own daemon.

**The console window** was my flag choice, not an inherent problem with launching it ourselves: `DETACHED_PROCESS` means "do not inherit the parent's console", and Windows honors it by giving the child a console of its own. `CREATE_NO_WINDOW` gives it none. Verified locally: no window, child survives the parent.

**Bug found while fixing this:** `_detach` injected `BOSN_STATE_DIR` into the child, which changed what `default_state_dir()` returned there, so the child derived a *different* port than the parent was polling and the spawn silently timed out. The port is now passed explicitly so the two agree by construction.

**Tests:** the end-to-end detached spawn no longer skips — it runs everywhere. Two new guard tests assert `_detach` never reaches for `spawn_daemon`/`launch_detached`/`rp_daemon`, and that Windows uses `CREATE_NO_WINDOW` and never `DETACHED_PROCESS`. Both parse the function body with `ast` and strip the docstring, so prose cannot satisfy the assertion.

162 passed, 0 skipped. Lint clean.