### PR TITLE
feat: daemon-owned build jobs with a bounded coalescing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ Other guarantees:
   build that failed.
 - **A hung build cannot pin the daemon.** Running jobs block idle retirement, so a per-job
   TTL (default 1 h, `BOSN_BUILD_TTL_SECONDS`) reaps anything that stops reporting.
+- **Job history is bounded too.** The 50 most recent finished jobs stay listable and
+  attachable; older ids are forgotten and report `no such job`. Remembering every job of
+  an all-day agent loop, each with its build output, is the same kind of unbounded growth
+  the queue policy exists to prevent.
 
 There is deliberately no `--detach`. Blocking-with-attach is the only mode, because
 backgrounding is the easiest way to recreate the pile-up above and fan-out is already

--- a/README.md
+++ b/README.md
@@ -117,10 +117,69 @@ Everything else is lifecycle and introspection:
 bosn tasks --json            # discovery: tasks, stacks, digests, registration state
 bosn status                  # tiers, leases, managed bytes vs ceiling, foreign registries
 bosn jobs / bosn attach <j>  # daemon-owned builds that survive a killed CLI
+bosn cancel <j>              # stop a build you no longer want
 bosn done                    # this workspace is finished; its caches become collectable
 bosn gc --dry-run            # what would be reclaimed right now
 bosn doctor                  # engine health, backing-volume free space, VHDX slack
 ```
+
+## Build jobs and the concurrency policy
+
+Cold builds belong to the daemon, not to the CLI that asked for one. `bosn run` submits a
+converge, attaches, streams the build to stderr, and exits with the job's status — but if
+that CLI is killed, the build keeps going. Re-run the same command and you reattach to it;
+`bosn jobs` lists what is in flight and `bosn attach <id>` reconnects explicitly. This is
+the whole point: a 20-minute build must not die because an agent's timeout fired.
+
+Which creates the problem the policy exists to solve. The daemon now owns work that
+outlives its requester, and bosn's primary consumer is an agent in an edit-and-rerun loop.
+Each edit is a new digest against the same stack, so those requests neither join (not
+identical) nor parallelize (same key). Left to serialize, they queue without bound — every
+entry but the last obsolete on arrival, each pinning volumes against GC, and running jobs
+block idle retirement, so the loop keeps the daemon resident and its resources
+uncollectable at the same time.
+
+**The rule: per `(workspace-id, stack)`, at most one running build and one pending
+request.**
+
+| Request arrives while... | What happens |
+| --- | --- |
+| nothing is in flight | it builds |
+| the same digest is building | it **joins** — one build, many watchers |
+| a different digest is building | it takes the **pending slot** |
+| the pending slot holds the same digest | it joins that |
+| the pending slot holds a different digest | it replaces the occupant, which ends as **superseded** |
+
+The bound is structural rather than tuned, and the worst case is waiting out one obsolete
+build — which warms BuildKit's layer cache for the one that follows. The alternative of
+cancelling in-flight builds so the newest always wins is more responsive but can livelock:
+under a fast edit loop every build is killed before finishing and the agent never gets
+output. Rejecting the second request instead ("a build is already running") turns a queue
+problem into a retry loop, which this project treats as a bug, not an error message.
+
+The consequence worth knowing: superseding only ever drops a build that has **not
+started**, so cancellation never happens behind your back. Stopping a running build is
+always deliberate — `bosn cancel`, daemon shutdown, or the per-job TTL.
+
+Other guarantees:
+
+- **Distinct keys build in parallel.** Two worktrees never block each other. `workspace-id`
+  is the resolved manifest root, never the cwd, so two agents in different subdirectories
+  of one worktree correctly share a key.
+- **Total concurrency is capped** at `max(2, cpus/2)` builds machine-wide (`BOSN_MAX_BUILDS`).
+  Per-key serialization alone does not bound host load; N worktrees still can.
+- **A cancelled build leaves nothing behind.** Registration happens only after `docker
+  build` exits 0, so a killed build cannot leave a generation row implying a usable image —
+  and cannot mark the previous, working generation superseded.
+- **Nothing fails silently.** A superseded, dropped, or cancelled request exits non-zero
+  with a message naming what happened: `4` for superseded, `5` for cancelled, `1` for a
+  build that failed.
+- **A hung build cannot pin the daemon.** Running jobs block idle retirement, so a per-job
+  TTL (default 1 h, `BOSN_BUILD_TTL_SECONDS`) reaps anything that stops reporting.
+
+There is deliberately no `--detach`. Blocking-with-attach is the only mode, because
+backgrounding is the easiest way to recreate the pile-up above and fan-out is already
+available by running from multiple worktrees.
 
 ## Existing Docker and Compose workloads
 

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -26,7 +26,8 @@ VERBS: dict[str, tuple[str, str]] = {
     "shell": ("interactive session in the persistent container", "implemented"),
     "tasks": ("list manifest tasks, stacks, digests, registration state", "implemented"),
     "jobs": ("list daemon-owned jobs", "implemented"),
-    "attach": ("attach to a daemon-owned job", "phase 6"),
+    "attach": ("attach to a daemon-owned job", "implemented"),
+    "cancel": ("cancel a daemon-owned job", "implemented"),
     "status": ("tiers, leases, managed bytes vs ceiling, foreign registries", "implemented"),
     "gc": ("report or reclaim collectable resources", "implemented"),
     "done": ("mark this workspace finished; its caches become collectable", "implemented"),
@@ -87,6 +88,8 @@ def build_parser() -> argparse.ArgumentParser:
     daemon_parser = subparsers.add_parser(DAEMON_VERB, help=argparse.SUPPRESS)
     daemon_parser.add_argument("--port", type=int, default=None)
     daemon_parser.add_argument("--idle-retire-seconds", type=float, default=None)
+    daemon_parser.add_argument("--max-builds", type=int, default=None)
+    daemon_parser.add_argument("--build-ttl-seconds", type=float, default=None)
     daemon_parser.add_argument("--stop", action="store_true", help="stop a running daemon")
     # Accepted after the verb as well, so a spawned argv need not order its flags.
     daemon_parser.add_argument("--state-dir", default=None, dest="daemon_state_dir")
@@ -121,7 +124,14 @@ def cmd_daemon(opts: Options) -> int:
         else daemon_mod.DEFAULT_IDLE_RETIRE_SECONDS
     )
     try:
-        daemon = daemon_mod.Daemon(state_dir=state_dir, port=opts.port, idle_retire_seconds=idle)
+        daemon = daemon_mod.Daemon(
+            state_dir=state_dir,
+            port=opts.port,
+            idle_retire_seconds=idle,
+            max_builds=opts.max_builds,
+            build_ttl_seconds=opts.build_ttl_seconds,
+            engine_binary=opts.engine,
+        )
         return daemon.serve_forever()
     except daemon_mod.DaemonError as exc:
         print(str(exc), file=sys.stderr)
@@ -190,8 +200,98 @@ def cmd_tasks(opts: Options) -> int:
     return 0
 
 
+class JobFailed(RuntimeError):
+    """A daemon-owned job ended without producing a usable generation."""
+
+    def __init__(self, message: str, exit_code: int) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def _drive_job(events, *, quiet: bool = False) -> dict:
+    """Render a job's event stream to stderr and return its terminal event.
+
+    Build output goes to stderr, never stdout: `bosn run`'s stdout belongs to the command
+    the user asked to run, and an agent parsing that output must not find build noise in it.
+    """
+    final: dict = {}
+    for event in events:
+        kind = event.get("event")
+        if kind == "log":
+            if not quiet:
+                print(event.get("line", ""), file=sys.stderr)
+        elif kind == "submitted" and not quiet:
+            note = _submission_note(event)
+            if note:
+                print(note, file=sys.stderr)
+        elif kind == "attached" and not quiet:
+            print(f"attached to {event.get('job')} ({event.get('state')})", file=sys.stderr)
+        if event.get("final"):
+            final = event
+    if not final:
+        raise JobFailed("the daemon ended the stream without a result", 1)
+    return final
+
+
+def _submission_note(event: dict) -> str | None:
+    disposition = event.get("disposition")
+    job = event.get("job")
+    if event.get("joined"):
+        return f"joined in-flight build {job} for the same generation"
+    if disposition == "pending":
+        return (
+            f"queued as {job}: a build for an older generation of this stack is still "
+            "running; it will start as soon as that one finishes"
+        )
+    if disposition == "queued":
+        return None
+    return None
+
+
+# Distinct codes so a caller can tell "your build broke" from "your request was dropped".
+BUILD_FAILED_EXIT = 1
+SUPERSEDED_EXIT = 4
+CANCELLED_EXIT = 5
+
+
+def _result_or_raise(final: dict):
+    """Turn a terminal job event into a ConvergeResult, or a specific, non-silent failure."""
+    from bosn.converge import ConvergeResult
+
+    state = final.get("state")
+    if state == "succeeded":
+        return ConvergeResult.from_dict(final.get("result") or {})
+    reason = final.get("error") or state or "unknown failure"
+    if state == "superseded":
+        raise JobFailed(f"converge did not run: {reason}", SUPERSEDED_EXIT)
+    if state == "cancelled":
+        raise JobFailed(f"build cancelled: {reason}", CANCELLED_EXIT)
+    raise JobFailed(f"build failed: {reason}", BUILD_FAILED_EXIT)
+
+
+def _converge_via_daemon(opts: Options, manifest, stack_name: str | None):
+    """Ask the daemon to converge, watching its build. The job outlives this process.
+
+    Converge runs in the daemon rather than here so that killing this CLI cannot destroy a
+    20-minute build, and so the registry keeps exactly one writer.
+    """
+    from bosn import daemon as daemon_mod
+    from bosn.converge import workspace_of
+
+    events = daemon_mod.stream(
+        "converge",
+        opts.state_dir,
+        manifest=str(manifest.path),
+        stack=stack_name,
+        workspace=workspace_of(manifest),
+        engine=opts.engine,
+    )
+    return _result_or_raise(_drive_job(events))
+
+
 def cmd_run(opts: Options) -> int:
-    from bosn.converge import Converger
+    from bosn import daemon as daemon_mod
+    from bosn.converge import Converger, workspace_of
     from bosn.engine import EngineError
     from bosn.manifest import ManifestError
 
@@ -208,14 +308,23 @@ def cmd_run(opts: Options) -> int:
 
     try:
         if opts.task:
-            from bosn.converge import run_task
-
-            _result, code, output = run_task(
-                manifest, registry, opts.task, engine=Engine(opts.engine)
-            )
+            task = manifest.task(opts.task)
+            command = ["sh", "-c", task.cmd]
+            stack_name = task.stack or None
         else:
-            converger = Converger(manifest, registry, Engine(opts.engine))
-            _result, code, output = converger.run(command, stack_name=opts.stack)
+            stack_name = opts.stack
+
+        converged = _converge_via_daemon(opts, manifest, stack_name)
+        converger = Converger(manifest, registry, Engine(opts.engine))
+        _result, code, output = converger.run_converged(
+            converged, command, stack_name=stack_name, workspace=workspace_of(manifest)
+        )
+    except JobFailed as exc:
+        print(str(exc), file=sys.stderr)
+        return exc.exit_code
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:  # fail closed, stay visible
+        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        return 1
     except (ManifestError, EngineError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -225,6 +334,50 @@ def cmd_run(opts: Options) -> int:
     if output:
         print(output)
     return code
+
+
+def cmd_attach(opts: Options) -> int:
+    from bosn import daemon as daemon_mod
+
+    job_id = next(iter(opts.command), "")
+    if not job_id:
+        print("attach needs a job id; see `bosn jobs`", file=sys.stderr)
+        return 2
+    try:
+        final = _drive_job(daemon_mod.stream("attach", opts.state_dir, job=job_id))
+    except JobFailed as exc:
+        print(str(exc), file=sys.stderr)
+        return exc.exit_code
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        return 1
+    state = final.get("state")
+    if state != "succeeded":
+        print(
+            f"job {job_id} ended as {state}: {final.get('error') or ''}".rstrip(), file=sys.stderr
+        )
+        return CANCELLED_EXIT if state == "cancelled" else BUILD_FAILED_EXIT
+    print(f"job {job_id} succeeded", file=sys.stderr)
+    return 0
+
+
+def cmd_cancel(opts: Options) -> int:
+    from bosn import daemon as daemon_mod
+
+    job_id = next(iter(opts.command), "")
+    if not job_id:
+        print("cancel needs a job id; see `bosn jobs`", file=sys.stderr)
+        return 2
+    try:
+        reply = daemon_mod.request("cancel", opts.state_dir, autostart=False, job=job_id)
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        return 1
+    if not reply.get("ok"):
+        print(str(reply.get("error") or "cancel failed"), file=sys.stderr)
+        return 1
+    print(f"cancelled {job_id}")
+    return 0
 
 
 def cmd_status(opts: Options) -> int:
@@ -257,6 +410,7 @@ def cmd_gc(opts: Options) -> int:
 
 
 def cmd_done(opts: Options) -> int:
+    from bosn.converge import workspace_of
     from bosn.gc import mark_done
     from bosn.manifest import ManifestError
 
@@ -266,7 +420,9 @@ def cmd_done(opts: Options) -> int:
         print(str(exc), file=sys.stderr)
         return 1
     try:
-        marked = mark_done(registry, str(manifest.root))
+        # The canonical workspace id, matching what converge registered resources under.
+        # A raw manifest.root would miss them whenever the two spellings differ.
+        marked = mark_done(registry, workspace_of(manifest))
     finally:
         registry.close()
     print(f"marked {marked} resource(s) in {manifest.root} as done")
@@ -292,6 +448,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         DAEMON_VERB: cmd_daemon,
         "doctor": lambda o: cmd_doctor(o.engine),
         "jobs": cmd_jobs,
+        "attach": cmd_attach,
+        "cancel": cmd_cancel,
         "tasks": cmd_tasks,
         "run": cmd_run,
         "shell": cmd_shell,

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -344,19 +344,19 @@ def cmd_attach(opts: Options) -> int:
         print("attach needs a job id; see `bosn jobs`", file=sys.stderr)
         return 2
     try:
-        final = _drive_job(daemon_mod.stream("attach", opts.state_dir, job=job_id))
+        # autostart=False: attaching asks about a job that already exists, and a daemon we
+        # just started cannot have one. Spawning here would spend 30s to answer "no such
+        # job" instead of the truth, which is that nothing is running.
+        final = _drive_job(daemon_mod.stream("attach", opts.state_dir, autostart=False, job=job_id))
+        # Same terminal-event handling as `run`, so a superseded job exits 4 here too
+        # rather than being flattened into a generic failure.
+        _result_or_raise(final)
     except JobFailed as exc:
         print(str(exc), file=sys.stderr)
         return exc.exit_code
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
         return 1
-    state = final.get("state")
-    if state != "succeeded":
-        print(
-            f"job {job_id} ended as {state}: {final.get('error') or ''}".rstrip(), file=sys.stderr
-        )
-        return CANCELLED_EXIT if state == "cancelled" else BUILD_FAILED_EXIT
     print(f"job {job_id} succeeded", file=sys.stderr)
     return 0
 

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -20,6 +20,10 @@ DAEMON_VERB = "__daemon"
 
 NOT_IMPLEMENTED_EXIT = 3
 
+# Long enough to cover a daemon draining a cancelled build (see SHUTDOWN_DRAIN_SECONDS),
+# short enough not to look hung.
+DAEMON_STOP_TIMEOUT = 45.0
+
 # verb -> (help text, phase that lands it)
 VERBS: dict[str, tuple[str, str]] = {
     "run": ("run an ad-hoc command in a stack", "implemented"),
@@ -114,8 +118,23 @@ def cmd_daemon(opts: Options) -> int:
     state_dir = opts.state_dir
 
     if opts.stop:
-        stopped = daemon_mod.stop(state_dir)
-        print("daemon stopped" if stopped else "no daemon was running")
+        # Three outcomes, not two. Stopping now drains in-flight builds before it closes
+        # the registry, so a daemon with a build to cancel can outlast the wait -- and
+        # reporting that as "no daemon was running" would be a plainly wrong answer to the
+        # question the user asked.
+        was_running = daemon_mod.is_serving(state_dir)
+        stopped = daemon_mod.stop(state_dir, timeout=DAEMON_STOP_TIMEOUT)
+        if stopped:
+            print("daemon stopped")
+        elif was_running:
+            print(
+                "daemon is still shutting down; it is waiting for an in-flight build to "
+                "stop cleanly. Run `bosn jobs` to see what it is finishing.",
+                file=sys.stderr,
+            )
+            return 1
+        else:
+            print("no daemon was running")
         return 0
 
     idle = (

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -140,8 +140,18 @@ class Converger:
         # doing it before the build means one cancelled build marks the *previous, working*
         # image for early collection in favor of an image that never got built. Nothing
         # about this generation is written until `docker build` has exited 0.
+        self._abort_if_cancelled()
         image_tag = image_tag_for(stack, digest)
         self._ensure_image(stack, digest, image_tag, workspace)
+
+        # The last point at which stopping is free. Past here the registry gets written and
+        # volumes get created, and `docker build` is no longer the only slow step -- so
+        # without this checkpoint a cancel arriving during a *warm* converge (image already
+        # present, nothing to build, nothing that consults the cancel flag) would be
+        # reported as "cancelled" only after this generation had already superseded its
+        # predecessor. Telling a user nothing happened while their previous generation went
+        # on retention's 24-hour clock is worse than either outcome on its own.
+        self._abort_if_cancelled()
 
         self.registry.record_generation(digest, stack.name)
         volumes = self._ensure_volumes(stack, digest, workspace)
@@ -164,11 +174,15 @@ class Converger:
             superseded=superseded,
         )
 
+    def _abort_if_cancelled(self) -> None:
+        if self.cancelled is not None and self.cancelled.is_set():
+            raise EngineError("converge was cancelled")
+
     def _generation_recorded(self, digest: str) -> bool:
-        row = self.registry.conn.execute(
-            "SELECT 1 FROM generations WHERE digest = ?", (digest,)
-        ).fetchone()
-        return row is not None
+        # Through the registry's own accessor, not `registry.conn` directly: that accessor
+        # holds the lock keeping this one sqlite connection single-writer, and converge now
+        # runs on up to `max_builds` daemon threads at once rather than alone in the CLI.
+        return self.registry.generation_recorded(digest)
 
     def _resource_labels(
         self, stack: StackSpec, kind: str, digest: str, scope: str, workspace: str

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -9,6 +9,9 @@ whose remedy is always the same mechanical command is just a forced retry loop.
 from __future__ import annotations
 
 import datetime as dt
+import os
+import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,6 +34,31 @@ class ConvergeResult:
     image_tag: str
     volumes: tuple[str, ...] = ()
     superseded: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        """Converge runs in the daemon and its result is used by the CLI, so it travels."""
+        return {
+            "stack": self.stack,
+            "digest": self.digest,
+            "action": self.action,
+            "image_tag": self.image_tag,
+            "volumes": list(self.volumes),
+            "superseded": self.superseded,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, object]) -> ConvergeResult:
+        volumes = raw.get("volumes") or []
+        if not isinstance(volumes, (list, tuple)):
+            volumes = []
+        return cls(
+            stack=str(raw.get("stack", "")),
+            digest=str(raw.get("digest", "")),
+            action=str(raw.get("action", "")),
+            image_tag=str(raw.get("image_tag", "")),
+            volumes=tuple(str(v) for v in volumes),
+            superseded=int(raw.get("superseded", 0) or 0),  # type: ignore[arg-type]
+        )
 
 
 def _now_iso() -> str:
@@ -81,27 +109,43 @@ class Converger:
         manifest: Manifest,
         registry: Registry,
         engine: Engine | None = None,
+        *,
+        progress: Callable[[str], None] | None = None,
+        cancelled: threading.Event | None = None,
     ) -> None:
         self.manifest = manifest
         self.registry = registry
         self.engine = engine or Engine()
+        # Set when a daemon job owns this converge: output goes to whoever is attached, and
+        # the build stops when the job is cancelled.
+        self.progress = progress
+        self.cancelled = cancelled
 
     def converge(
         self, stack_name: str | None = None, *, workspace: str | None = None
     ) -> ConvergeResult:
         stack = self.manifest.stack(stack_name)
         digest = generation_digest(self.manifest, stack)
-        workspace = workspace or str(self.manifest.root)
+        workspace = workspace or workspace_of(self.manifest)
 
         known = self.registry.generation_superseded_at(digest)
         is_new_generation = known is None and not self._generation_recorded(digest)
 
-        self.registry.record_generation(digest, stack.name)
-        superseded = self.registry.supersede_generations(stack.name, keep_digest=digest)
-
+        # Build first, register second. The ordering is load-bearing, not stylistic: a
+        # build can now be cancelled (by `bosn cancel`, daemon shutdown, or the job TTL),
+        # and a cancelled build must leave nothing behind that implies a usable image.
+        #
+        # Superseding is the sharp edge. Recording this generation retires every sibling,
+        # and retention puts superseded generations on a 24-hour collection clock -- so
+        # doing it before the build means one cancelled build marks the *previous, working*
+        # image for early collection in favor of an image that never got built. Nothing
+        # about this generation is written until `docker build` has exited 0.
         image_tag = image_tag_for(stack, digest)
         self._ensure_image(stack, digest, image_tag, workspace)
+
+        self.registry.record_generation(digest, stack.name)
         volumes = self._ensure_volumes(stack, digest, workspace)
+        superseded = self.registry.supersede_generations(stack.name, keep_digest=digest)
 
         if superseded:
             action = ROLLED
@@ -149,7 +193,7 @@ class Converger:
         label_args = self._resource_labels(
             stack, "image", digest, "spec", workspace
         ).to_docker_args()
-        result = self.engine.run(
+        result = self.engine.stream(
             [
                 "build",
                 "--file",
@@ -158,10 +202,17 @@ class Converger:
                 tag,
                 *label_args,
                 str(self.manifest.root),
-            ]
+            ],
+            on_line=self.progress,
+            cancelled=self.cancelled,
         )
         if not result.ok:
+            if self.cancelled is not None and self.cancelled.is_set():
+                raise EngineError(f"building {tag} was cancelled")
             raise EngineError(f"building {tag} failed: {result.stderr or result.stdout}")
+        # Registration happens only after the build exits 0, which is what makes a
+        # cancelled or failed build safe: it can never leave a generation row implying a
+        # usable image exists. Do not hoist this above the build.
         self._register(stack, "image", tag, digest, "spec", workspace)
 
     def _ensure_volumes(self, stack: StackSpec, digest: str, workspace: str) -> list[str]:
@@ -209,7 +260,26 @@ class Converger:
         workspace: str | None = None,
     ) -> tuple[ConvergeResult, int, str]:
         """Converge silently, then run the command in the stack. Returns (result, rc, output)."""
+        workspace = workspace or workspace_of(self.manifest)
         converged = self.converge(stack_name, workspace=workspace)
+        return self.run_converged(converged, command, stack_name=stack_name, workspace=workspace)
+
+    def run_converged(
+        self,
+        converged: ConvergeResult,
+        command: list[str],
+        *,
+        stack_name: str | None = None,
+        workspace: str | None = None,
+    ) -> tuple[ConvergeResult, int, str]:
+        """Run a command against an already-converged generation.
+
+        Split out from `run` because the two halves live in different processes once builds
+        are daemon-owned: the daemon converges (it is the registry's writer and the owner
+        of the long build), and the CLI runs the container itself, so the command keeps the
+        caller's terminal and exit status.
+        """
+        workspace = workspace or workspace_of(self.manifest)
         stack = self.manifest.stack(stack_name)
 
         args = ["run", "--rm"]
@@ -219,7 +289,7 @@ class Converger:
                 volume.scope,
                 volume.name,
                 digest=converged.digest,
-                workspace=workspace or str(self.manifest.root),
+                workspace=workspace,
                 family=stack.family,
             )
             args += ["--volume", f"{name}:/bosn/{volume.name}"]
@@ -244,4 +314,17 @@ def run_task(
 
 
 def workspace_of(manifest: Manifest) -> str:
-    return str(Path(manifest.root).resolve())
+    """The canonical workspace identity: the resolved manifest root, never the cwd.
+
+    Everything that must serialize or run in parallel keys off this string -- the job
+    table's `(workspace-id, stack)` key, stack-scoped volume names, and `bosn done`. Two
+    agents in different subdirectories of one worktree find the same `bosn.toml`, so they
+    get the same id and correctly serialize; two worktrees get different ids and correctly
+    build in parallel.
+
+    It has to be canonical, not merely convenient. `resolve()` collapses symlinks and `..`
+    so the same worktree reached by two paths is one workspace, and normcase folds Windows
+    drive-letter and case differences that would otherwise split it in two. Keying on the
+    cwd instead is the per-worktree path-hashing that produced the volume explosion in #1.
+    """
+    return os.path.normcase(str(Path(manifest.root).resolve()))

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -410,12 +410,12 @@ class Daemon:
             "stack": stack.name,
             "superseded": submission.superseded.id if submission.superseded else None,
         }
-        yield from self.jobs.follow(job, stop=self._stop)
+        yield from self.jobs.follow(job)
 
     def _verb_attach(self, request: dict[str, Any]) -> Iterator[dict[str, Any]]:
         job = self.jobs.get(str(request.get("job") or ""))
         yield {"event": "attached", "job": job.id, "state": job.state}
-        yield from self.jobs.follow(job, stop=self._stop)
+        yield from self.jobs.follow(job)
 
     # -- the builder -------------------------------------------------------
 

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -24,11 +24,13 @@ import subprocess
 import sys
 import threading
 import time
+from collections.abc import Generator, Iterator
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
 from bosn import __version__, ipc
+from bosn.jobs import BuildOutcome, Job, JobError, JobManager
 from bosn.registry import Registry, default_state_dir
 
 DAEMON_NAME = "bosn-daemon"
@@ -39,6 +41,9 @@ PORT_RANGE_SIZE = 1024
 
 DEFAULT_IDLE_RETIRE_SECONDS = 900.0
 SPAWN_TIMEOUT_SECONDS = 30.0
+
+# Verbs that hold the connection open and write many messages instead of one.
+STREAMING_VERBS = frozenset({"converge", "attach"})
 
 
 class DaemonError(RuntimeError):
@@ -128,6 +133,9 @@ class _Handler(socketserver.StreamRequestHandler):
         daemon_ref.note_activity()
         verb = str(request.get("verb", ""))
         try:
+            if verb in STREAMING_VERBS:
+                self._stream(daemon_ref, verb, request)
+                return
             response = daemon_ref.dispatch(verb, request)
         except KeyboardInterrupt:
             # Ctrl-C on the daemon means shut down, not "this one request failed".
@@ -136,6 +144,36 @@ class _Handler(socketserver.StreamRequestHandler):
         except Exception as exc:  # noqa: BLE001 - every failure is observable, none fatal
             response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
         ipc.send_response(self.connection, response)
+
+    def _stream(self, daemon_ref: Daemon, verb: str, request: dict[str, Any]) -> None:
+        """Hold the connection open and write events until the job reaches a terminal one.
+
+        A client that hangs up here is abandoning its *view* of the job, never the job --
+        which is the entire point of moving builds into the daemon. So a write failure ends
+        this loop and nothing else.
+        """
+
+        def emit(event: dict[str, Any]) -> bool:
+            try:
+                ipc.send_response(self.connection, event)
+            except OSError:
+                return False  # the client went away; the job carries on without it
+            return True
+
+        # The whole iteration is guarded, not just the call that builds it: a streaming
+        # verb is a generator, so nothing in its body runs until the first `next`. Catching
+        # only around the call would let a bad manifest or an unknown job id hang the
+        # connection up with no message at all -- a silent failure, which is the one thing
+        # this protocol may never do.
+        try:
+            for event in daemon_ref.dispatch_stream(verb, request):
+                if not emit(event):
+                    return
+        except KeyboardInterrupt:
+            daemon_ref.request_stop()
+            raise
+        except Exception as exc:  # noqa: BLE001 - a failed stream still owes the client a reason
+            emit({"ok": False, "final": True, "error": f"{type(exc).__name__}: {exc}"})
 
 
 class _Server(socketserver.ThreadingTCPServer):
@@ -169,7 +207,11 @@ class Daemon:
         state_dir: Path | None = None,
         port: int | None = None,
         idle_retire_seconds: float = DEFAULT_IDLE_RETIRE_SECONDS,
+        max_builds: int | None = None,
+        build_ttl_seconds: float | None = None,
+        engine_binary: str = "docker",
     ) -> None:
+        self.engine_binary = engine_binary
         self.state_dir = state_dir or default_state_dir()
         self.bind_port = port_for(self.state_dir) if port is None else port
         self.idle_retire_seconds = idle_retire_seconds
@@ -179,6 +221,14 @@ class Daemon:
         self._server: _Server | None = None
         self._stop = threading.Event()
         self.registry = Registry(self.state_dir / "registry.sqlite3")
+        self.jobs = JobManager(
+            self._build,
+            max_builds=max_builds,
+            ttl_seconds=build_ttl_seconds,
+            # A finished job is activity: without this the daemon could retire the instant
+            # a 20-minute build lands, before the client that was waiting for it comes back.
+            on_settled=self.note_activity,
+        )
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -196,6 +246,16 @@ class Daemon:
         return time.time() - self.last_activity
 
     def should_retire(self) -> bool:
+        """Idle *and* holding no work. Retiring mid-build would destroy it.
+
+        Request idleness alone is not enough now that the daemon owns builds: a client that
+        submits a 20-minute build and hangs up leaves no request traffic at all, and the
+        old rule would have retired the daemon out from under its own job. The job TTL is
+        what keeps this from becoming a way to pin the daemon forever -- a build that never
+        reports is eventually cancelled, and then this goes back to being about idleness.
+        """
+        if self.jobs.active_count() > 0:
+            return False
         return self.idle_seconds() >= self.idle_retire_seconds
 
     def serve_forever(self) -> int:
@@ -227,6 +287,8 @@ class Daemon:
 
     def _idle_watchdog(self) -> None:
         while not self._stop.wait(0.5):
+            for job in self.jobs.reap_expired():
+                self.registry.log_event("job.expired", f"{job.id} {job.stack}")
             if self.should_retire():
                 self.registry.log_event("daemon.idle_retired", f"idle={self.idle_seconds():.0f}s")
                 self.request_stop()
@@ -239,6 +301,9 @@ class Daemon:
 
     def shutdown(self) -> None:
         self._stop.set()
+        # Cancel in-flight builds before closing the registry they write to. Each one tells
+        # its attached clients why it stopped rather than dying silently.
+        self.jobs.shutdown()
         if self._server is not None:
             self._server.server_close()
             self._server = None
@@ -258,11 +323,19 @@ class Daemon:
             "ping": self._verb_ping,
             "status": self._verb_status,
             "jobs": self._verb_jobs,
+            "cancel": self._verb_cancel,
             "shutdown": self._verb_shutdown,
         }.get(verb)
         if handler is None:
             return {"ok": False, "error": f"unknown daemon verb {verb!r}"}
         return handler(request)
+
+    def dispatch_stream(self, verb: str, request: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        if verb == "converge":
+            return self._verb_converge(request)
+        if verb == "attach":
+            return self._verb_attach(request)
+        raise DaemonError(f"unknown streaming verb {verb!r}")
 
     def _verb_ping(self, _request: dict[str, Any]) -> dict[str, Any]:
         return {"ok": True, "pong": True, "pid": os.getpid(), "version": __version__}
@@ -279,8 +352,101 @@ class Daemon:
             "resources": len(self.registry.list_resources()),
         }
 
-    def _verb_jobs(self, _request: dict[str, Any]) -> dict[str, Any]:
-        return {"ok": True, "jobs": []}
+    def _verb_jobs(self, request: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "jobs": self.jobs.list_jobs(include_finished=bool(request.get("all", True))),
+            "max_builds": self.jobs.max_builds,
+        }
+
+    def _verb_cancel(self, request: dict[str, Any]) -> dict[str, Any]:
+        job_id = str(request.get("job") or "")
+        try:
+            job = self.jobs.cancel(job_id)
+        except JobError as exc:
+            return {"ok": False, "error": str(exc)}
+        self.registry.log_event("job.cancelled", job.id)
+        return {"ok": True, "job": job.id, "state": job.state}
+
+    def _verb_converge(self, request: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        """Submit a converge under the coalescing policy, then stream the job it landed on.
+
+        The submission decision itself is reported before any build output, so a client can
+        always tell whether it started work, joined someone else's, or is queued behind an
+        obsolete build it is about to wait out.
+        """
+        manifest_path = str(request.get("manifest") or "")
+        if not manifest_path:
+            raise DaemonError("converge requires a manifest path")
+
+        from bosn.converge import workspace_of
+        from bosn.manifest import generation_digest, load
+
+        manifest = load(Path(manifest_path))
+        stack = manifest.stack(request.get("stack") or None)
+        digest = generation_digest(manifest, stack)
+        workspace = str(request.get("workspace") or workspace_of(manifest))
+
+        submission = self.jobs.submit(
+            workspace=workspace,
+            stack=stack.name,
+            digest=digest,
+            payload={
+                "manifest": str(manifest.path),
+                "stack": stack.name,
+                "engine": str(request.get("engine") or self.engine_binary),
+            },
+        )
+        job = submission.job
+        self.registry.log_event("job.submitted", f"{job.id} {submission.disposition}")
+        yield {
+            "event": "submitted",
+            "job": job.id,
+            "state": job.state,
+            "joined": submission.joined,
+            "disposition": submission.disposition,
+            "digest": digest,
+            "workspace": workspace,
+            "stack": stack.name,
+            "superseded": submission.superseded.id if submission.superseded else None,
+        }
+        yield from self.jobs.follow(job, stop=self._stop)
+
+    def _verb_attach(self, request: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        job = self.jobs.get(str(request.get("job") or ""))
+        yield {"event": "attached", "job": job.id, "state": job.state}
+        yield from self.jobs.follow(job, stop=self._stop)
+
+    # -- the builder -------------------------------------------------------
+
+    def _build(self, job: Job) -> BuildOutcome:
+        """Run one converge to completion inside the daemon.
+
+        This is where the registry actually becomes single-writer for converge: the build
+        and the generation/resource rows it produces both happen here, in the process that
+        outlives the CLI.
+        """
+        from bosn.converge import Converger
+        from bosn.engine import Engine, EngineError
+        from bosn.manifest import load
+
+        manifest = load(Path(str(job.payload["manifest"])))
+        engine = Engine(str(job.payload.get("engine") or self.engine_binary))
+        converger = Converger(
+            manifest,
+            self.registry,
+            engine,
+            progress=lambda line: job.log(line),
+            cancelled=job.cancelled,
+        )
+        try:
+            result = converger.converge(
+                str(job.payload.get("stack") or "") or None, workspace=job.workspace
+            )
+        except EngineError as exc:
+            job.log(str(exc), stream="stderr")
+            return BuildOutcome(returncode=1)
+        return BuildOutcome(returncode=0, result=result.to_dict())
 
     def _verb_shutdown(self, _request: dict[str, Any]) -> dict[str, Any]:
         self.request_stop()
@@ -388,6 +554,22 @@ def request(
             raise DaemonError("no bosn daemon is running")
         spawn(state_dir)
     return ipc.send_request(port_for(state_dir), {"verb": verb, **payload})
+
+
+def stream(
+    verb: str,
+    state_dir: Path | None = None,
+    *,
+    autostart: bool = True,
+    **payload: Any,
+) -> Generator[dict[str, Any], None, None]:
+    """Send a streaming verb and yield its events until the daemon sends `final`."""
+    state_dir = state_dir or default_state_dir()
+    if not is_serving(state_dir):
+        if not autostart:
+            raise DaemonError("no bosn daemon is running")
+        spawn(state_dir)
+    return ipc.stream_request(port_for(state_dir), {"verb": verb, **payload})
 
 
 def stop(state_dir: Path | None = None, *, timeout: float = 10.0) -> bool:

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -45,6 +45,11 @@ SPAWN_TIMEOUT_SECONDS = 30.0
 # Verbs that hold the connection open and write many messages instead of one.
 STREAMING_VERBS = frozenset({"converge", "attach"})
 
+# How long shutdown waits for cancelled builds to finish tearing down and release the
+# registry. Must exceed a builder's worst case (Engine.stream waits 30s for the process,
+# then converge still has its registry writes and volume creation to finish).
+SHUTDOWN_DRAIN_SECONDS = 60.0
+
 
 class DaemonError(RuntimeError):
     """The daemon could not be started, reached, or stopped."""
@@ -301,9 +306,16 @@ class Daemon:
 
     def shutdown(self) -> None:
         self._stop.set()
-        # Cancel in-flight builds before closing the registry they write to. Each one tells
-        # its attached clients why it stopped rather than dying silently.
-        self.jobs.shutdown()
+        # Cancel in-flight builds and wait for them *before* closing the registry they
+        # write to. Each one tells its attached clients why it stopped rather than dying
+        # silently.
+        #
+        # The timeout has to cover a builder's whole teardown, not just the kill: a
+        # cancelled build waits up to 30s for the process to die and then still finishes
+        # its converge. Closing the registry underneath it would turn a build that actually
+        # succeeded into a failure, and leave the image and volumes Docker just created
+        # with no registry rows -- the untracked resources bosn exists to prevent.
+        self.jobs.shutdown(timeout=SHUTDOWN_DRAIN_SECONDS)
         if self._server is not None:
             self._server.server_close()
             self._server = None
@@ -425,6 +437,12 @@ class Daemon:
         This is where the registry actually becomes single-writer for converge: the build
         and the generation/resource rows it produces both happen here, in the process that
         outlives the CLI.
+
+        The manifest is re-read here rather than carried over from submission, so the
+        digest built is the one the spec has *now*. The job's own digest is a snapshot taken
+        at submit time and is only ever a coalescing key -- if the Dockerfile changed again
+        while this job sat in the pending slot, converging to the newer content is the
+        right answer, and the ConvergeResult reports the digest actually built.
         """
         from bosn.converge import Converger
         from bosn.engine import Engine, EngineError
@@ -444,13 +462,24 @@ class Daemon:
                 str(job.payload.get("stack") or "") or None, workspace=job.workspace
             )
         except EngineError as exc:
-            job.log(str(exc), stream="stderr")
+            # Truncated: a build failure's message embeds the failed command's whole
+            # output, which for `docker build` is the entire transcript -- already streamed
+            # line by line. Logging it whole would duplicate the build into one enormous
+            # event and evict real output from the ring buffer.
+            job.log(_clip(str(exc)), stream="stderr")
             return BuildOutcome(returncode=1)
         return BuildOutcome(returncode=0, result=result.to_dict())
 
     def _verb_shutdown(self, _request: dict[str, Any]) -> dict[str, Any]:
         self.request_stop()
         return {"ok": True, "stopping": True}
+
+
+def _clip(text: str, limit: int = 2000) -> str:
+    """Keep the tail of an over-long message -- the end of a build log is the useful part."""
+    if len(text) <= limit:
+        return text
+    return f"[...{len(text) - limit} characters elided...] {text[-limit:]}"
 
 
 # -- client side -----------------------------------------------------------

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -8,11 +8,16 @@ never shell strings.
 from __future__ import annotations
 
 import shutil
+import threading
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import running_process as rp
 
 DEFAULT_TIMEOUT = 60
+# How often a streaming command checks whether it has been cancelled.
+STREAM_POLL_SECONDS = 0.05
 
 
 class EngineError(RuntimeError):
@@ -70,6 +75,66 @@ class Engine:
                 f"{result.stderr or result.stdout}"
             )
         return result
+
+    def stream(
+        self,
+        args: list[str],
+        *,
+        on_line: Callable[[str], None] | None = None,
+        cancelled: threading.Event | None = None,
+    ) -> EngineResult:
+        """Run a command, publishing output line by line, killing it on cancellation.
+
+        Builds go through here rather than `run`. Two reasons, both about the 20-minute
+        cold build: its output has to reach a watching client while it happens rather than
+        in one lump at the end, and it has to be killable, since `bosn cancel`, daemon
+        shutdown, and the job TTL all need a way to stop a build that is already going.
+
+        Deliberately no timeout: the owning job's TTL is the one deadline. `run`'s 60s
+        default is right for `docker inspect` and catastrophic for `docker build`, and two
+        competing deadlines would just mean the tighter one silently wins.
+        """
+        if not self.available():
+            raise EngineError(f"{self.binary!r} is not on PATH")
+        lines: list[str] = []
+
+        def publish(text: str) -> None:
+            lines.append(text)
+            if on_line is not None:
+                on_line(text)
+
+        process = rp.RunningProcess([self.binary, *args], check=False, timeout=None)
+        killed = False
+        try:
+            while True:
+                if cancelled is not None and cancelled.is_set() and not killed:
+                    process.kill()
+                    killed = True
+                line = process.get_next_line_non_blocking()
+                if isinstance(line, rp.EndOfStream):
+                    break
+                if line is None:
+                    if process.finished and not process.has_pending_output:
+                        break
+                    time.sleep(STREAM_POLL_SECONDS)
+                    continue
+                publish(str(line))
+        finally:
+            try:
+                # wait() is typed as int | IdleWaitResult because it doubles as an idle
+                # detector; with no idle_detector passed it always returns the exit code.
+                waited = process.wait(timeout=30)
+                returncode = waited if isinstance(waited, int) else -1
+            except KeyboardInterrupt:
+                raise
+            except Exception:  # noqa: BLE001 - a wait that fails must not mask the real outcome
+                process.kill()
+                returncode = -1
+
+        output = "\n".join(lines)
+        if killed:
+            return EngineResult(returncode=returncode or -1, stdout=output, stderr="cancelled")
+        return EngineResult(returncode=returncode, stdout=output, stderr="")
 
     def info(self) -> EngineInfo:
         """Probe the engine. Never raises — the result carries the diagnosis."""

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -114,7 +114,10 @@ class Engine:
                 if isinstance(line, rp.EndOfStream):
                     break
                 if line is None:
-                    if process.finished and not process.has_pending_output:
+                    # `finished` is a property but `has_pending_output` is a method -- calling
+                    # one and not the other silently turns this into `not <bound method>`,
+                    # i.e. never true, and the drain guard stops guarding anything.
+                    if process.finished and not process.has_pending_output():
                         break
                     time.sleep(STREAM_POLL_SECONDS)
                     continue

--- a/src/bosn/ipc.py
+++ b/src/bosn/ipc.py
@@ -26,6 +26,8 @@ DEFAULT_TIMEOUT = 10.0
 # Generous, because a cold build is silent for long stretches -- but not infinite, because
 # a client must eventually notice a daemon that died. The daemon heartbeats well inside it.
 STREAM_TIMEOUT = 120.0
+# A connected client that has not sent its request by now is not going to.
+REQUEST_READ_TIMEOUT = 30.0
 
 
 class TransportError(RuntimeError):
@@ -121,11 +123,24 @@ def stream_request(
 
 
 def read_request(conn: socket.socket) -> dict[str, Any] | None:
-    """Server side: read one newline-delimited JSON request, or None on clean EOF."""
+    """Server side: read one newline-delimited JSON request, or None on clean EOF.
+
+    The read is deadlined even though the daemon is patient elsewhere. A client always
+    writes its request immediately, so a connection that opens and then says nothing is a
+    port scanner, a half-open socket, or a CLI killed mid-handshake -- and with no timeout
+    each one parks a handler thread in `recv` forever. Daemon threads keep that from
+    blocking process exit, but they accumulate without bound in a process meant to stay
+    resident for hours.
+
+    The deadline is then cleared: it governs reading the request, not the minutes or hours
+    of build output that a streaming verb may go on to write.
+    """
     try:
-        return MessageStream(conn, timeout=None).read()
+        request = MessageStream(conn, timeout=REQUEST_READ_TIMEOUT).read()
     except TransportError:
         return None
+    conn.settimeout(None)
+    return request
 
 
 def send_response(conn: socket.socket, response: dict[str, Any]) -> None:

--- a/src/bosn/ipc.py
+++ b/src/bosn/ipc.py
@@ -4,6 +4,12 @@ A newline-delimited JSON protocol over loopback TCP. Loopback (not a unix socket
 v1 targets cmd.exe, PowerShell, and MSYS Git Bash on Windows alongside macOS and Linux with
 one mechanism. The listening port is published in the daemon's state file.
 
+Most verbs are one request, one reply. Build jobs are the exception: the connection stays
+open and the daemon writes a stream of events -- output lines, status changes, heartbeats
+-- terminated by one message carrying `"final": true`. That is why reads go through
+`MessageStream` rather than a single recv: a stream puts many messages on one socket, and
+whatever arrives past the first newline is the next message, not garbage to discard.
+
 Mutating verbs fail closed when the daemon is unreachable -- falling back to raw Docker
 would recreate exactly the unregistered resources bosn exists to eliminate.
 """
@@ -12,14 +18,56 @@ from __future__ import annotations
 
 import json
 import socket
+from collections.abc import Generator
 from typing import Any
 
 LOOPBACK = "127.0.0.1"
 DEFAULT_TIMEOUT = 10.0
+# Generous, because a cold build is silent for long stretches -- but not infinite, because
+# a client must eventually notice a daemon that died. The daemon heartbeats well inside it.
+STREAM_TIMEOUT = 120.0
 
 
 class TransportError(RuntimeError):
     """The daemon could not be reached or spoke nonsense."""
+
+
+class MessageStream:
+    """Reads newline-delimited JSON objects off a socket, buffering across messages."""
+
+    def __init__(self, sock: socket.socket, *, timeout: float | None = DEFAULT_TIMEOUT) -> None:
+        self.sock = sock
+        self._buffer = b""
+        if timeout is not None:
+            self.sock.settimeout(timeout)
+
+    def read(self) -> dict[str, Any] | None:
+        """The next message, or None at clean end of stream."""
+        while b"\n" not in self._buffer:
+            try:
+                chunk = self.sock.recv(65536)
+            except TimeoutError as exc:
+                raise TransportError("timed out waiting for the daemon") from exc
+            except OSError as exc:
+                raise TransportError(f"connection to the daemon failed: {exc}") from exc
+            if not chunk:
+                if self._buffer.strip():
+                    raise TransportError("daemon closed the connection mid-message")
+                return None
+            self._buffer += chunk
+        raw, self._buffer = self._buffer.split(b"\n", 1)
+        if not raw.strip():
+            return None
+        try:
+            message = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise TransportError(f"malformed reply from daemon: {exc}") from exc
+        if not isinstance(message, dict):
+            raise TransportError("daemon reply was not a JSON object")
+        return message
+
+    def write(self, message: dict[str, Any]) -> None:
+        self.sock.sendall((json.dumps(message) + "\n").encode("utf-8"))
 
 
 def send_request(
@@ -29,41 +77,53 @@ def send_request(
     host: str = LOOPBACK,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> dict[str, Any]:
-    payload = (json.dumps(request) + "\n").encode("utf-8")
+    """One request, one reply."""
     try:
         with socket.create_connection((host, port), timeout=timeout) as sock:
-            sock.settimeout(timeout)
-            sock.sendall(payload)
-            return _read_message(sock)
+            stream = MessageStream(sock, timeout=timeout)
+            stream.write(request)
+            reply = stream.read()
+    except TransportError:
+        raise
     except OSError as exc:
         raise TransportError(f"daemon unreachable on {host}:{port}: {exc}") from exc
-
-
-def _read_message(sock: socket.socket) -> dict[str, Any]:
-    chunks: list[bytes] = []
-    while True:
-        chunk = sock.recv(4096)
-        if not chunk:
-            break
-        chunks.append(chunk)
-        if b"\n" in chunk:
-            break
-    raw = b"".join(chunks).split(b"\n", 1)[0]
-    if not raw:
+    if reply is None:
         raise TransportError("daemon closed the connection without replying")
+    return reply
+
+
+def stream_request(
+    port: int,
+    request: dict[str, Any],
+    *,
+    host: str = LOOPBACK,
+    timeout: float = STREAM_TIMEOUT,
+) -> Generator[dict[str, Any], None, None]:
+    """One request, many replies -- yields events until the daemon sends `final`.
+
+    Disconnecting mid-stream is safe and expected: the job belongs to the daemon, so
+    hanging up abandons the *view*, never the work.
+    """
     try:
-        message = json.loads(raw.decode("utf-8"))
-    except json.JSONDecodeError as exc:
-        raise TransportError(f"malformed reply from daemon: {exc}") from exc
-    if not isinstance(message, dict):
-        raise TransportError("daemon reply was not a JSON object")
-    return message
+        sock = socket.create_connection((host, port), timeout=timeout)
+    except OSError as exc:
+        raise TransportError(f"daemon unreachable on {host}:{port}: {exc}") from exc
+    with sock:
+        stream = MessageStream(sock, timeout=timeout)
+        stream.write(request)
+        while True:
+            message = stream.read()
+            if message is None:
+                raise TransportError("daemon closed the stream before the job ended")
+            yield message
+            if message.get("final"):
+                return
 
 
 def read_request(conn: socket.socket) -> dict[str, Any] | None:
     """Server side: read one newline-delimited JSON request, or None on clean EOF."""
     try:
-        return _read_message(conn)
+        return MessageStream(conn, timeout=None).read()
     except TransportError:
         return None
 

--- a/src/bosn/jobs.py
+++ b/src/bosn/jobs.py
@@ -1,0 +1,560 @@
+"""Daemon-owned build jobs and the concurrency policy that bounds them.
+
+A build moved behind the daemon survives the CLI that asked for it -- which is the whole
+point, since a killed CLI must not destroy a 20-minute build. But it also means the daemon
+now owns work that outlives its requester, and *something* has to bound how much of it
+accumulates. bosn's primary consumer is an agent in an edit-and-rerun loop, so the bound is
+not a nicety.
+
+**Policy: coalesce with queue depth 1, joining by digest.**
+
+Per `(workspace-id, stack)` key the daemon holds at most one active job and one pending
+job:
+
+1. Nothing active for this key -> the request becomes active and builds.
+2. Active job has the *same* digest -> the request joins it. One build, many watchers.
+3. Active job has a *different* digest -> the request takes the pending slot. If that slot
+   is already occupied, an identical digest joins it, and a different digest replaces its
+   occupant, which terminates as SUPERSEDED and tells its clients so.
+
+Why this and not the alternatives:
+
+- *Cancel-and-replace* (kill the in-flight build, newest always wins) is more responsive
+  but can livelock: under a fast edit loop every build is cancelled before finishing, so
+  nothing ever completes and the agent never gets output. Avoiding that needs age floors
+  or debounce -- machinery whose tuning is another thing to get wrong. Depth-1 coalescing
+  is bounded and livelock-free *by construction*: the worst case is waiting out one
+  obsolete build, and that build warms BuildKit's layer cache for the one that follows it.
+- *Fail fast* ("a build is already running, stop it first") is simplest for a human at a
+  terminal and hostile to the loop this project exists to serve. An error whose remedy is
+  always the same mechanical command is just a forced retry loop.
+- *Unbounded serialization* is the failure mode itself: a queue of obsolete builds, each
+  pinning volumes against GC and blocking the daemon's idle retirement.
+
+The consequence worth naming: superseding only ever drops a job that has **not started**,
+so cancellation is never on the hot path. Cancelling a *running* build stays a real,
+deliberate act -- `bosn cancel`, daemon shutdown, or the per-job TTL -- and never something
+the policy does behind your back.
+
+Nothing here silently does nothing. Every job that is superseded, cancelled, or dropped
+terminates with a reason its clients can read.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import queue
+import threading
+import time
+import uuid
+from collections import deque
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+# -- job states -------------------------------------------------------------
+
+PENDING = "pending"  # holds the key's depth-1 pending slot, waiting on the active job
+QUEUED = "queued"  # owns the key, waiting on the machine-wide build cap
+RUNNING = "running"  # the builder is executing
+SUCCEEDED = "succeeded"
+FAILED = "failed"
+CANCELLED = "cancelled"
+SUPERSEDED = "superseded"
+
+TERMINAL_STATES = frozenset({SUCCEEDED, FAILED, CANCELLED, SUPERSEDED})
+ACTIVE_STATES = frozenset({PENDING, QUEUED, RUNNING})
+
+DEFAULT_TTL_SECONDS = 3600.0
+# Keep the tail of a job's output for late attachers without letting a chatty build grow
+# the daemon's heap without bound.
+MAX_LOG_LINES = 5000
+
+
+def default_max_builds() -> int:
+    """How many builds may run at once across every key on this machine.
+
+    Per-key serialization alone does not bound host load: N worktrees each building their
+    own distinct key are all individually legal and can still saturate the machine. #1 caps
+    bytes; this is the CPU-side analogue of the same commitment.
+    """
+    override = os.environ.get("BOSN_MAX_BUILDS")
+    if override:
+        try:
+            return max(1, int(override))
+        except ValueError:
+            pass
+    return max(2, (os.cpu_count() or 2) // 2)
+
+
+def default_ttl_seconds() -> float:
+    override = os.environ.get("BOSN_BUILD_TTL_SECONDS")
+    if override:
+        try:
+            return max(1.0, float(override))
+        except ValueError:
+            pass
+    return DEFAULT_TTL_SECONDS
+
+
+class JobError(RuntimeError):
+    """A job could not be submitted, found, or cancelled."""
+
+
+@dataclass(frozen=True)
+class BuildOutcome:
+    """What a builder returns: an exit code plus whatever the verb wants to report back."""
+
+    returncode: int
+    result: dict[str, Any] = field(default_factory=dict)
+
+
+# A builder runs one job to completion. It must poll `job.cancelled` and stop when set.
+Builder = Callable[["Job"], BuildOutcome]
+
+_ids = itertools.count(1)
+
+
+class Job:
+    """One unit of daemon-owned work, plus the fan-out to everyone watching it."""
+
+    def __init__(
+        self,
+        *,
+        workspace: str,
+        stack: str,
+        digest: str,
+        payload: dict[str, Any],
+        state: str,
+        now: float,
+    ) -> None:
+        self.id = f"j{next(_ids)}-{uuid.uuid4().hex[:8]}"
+        self.workspace = workspace
+        self.stack = stack
+        self.digest = digest
+        self.payload = payload
+        self.state = state
+        self.created_at = now
+        self.started_at: float | None = None
+        self.ended_at: float | None = None
+        self.returncode: int | None = None
+        self.error: str | None = None
+        self.result: dict[str, Any] = {}
+
+        self.cancelled = threading.Event()
+        self.done = threading.Event()
+        self._lock = threading.Lock()
+        self._log: deque[dict[str, Any]] = deque(maxlen=MAX_LOG_LINES)
+        self._dropped = 0
+        self._watchers: list[queue.SimpleQueue[dict[str, Any]]] = []
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.workspace, self.stack)
+
+    @property
+    def finished(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    # -- output fan-out ----------------------------------------------------
+
+    def emit(self, event: dict[str, Any]) -> None:
+        """Publish one event to every watcher, and remember it for late arrivals."""
+        with self._lock:
+            if event.get("event") == "log":
+                if len(self._log) == self._log.maxlen:
+                    self._dropped += 1
+                self._log.append(event)
+            watchers = list(self._watchers)
+        for watcher in watchers:
+            watcher.put(event)
+
+    def watch(self) -> queue.SimpleQueue[dict[str, Any]]:
+        """Subscribe, receiving the output so far before anything new.
+
+        The backlog is what makes reattaching useful: a CLI that died mid-build and came
+        back still sees what it missed rather than joining a silent stream.
+        """
+        watcher: queue.SimpleQueue[dict[str, Any]] = queue.SimpleQueue()
+        with self._lock:
+            if self._dropped:
+                watcher.put(
+                    {
+                        "event": "log",
+                        "stream": "meta",
+                        "line": f"[{self._dropped} earlier line(s) dropped from the buffer]",
+                    }
+                )
+            for event in self._log:
+                watcher.put(event)
+            if self.state in TERMINAL_STATES:
+                watcher.put(self.summary(final=True))
+            else:
+                self._watchers.append(watcher)
+        return watcher
+
+    def unwatch(self, watcher: queue.SimpleQueue[dict[str, Any]]) -> None:
+        with self._lock:
+            if watcher in self._watchers:
+                self._watchers.remove(watcher)
+
+    def log(self, line: str, stream: str = "stdout") -> None:
+        self.emit({"event": "log", "stream": stream, "line": line})
+
+    def summary(self, *, final: bool = False) -> dict[str, Any]:
+        return {
+            "event": "end" if final else "status",
+            "final": final,
+            "job": self.id,
+            "state": self.state,
+            "workspace": self.workspace,
+            "stack": self.stack,
+            "digest": self.digest,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "returncode": self.returncode,
+            "error": self.error,
+            "result": self.result,
+        }
+
+
+@dataclass
+class _Slot:
+    """The whole bound, in two fields: one active job, one pending job."""
+
+    active: Job | None = None
+    pending: Job | None = None
+
+    def empty(self) -> bool:
+        return self.active is None and self.pending is None
+
+
+@dataclass(frozen=True)
+class Submission:
+    """What happened to a submit() -- the caller needs to be able to say which."""
+
+    job: Job
+    joined: bool
+    superseded: Job | None = None
+
+    @property
+    def disposition(self) -> str:
+        if self.joined:
+            return "joined"
+        return self.job.state
+
+
+class JobManager:
+    """The job table: the policy above, plus the threads that carry it out."""
+
+    def __init__(
+        self,
+        builder: Builder,
+        *,
+        max_builds: int | None = None,
+        ttl_seconds: float | None = None,
+        on_settled: Callable[[], None] | None = None,
+    ) -> None:
+        self.builder = builder
+        self.max_builds = max_builds if max_builds is not None else default_max_builds()
+        self.ttl_seconds = ttl_seconds if ttl_seconds is not None else default_ttl_seconds()
+        self.on_settled = on_settled
+
+        self._lock = threading.RLock()
+        self._slots: dict[tuple[str, str], _Slot] = {}
+        self._jobs: dict[str, Job] = {}
+        self._cap_queue: deque[Job] = deque()
+        self._running = 0
+        self._threads: list[threading.Thread] = []
+        self._stopped = False
+
+    # -- submission --------------------------------------------------------
+
+    def submit(
+        self,
+        *,
+        workspace: str,
+        stack: str,
+        digest: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Submission:
+        """Apply the coalescing policy to one request. Never blocks on a build."""
+        with self._lock:
+            if self._stopped:
+                raise JobError("the daemon is shutting down; no new jobs are accepted")
+            slot = self._slots.setdefault((workspace, stack), _Slot())
+
+            # 2. identical work already in flight -- join it rather than build twice
+            if slot.active is not None and slot.active.digest == digest:
+                return Submission(slot.active, joined=True)
+
+            # 1. nothing in flight for this key
+            if slot.active is None:
+                job = self._new_job(workspace, stack, digest, payload, QUEUED)
+                slot.active = job
+                self._cap_queue.append(job)
+                self._pump()
+                return Submission(job, joined=False)
+
+            # 3. a different digest is in flight: the depth-1 pending slot decides
+            if slot.pending is not None and slot.pending.digest == digest:
+                return Submission(slot.pending, joined=True)
+
+            superseded = slot.pending
+            if superseded is not None:
+                self._settle(
+                    superseded,
+                    SUPERSEDED,
+                    error=(
+                        f"superseded: digest {_short(superseded.digest)} replaced by "
+                        f"{_short(digest)} before its build started"
+                    ),
+                )
+            job = self._new_job(workspace, stack, digest, payload, PENDING)
+            slot.pending = job
+            return Submission(job, joined=False, superseded=superseded)
+
+    def _new_job(
+        self,
+        workspace: str,
+        stack: str,
+        digest: str,
+        payload: dict[str, Any] | None,
+        state: str,
+    ) -> Job:
+        job = Job(
+            workspace=workspace,
+            stack=stack,
+            digest=digest,
+            payload=payload or {},
+            state=state,
+            now=time.time(),
+        )
+        self._jobs[job.id] = job
+        return job
+
+    # -- scheduling --------------------------------------------------------
+
+    def _pump(self) -> None:
+        """Start as many queued jobs as the machine-wide cap allows. Caller holds the lock."""
+        while self._running < self.max_builds and self._cap_queue:
+            job = self._cap_queue.popleft()
+            if job.finished:
+                continue
+            job.state = RUNNING
+            job.started_at = time.time()
+            self._running += 1
+            job.emit(job.summary())
+            thread = threading.Thread(target=self._run, args=(job,), daemon=True)
+            self._threads.append(thread)
+            thread.start()
+
+    def _run(self, job: Job) -> None:
+        state = FAILED
+        error: str | None = None
+        outcome: BuildOutcome | None = None
+        try:
+            outcome = self.builder(job)
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - a builder crash must terminate its job, not the daemon
+            error = f"{type(exc).__name__}: {exc}"
+        else:
+            state = SUCCEEDED if outcome.returncode == 0 else FAILED
+            if state == FAILED:
+                error = f"build exited {outcome.returncode}"
+
+        if job.cancelled.is_set():
+            state, error = CANCELLED, job.error or "cancelled"
+
+        with self._lock:
+            self._settle(
+                job,
+                state,
+                error=error,
+                returncode=outcome.returncode if outcome else None,
+                result=outcome.result if outcome else None,
+            )
+            self._running -= 1
+            self._advance(job)
+            self._pump()
+        if self.on_settled is not None:
+            self.on_settled()
+
+    def _advance(self, job: Job) -> None:
+        """Promote the pending job into the slot its predecessor just vacated."""
+        slot = self._slots.get(job.key)
+        if slot is None or slot.active is not job:
+            return
+        slot.active = slot.pending
+        slot.pending = None
+        if slot.active is not None:
+            slot.active.state = QUEUED
+            slot.active.emit(slot.active.summary())
+            self._cap_queue.append(slot.active)
+        elif slot.empty():
+            self._slots.pop(job.key, None)
+
+    def _settle(
+        self,
+        job: Job,
+        state: str,
+        *,
+        error: str | None = None,
+        returncode: int | None = None,
+        result: dict[str, Any] | None = None,
+    ) -> None:
+        """Move a job to a terminal state exactly once and tell everyone watching."""
+        if job.finished:
+            return
+        job.state = state
+        job.ended_at = time.time()
+        job.error = error
+        job.returncode = returncode
+        if result:
+            job.result = result
+        job.done.set()
+        job.emit(job.summary(final=True))
+
+    # -- cancellation ------------------------------------------------------
+
+    def cancel(self, job_id: str, *, reason: str = "cancelled by request") -> Job:
+        """Cancel a job. Running builds are asked to stop; queued ones never start."""
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                raise JobError(f"no such job {job_id!r}")
+            if job.finished:
+                raise JobError(f"job {job_id} already finished as {job.state}")
+            job.error = reason
+            job.cancelled.set()
+            if job.state == RUNNING:
+                # The builder sees the event, kills its process, and _run settles the job.
+                return job
+            slot = self._slots.get(job.key)
+            self._settle(job, CANCELLED, error=reason)
+            if slot is not None:
+                if slot.pending is job:
+                    slot.pending = None
+                    if slot.empty():
+                        self._slots.pop(job.key, None)
+                elif slot.active is job:
+                    self._advance(job)
+            self._pump()
+        if self.on_settled is not None:
+            self.on_settled()
+        return job
+
+    def reap_expired(self, now: float | None = None) -> list[Job]:
+        """Cancel builds that have outlived their TTL.
+
+        Without this a builder that hangs forever pins the daemon forever: running jobs
+        block idle retirement, so a job that never reports is also a daemon that never
+        retires and resources that never get collected.
+        """
+        now = now if now is not None else time.time()
+        expired: list[Job] = []
+        with self._lock:
+            for job in list(self._jobs.values()):
+                if job.state != RUNNING or job.started_at is None:
+                    continue
+                age = now - job.started_at
+                if age > self.ttl_seconds:
+                    expired.append(job)
+        for job in expired:
+            try:
+                self.cancel(job.id, reason=f"exceeded the {self.ttl_seconds:.0f}s build TTL")
+            except JobError:
+                continue  # it finished on its own between the scan and the cancel
+        return expired
+
+    # -- observation -------------------------------------------------------
+
+    def get(self, job_id: str) -> Job:
+        with self._lock:
+            job = self._jobs.get(job_id)
+        if job is None:
+            raise JobError(f"no such job {job_id!r}")
+        return job
+
+    def active_count(self) -> int:
+        with self._lock:
+            return sum(1 for job in self._jobs.values() if job.state in ACTIVE_STATES)
+
+    def list_jobs(self, *, include_finished: bool = True) -> list[dict[str, Any]]:
+        with self._lock:
+            jobs = sorted(self._jobs.values(), key=lambda j: j.created_at)
+        return [
+            {
+                "id": job.id,
+                "state": job.state,
+                "workspace": job.workspace,
+                "stack": job.stack,
+                "digest": job.digest,
+                "created_at": job.created_at,
+                "started_at": job.started_at,
+                "ended_at": job.ended_at,
+                "returncode": job.returncode,
+                "error": job.error,
+            }
+            for job in jobs
+            if include_finished or not job.finished
+        ]
+
+    def depth(self, workspace: str, stack: str) -> int:
+        """How many jobs this key is holding. The policy's invariant: never more than 2."""
+        with self._lock:
+            slot = self._slots.get((workspace, stack))
+            if slot is None:
+                return 0
+            return int(slot.active is not None) + int(slot.pending is not None)
+
+    def follow(
+        self, job: Job, *, heartbeat: float = 30.0, stop: threading.Event | None = None
+    ) -> Iterator[dict[str, Any]]:
+        """Yield a job's events until it ends, with heartbeats so silence is not death.
+
+        A cold build can go minutes without printing. Without a heartbeat the client cannot
+        distinguish a quiet build from a daemon that died, and would have to choose between
+        a timeout that kills long builds and one that hangs forever.
+        """
+        watcher = job.watch()
+        try:
+            while True:
+                if stop is not None and stop.is_set():
+                    return
+                try:
+                    event = watcher.get(timeout=heartbeat)
+                except queue.Empty:
+                    yield {"event": "heartbeat", "job": job.id, "state": job.state}
+                    continue
+                yield event
+                if event.get("final"):
+                    return
+        finally:
+            job.unwatch(watcher)
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def shutdown(self, *, timeout: float = 10.0) -> None:
+        """Stop accepting work and cancel what is in flight, visibly."""
+        with self._lock:
+            self._stopped = True
+            in_flight = [j for j in self._jobs.values() if j.state in ACTIVE_STATES]
+        for job in in_flight:
+            try:
+                self.cancel(job.id, reason="the bosn daemon is shutting down")
+            except JobError:
+                continue
+        deadline = time.time() + timeout
+        for thread in list(self._threads):
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            thread.join(timeout=remaining)
+
+
+def _short(digest: str) -> str:
+    return digest.removeprefix("sha256:")[:12]

--- a/src/bosn/jobs.py
+++ b/src/bosn/jobs.py
@@ -204,6 +204,47 @@ class Job:
             if watcher in self._watchers:
                 self._watchers.remove(watcher)
 
+    def finalize(
+        self,
+        state: str,
+        *,
+        error: str | None,
+        returncode: int | None,
+        result: dict[str, Any] | None,
+    ) -> bool:
+        """Move to a terminal state and notify, as one atomic step. True if this call did it.
+
+        The atomicity is the point, and it is subtle. `watch()` decides whether to register
+        a watcher or hand back the terminal event directly, based on `self.state` -- so if
+        the terminal transition were spread over several statements, a `watch()` landing in
+        the middle would see the terminal state, synthesize an event from fields not yet
+        written (no returncode, no error, empty result), and skip registering, so the real
+        event never reached it. A client hitting that window would be told its build
+        succeeded and handed an empty ConvergeResult, i.e. an empty image tag.
+
+        Everything therefore happens under the same lock `watch()` takes, which leaves only
+        two orderings: watch-then-finalize (registered, gets the real event) and
+        finalize-then-watch (sees a fully written job and gets a complete summary).
+        """
+        with self._lock:
+            if self.state in TERMINAL_STATES:
+                return False
+            self.state = state
+            self.ended_at = time.time()
+            self.error = error
+            self.returncode = returncode
+            if result:
+                self.result = result
+            self.done.set()
+            event = self.summary(final=True)
+            watchers = list(self._watchers)
+            self._watchers.clear()
+        # Outside the lock only because it need not be inside; SimpleQueue.put is unbounded
+        # and never blocks, so holding it would also have been safe.
+        for watcher in watchers:
+            watcher.put(event)
+        return True
+
     def log(self, line: str, stream: str = "stdout") -> None:
         self.emit({"event": "log", "stream": stream, "line": line})
 
@@ -293,8 +334,20 @@ class JobManager:
                 raise JobError("the daemon is shutting down; no new jobs are accepted")
             slot = self._slots.setdefault((workspace, stack), _Slot())
 
-            # 2. identical work already in flight -- join it rather than build twice
-            if slot.active is not None and slot.active.digest == digest:
+            # 2. identical work already in flight -- join it rather than build twice.
+            #
+            # Unless it is already dying. A cancelled job stays `active` until its builder
+            # notices and tears down, which can take a while (killing a build, or a TTL
+            # reap of a build that is ignoring the kill). Joining it would hand the new
+            # request the corpse's CANCELLED event: `bosn cancel` immediately followed by
+            # `bosn run` would build nothing and exit 5, and after a TTL reap *every*
+            # subsequent run for that digest would do the same until the old process
+            # finally died -- an agent loop wedged by a job it never asked about.
+            if (
+                slot.active is not None
+                and slot.active.digest == digest
+                and not slot.active.cancelled.is_set()
+            ):
                 return Submission(slot.active, joined=True)
 
             # 1. nothing in flight for this key
@@ -346,6 +399,12 @@ class JobManager:
 
     def _pump(self) -> None:
         """Start as many queued jobs as the machine-wide cap allows. Caller holds the lock."""
+        # Never start new work while shutting down. `shutdown` cancels in-flight jobs one at
+        # a time, releasing the lock between each, so without this a job finishing in that
+        # gap would promote its pending successor and launch a fresh `docker build` for a
+        # daemon that is on its way out.
+        if self._stopped:
+            return
         while self._running < self.max_builds and self._cap_queue:
             job = self._cap_queue.popleft()
             if job.finished:
@@ -355,6 +414,9 @@ class JobManager:
             self._running += 1
             job.emit(job.summary())
             thread = threading.Thread(target=self._run, args=(job,), daemon=True)
+            # Dead threads are dropped here rather than accumulating for the daemon's
+            # lifetime; an agent loop starts one per edit.
+            self._threads = [t for t in self._threads if t.is_alive()]
             self._threads.append(thread)
             thread.start()
 
@@ -414,16 +476,8 @@ class JobManager:
         result: dict[str, Any] | None = None,
     ) -> None:
         """Move a job to a terminal state exactly once and tell everyone watching."""
-        if job.finished:
+        if not job.finalize(state, error=error, returncode=returncode, result=result):
             return
-        job.state = state
-        job.ended_at = time.time()
-        job.error = error
-        job.returncode = returncode
-        if result:
-            job.result = result
-        job.done.set()
-        job.emit(job.summary(final=True))
         self._prune_history()
 
     def _prune_history(self) -> None:
@@ -478,20 +532,27 @@ class JobManager:
         retires and resources that never get collected.
         """
         now = now if now is not None else time.time()
-        expired: list[Job] = []
+        candidates: list[Job] = []
         with self._lock:
             for job in list(self._jobs.values()):
                 if job.state != RUNNING or job.started_at is None:
                     continue
-                age = now - job.started_at
-                if age > self.ttl_seconds:
-                    expired.append(job)
-        for job in expired:
+                # Already reaped: a cancelled build stays RUNNING until its builder tears
+                # down, which can take tens of seconds. Without this the watchdog reaps it
+                # again on every 0.5s tick and writes an event row each time.
+                if job.cancelled.is_set():
+                    continue
+                if now - job.started_at > self.ttl_seconds:
+                    candidates.append(job)
+
+        reaped: list[Job] = []
+        for job in candidates:
             try:
                 self.cancel(job.id, reason=f"exceeded the {self.ttl_seconds:.0f}s build TTL")
             except JobError:
                 continue  # it finished on its own between the scan and the cancel
-        return expired
+            reaped.append(job)
+        return reaped
 
     # -- observation -------------------------------------------------------
 

--- a/src/bosn/jobs.py
+++ b/src/bosn/jobs.py
@@ -70,6 +70,11 @@ DEFAULT_TTL_SECONDS = 3600.0
 # Keep the tail of a job's output for late attachers without letting a chatty build grow
 # the daemon's heap without bound.
 MAX_LOG_LINES = 5000
+# How many finished jobs stay listable and attachable. Bounding this matters for the same
+# reason the queue is bounded: an agent loop submits continuously and keeps the daemon
+# resident while it does, so "remember every job forever" is a leak that only shows up
+# under exactly the workload this design is for. Older jobs are forgotten, not their work.
+MAX_FINISHED_JOBS = 50
 
 
 def default_max_builds() -> int:
@@ -255,11 +260,13 @@ class JobManager:
         *,
         max_builds: int | None = None,
         ttl_seconds: float | None = None,
+        max_history: int = MAX_FINISHED_JOBS,
         on_settled: Callable[[], None] | None = None,
     ) -> None:
         self.builder = builder
         self.max_builds = max_builds if max_builds is not None else default_max_builds()
         self.ttl_seconds = ttl_seconds if ttl_seconds is not None else default_ttl_seconds()
+        self.max_history = max_history
         self.on_settled = on_settled
 
         self._lock = threading.RLock()
@@ -417,6 +424,22 @@ class JobManager:
             job.result = result
         job.done.set()
         job.emit(job.summary(final=True))
+        self._prune_history()
+
+    def _prune_history(self) -> None:
+        """Forget the oldest finished jobs. Caller holds the lock.
+
+        Only finished jobs are ever dropped, so this can never lose track of work that is
+        still running. A forgotten job id stops resolving, which `attach` and `cancel`
+        report as "no such job" -- the honest answer.
+        """
+        finished = [job for job in self._jobs.values() if job.finished]
+        excess = len(finished) - self.max_history
+        if excess <= 0:
+            return
+        finished.sort(key=lambda job: job.ended_at or job.created_at)
+        for job in finished[:excess]:
+            self._jobs.pop(job.id, None)
 
     # -- cancellation ------------------------------------------------------
 
@@ -511,20 +534,22 @@ class JobManager:
                 return 0
             return int(slot.active is not None) + int(slot.pending is not None)
 
-    def follow(
-        self, job: Job, *, heartbeat: float = 30.0, stop: threading.Event | None = None
-    ) -> Iterator[dict[str, Any]]:
+    def follow(self, job: Job, *, heartbeat: float = 30.0) -> Iterator[dict[str, Any]]:
         """Yield a job's events until it ends, with heartbeats so silence is not death.
 
         A cold build can go minutes without printing. Without a heartbeat the client cannot
         distinguish a quiet build from a daemon that died, and would have to choose between
         a timeout that kills long builds and one that hangs forever.
+
+        This deliberately ends only at the job's terminal event, and not on daemon
+        shutdown: shutdown cancels every in-flight job first, so waiting for the terminal
+        event is what lets an attached client be *told* it was cancelled. Bailing out on
+        the stop signal would race that message and leave the client with a bare dropped
+        connection instead of a reason.
         """
         watcher = job.watch()
         try:
             while True:
-                if stop is not None and stop.is_set():
-                    return
                 try:
                     event = watcher.get(timeout=heartbeat)
                 except queue.Empty:

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -39,6 +39,8 @@ class Options:
     # daemon
     port: int | None = None
     idle_retire_seconds: float | None = None
+    max_builds: int | None = None
+    build_ttl_seconds: float | None = None
     stop: bool = False
 
     extras: tuple[str, ...] = field(default=())
@@ -88,6 +90,8 @@ def from_namespace(ns: argparse.Namespace) -> Options:
 
     idle = get("idle_retire_seconds")
     port = get("port")
+    max_builds = get("max_builds")
+    build_ttl = get("build_ttl_seconds")
 
     return Options(
         verb=_as_str(get("verb")),
@@ -100,5 +104,7 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         dry_run=bool(get("dry_run", True)),
         port=None if port is None else int(str(port)),
         idle_retire_seconds=None if idle is None else float(str(idle)),
+        max_builds=None if max_builds is None else int(str(max_builds)),
+        build_ttl_seconds=None if build_ttl is None else float(str(build_ttl)),
         stop=bool(get("stop", False)),
     )

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -294,6 +294,12 @@ class Registry:
         )
         return cur.rowcount
 
+    def generation_recorded(self, digest: str) -> bool:
+        return (
+            self._exec("SELECT 1 FROM generations WHERE digest = ?", (digest,)).fetchone()
+            is not None
+        )
+
     def generation_superseded_at(self, digest: str) -> float | None:
         row = self._exec(
             "SELECT superseded_at FROM generations WHERE digest = ?", (digest,)

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -1,0 +1,96 @@
+"""How the CLI renders a daemon-owned job, and what it exits with.
+
+The rule under test is "fail closed, stay visible": a request that was superseded,
+cancelled, or failed must exit non-zero with a message naming what happened. Silently
+exiting 0 having done nothing is the failure this whole design is meant to rule out.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bosn import cli
+
+
+def events(*items):
+    return iter(items)
+
+
+def end(state: str, **extra):
+    return {"event": "end", "final": True, "state": state, **extra}
+
+
+# -- rendering -------------------------------------------------------------
+
+
+def test_build_output_goes_to_stderr_not_stdout(capsys) -> None:
+    """`bosn run`'s stdout belongs to the command being run, not to build noise."""
+    cli._drive_job(events({"event": "log", "line": "step 1/2"}, end("succeeded")))
+    captured = capsys.readouterr()
+    assert "step 1/2" in captured.err
+    assert captured.out == ""
+
+
+def test_joining_an_existing_build_is_announced(capsys) -> None:
+    cli._drive_job(events({"event": "submitted", "job": "j1", "joined": True}, end("succeeded")))
+    assert "joined in-flight build j1" in capsys.readouterr().err
+
+
+def test_being_queued_behind_an_obsolete_build_is_announced(capsys) -> None:
+    """The one cost of depth-1 coalescing, so the user is told about it rather than left
+    wondering why a build has not started."""
+    cli._drive_job(
+        events(
+            {"event": "submitted", "job": "j2", "joined": False, "disposition": "pending"},
+            end("succeeded"),
+        )
+    )
+    assert "queued as j2" in capsys.readouterr().err
+
+
+def test_a_stream_that_ends_without_a_result_is_an_error() -> None:
+    with pytest.raises(cli.JobFailed, match="without a result"):
+        cli._drive_job(events({"event": "log", "line": "..."}))
+
+
+# -- exit codes ------------------------------------------------------------
+
+
+def test_a_successful_job_yields_the_converge_result() -> None:
+    result = cli._result_or_raise(
+        end(
+            "succeeded",
+            result={"stack": "dev", "digest": "sha256:abc", "image_tag": "bosn/dev:abc"},
+        )
+    )
+    assert result.stack == "dev"
+    assert result.image_tag == "bosn/dev:abc"
+
+
+def test_a_superseded_request_exits_nonzero_naming_what_happened() -> None:
+    with pytest.raises(cli.JobFailed) as raised:
+        cli._result_or_raise(end("superseded", error="superseded: digest aaa replaced by bbb"))
+    assert raised.value.exit_code == cli.SUPERSEDED_EXIT
+    assert raised.value.exit_code != 0
+    assert "superseded" in str(raised.value)
+    assert "bbb" in str(raised.value), "the message must name the digest that replaced it"
+
+
+def test_a_cancelled_build_exits_with_its_own_code() -> None:
+    with pytest.raises(cli.JobFailed) as raised:
+        cli._result_or_raise(end("cancelled", error="the bosn daemon is shutting down"))
+    assert raised.value.exit_code == cli.CANCELLED_EXIT
+    assert "shutting down" in str(raised.value)
+
+
+def test_a_failed_build_exits_one() -> None:
+    with pytest.raises(cli.JobFailed) as raised:
+        cli._result_or_raise(end("failed", error="build exited 1"))
+    assert raised.value.exit_code == cli.BUILD_FAILED_EXIT
+
+
+def test_the_three_outcomes_are_distinguishable() -> None:
+    """An agent has to be able to tell 'your build broke' from 'your request was dropped'."""
+    codes = {cli.BUILD_FAILED_EXIT, cli.SUPERSEDED_EXIT, cli.CANCELLED_EXIT}
+    assert len(codes) == 3
+    assert 0 not in codes

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -77,3 +77,25 @@ def test_doctor_reports_unreachable_engine_without_crashing(capsys) -> None:
     captured = capsys.readouterr()
     assert "reachable:      no" in captured.out
     assert "not on PATH" in captured.err
+
+
+def test_stopping_a_daemon_that_was_not_running_says_so(tmp_path, capsys) -> None:
+    assert cli.main(["--state-dir", str(tmp_path), "__daemon", "--stop"]) == 0
+    assert "no daemon was running" in capsys.readouterr().out
+
+
+def test_a_daemon_still_draining_is_not_reported_as_absent(tmp_path, monkeypatch, capsys) -> None:
+    """Stopping now waits for in-flight builds, so the wait can expire on a live daemon.
+
+    Saying "no daemon was running" there would be a plainly wrong answer to the question
+    the user asked, and it would send them looking in the wrong place.
+    """
+    from bosn import daemon as daemon_mod
+
+    monkeypatch.setattr(daemon_mod, "is_serving", lambda *a, **k: True)
+    monkeypatch.setattr(daemon_mod, "stop", lambda *a, **k: False)
+
+    assert cli.main(["--state-dir", str(tmp_path), "__daemon", "--stop"]) == 1
+    err = capsys.readouterr().err
+    assert "still shutting down" in err
+    assert "bosn jobs" in err

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -9,7 +9,8 @@ from bosn import cli
 UNIMPLEMENTED = sorted(v for v, (_, phase) in cli.VERBS.items() if phase != "implemented")
 
 
-@pytest.mark.parametrize("verb", UNIMPLEMENTED)
+@pytest.mark.skipif(not UNIMPLEMENTED, reason="every designed verb is implemented")
+@pytest.mark.parametrize("verb", UNIMPLEMENTED or [""])
 def test_unimplemented_verbs_fail_with_a_specific_error(verb: str, capsys) -> None:
     code = cli.main([verb])
     assert code == cli.NOT_IMPLEMENTED_EXIT, f"{verb} must not silently succeed"
@@ -18,9 +19,50 @@ def test_unimplemented_verbs_fail_with_a_specific_error(verb: str, capsys) -> No
     assert "not implemented" in err
 
 
+def test_the_unimplemented_path_still_fails_loudly() -> None:
+    """Kept live even with nothing left to skip: a placeholder must never be a no-op."""
+    error = cli.VerbNotImplementedError("someday", "a later phase")
+    assert "someday" in str(error)
+    assert "not implemented" in str(error)
+
+
 def test_every_designed_verb_is_registered() -> None:
-    designed = {"run", "shell", "tasks", "jobs", "attach", "status", "gc", "done", "doctor"}
+    designed = {
+        "run",
+        "shell",
+        "tasks",
+        "jobs",
+        "attach",
+        "cancel",
+        "status",
+        "gc",
+        "done",
+        "doctor",
+    }
     assert designed <= set(cli.VERBS)
+
+
+def test_attach_and_cancel_are_no_longer_placeholders() -> None:
+    """Both landed with daemon-owned jobs; `attach`'s stale 'phase 6' label went with them."""
+    assert cli.VERBS["attach"][1] == "implemented"
+    assert cli.VERBS["cancel"][1] == "implemented"
+
+
+def test_attach_without_a_job_id_explains_itself(capsys) -> None:
+    assert cli.main(["attach"]) == 2
+    assert "job id" in capsys.readouterr().err
+
+
+def test_cancel_without_a_job_id_explains_itself(capsys) -> None:
+    assert cli.main(["cancel"]) == 2
+    assert "job id" in capsys.readouterr().err
+
+
+def test_cancel_fails_closed_when_no_daemon_is_running(tmp_path, capsys) -> None:
+    """No daemon means no jobs to cancel -- and never a fallback to raw Docker."""
+    code = cli.main(["--state-dir", str(tmp_path), "cancel", "j1-abc"])
+    assert code == 1
+    assert "cannot reach the bosn daemon" in capsys.readouterr().err
 
 
 def test_unknown_verb_is_rejected() -> None:

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,18 @@ class FakeEngine:
         if args[0] == "build":
             self.existing.add(args[args.index("--tag") + 1])
         return EngineResult(0, "ok", "")
+
+    def stream(
+        self,
+        args: list[str],
+        *,
+        on_line=None,
+        cancelled=None,
+    ) -> EngineResult:
+        """Builds go through stream(); record them the same way so `ran` still sees them."""
+        if on_line is not None:
+            on_line(f"fake build: {' '.join(args[:2])}")
+        return self.run(args)
 
     def ran(self, *prefix: str) -> list[list[str]]:
         return [c for c in self.commands if c[: len(prefix)] == list(prefix)]
@@ -196,6 +209,143 @@ def test_machine_scope_is_shared_across_a_family() -> None:
         family="rust",
     )
     assert one == two, "same family must share one machine-scoped volume"
+
+
+# -- workspace identity ----------------------------------------------------
+#
+# The job table keys on `(workspace-id, stack)`, so this string decides what serializes and
+# what runs in parallel. #1 blames per-worktree path-hashing for the original volume
+# explosion, which is why it is the manifest root and never the cwd.
+
+
+def test_workspace_id_is_the_manifest_root_not_the_cwd(project: Path, monkeypatch) -> None:
+    """Two agents in different subdirectories of one worktree are one workspace."""
+    from bosn.converge import workspace_of
+    from bosn.manifest import find_manifest, load
+
+    nested = project / "src" / "deep"
+    nested.mkdir(parents=True)
+
+    monkeypatch.chdir(project)
+    from_root = workspace_of(load(find_manifest()))  # type: ignore[arg-type]
+    monkeypatch.chdir(nested)
+    from_nested = workspace_of(load(find_manifest()))  # type: ignore[arg-type]
+
+    assert from_root == from_nested, "same worktree, different cwd -> one key, so they serialize"
+
+
+def test_distinct_worktrees_get_distinct_workspace_ids(tmp_path: Path) -> None:
+    """...and two worktrees must differ, or a slow build in A would block B."""
+    from bosn.converge import workspace_of
+    from bosn.manifest import load
+
+    ids = []
+    for name in ("wt-a", "wt-b"):
+        root = tmp_path / name
+        root.mkdir()
+        (root / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+        (root / "bosn.toml").write_text(SAMPLE, encoding="utf-8")
+        ids.append(workspace_of(load(root)))
+
+    assert ids[0] != ids[1]
+
+
+def test_a_non_canonical_path_to_the_same_root_is_the_same_workspace(project: Path) -> None:
+    """`..` and `.` must not be able to split one worktree into two."""
+    from bosn.converge import workspace_of
+    from bosn.manifest import load
+
+    scenic = project / "." / "src" / ".." / "bosn.toml"
+    (project / "src").mkdir(exist_ok=True)
+
+    assert workspace_of(load(project)) == workspace_of(load(scenic))
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="case-insensitive paths")
+def test_windows_path_case_does_not_split_a_workspace(project: Path) -> None:
+    from bosn.converge import workspace_of
+    from bosn.manifest import load
+
+    shouted = Path(str(project).upper())
+    assert workspace_of(load(project)) == workspace_of(load(shouted))
+
+
+def test_converge_registers_resources_under_the_canonical_workspace(
+    converger: Converger, registry: Registry
+) -> None:
+    """`bosn done` looks resources up by this id, so converge must write the same one."""
+    from bosn.converge import workspace_of
+
+    converger.converge()
+    expected = workspace_of(converger.manifest)
+    assert {r.workspace for r in registry.list_resources()} == {expected}
+
+
+# -- a cancelled build leaves nothing behind -------------------------------
+
+
+def test_a_failed_build_registers_no_image_and_no_generation(
+    project: Path, registry: Registry
+) -> None:
+    """Registration happens only after `docker build` exits 0."""
+    from bosn.engine import EngineError
+
+    class FailingEngine(FakeEngine):
+        def stream(self, args, *, on_line=None, cancelled=None) -> EngineResult:
+            self.commands.append(list(args))
+            return EngineResult(1, "", "build blew up")
+
+    with pytest.raises(EngineError):
+        Converger(load(project), registry, FailingEngine()).converge()  # type: ignore[arg-type]
+
+    assert registry.list_resources() == []
+    assert registry.conn.execute("SELECT 1 FROM generations").fetchall() == []
+
+
+def test_a_failed_build_does_not_supersede_the_working_generation(
+    project: Path, registry: Registry
+) -> None:
+    """Retention puts superseded generations on a 24h clock -- so this would collect the
+    only image that actually works, in favor of one that never got built."""
+    from bosn.engine import EngineError
+
+    good = Converger(load(project), registry, FakeEngine()).converge()  # type: ignore[arg-type]
+
+    class FailingEngine(FakeEngine):
+        def stream(self, args, *, on_line=None, cancelled=None) -> EngineResult:
+            self.commands.append(list(args))
+            return EngineResult(1, "", "nope")
+
+    (project / "Dockerfile").write_text("FROM debian\n", encoding="utf-8")
+    with pytest.raises(EngineError):
+        Converger(load(project), registry, FailingEngine()).converge()  # type: ignore[arg-type]
+
+    assert registry.generation_superseded_at(good.digest) is None
+
+
+def test_a_cancelled_build_reports_cancellation_not_a_generic_failure(
+    project: Path, registry: Registry
+) -> None:
+    import threading
+
+    from bosn.engine import EngineError
+
+    cancelled = threading.Event()
+    cancelled.set()
+
+    class CancelledEngine(FakeEngine):
+        def stream(self, args, *, on_line=None, cancelled=None) -> EngineResult:
+            self.commands.append(list(args))
+            return EngineResult(-1, "", "cancelled")
+
+    converger = Converger(
+        load(project),
+        registry,
+        CancelledEngine(),  # type: ignore[arg-type]
+        cancelled=cancelled,
+    )
+    with pytest.raises(EngineError, match="was cancelled"):
+        converger.converge()
 
 
 # -- running ---------------------------------------------------------------

--- a/tests/test_daemon_jobs.py
+++ b/tests/test_daemon_jobs.py
@@ -1,0 +1,373 @@
+"""Daemon-owned build jobs end to end: streaming, attach, cancel, and retirement.
+
+These exercise the real daemon over the real loopback protocol with a fake builder, so the
+streaming transport and the job policy are tested together without needing Docker. The
+`docker` marker covers the same ground against a real build in `test_scenario_docker.py`.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bosn import daemon as daemon_mod
+from bosn import ipc
+from bosn.daemon import Daemon
+from bosn.jobs import BuildOutcome, Job
+
+SAMPLE = """
+[stack.dev]
+dockerfile = "Dockerfile"
+family = "rust"
+default = true
+
+[stack.dev.volumes]
+target = { scope = "spec" }
+"""
+
+
+def wait_until(predicate, timeout: float = 15.0, interval: float = 0.02) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+class ControlledBuilder:
+    """A daemon builder the test can hold open and release."""
+
+    def __init__(self) -> None:
+        self.release = threading.Event()
+        self.started = threading.Event()
+        self.digests: list[str] = []
+
+    def __call__(self, job: Job) -> BuildOutcome:
+        self.digests.append(job.digest)
+        self.started.set()
+        job.log("step 1/2 : FROM alpine")
+        while not self.release.is_set():
+            if job.cancelled.is_set():
+                return BuildOutcome(returncode=130)
+            time.sleep(0.005)
+        job.log("step 2/2 : done")
+        return BuildOutcome(returncode=0, result={"stack": job.stack, "digest": job.digest})
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (root / "bosn.toml").write_text(SAMPLE, encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def builder() -> ControlledBuilder:
+    return ControlledBuilder()
+
+
+@pytest.fixture
+def served(tmp_path: Path, builder: ControlledBuilder) -> Iterator[Daemon]:
+    state_dir = tmp_path / "state"
+    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=3600)
+    daemon.jobs.builder = builder
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    assert wait_until(lambda: daemon_mod.is_serving(state_dir)), "daemon never came up"
+    try:
+        yield daemon
+    finally:
+        builder.release.set()
+        daemon.request_stop()
+        thread.join(timeout=15)
+        daemon.shutdown()
+
+
+def converge_events(daemon: Daemon, project: Path, **extra):
+    return ipc.stream_request(
+        daemon.port,
+        {"verb": "converge", "manifest": str(project / "bosn.toml"), **extra},
+        timeout=30,
+    )
+
+
+def drain(events) -> list[dict]:
+    return list(events)
+
+
+# -- streaming converge ----------------------------------------------------
+
+
+def test_converge_streams_build_output_and_a_terminal_event(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    builder.release.set()
+    events = drain(converge_events(served, project))
+
+    assert events[0]["event"] == "submitted"
+    assert any(e.get("event") == "log" and "FROM alpine" in e["line"] for e in events)
+    assert events[-1]["final"] is True
+    assert events[-1]["state"] == "succeeded"
+
+
+def test_a_second_identical_converge_joins_rather_than_rebuilding(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    stream = converge_events(served, project)
+    assert next(stream)["event"] == "submitted"
+    assert builder.started.wait(10)
+
+    joined = next(converge_events(served, project))
+    assert joined["joined"] is True, "identical in-flight work must be joined, not duplicated"
+
+    builder.release.set()
+    drain(stream)
+    assert len(builder.digests) == 1, "one build served both requests"
+
+
+def test_an_unreadable_manifest_is_reported_not_swallowed(served: Daemon, tmp_path: Path) -> None:
+    events = drain(
+        ipc.stream_request(
+            served.port,
+            {"verb": "converge", "manifest": str(tmp_path / "nope" / "bosn.toml")},
+            timeout=30,
+        )
+    )
+    assert events[-1]["ok"] is False
+    assert events[-1]["final"] is True
+
+
+# -- the job survives its client -------------------------------------------
+
+
+def test_hanging_up_mid_build_leaves_the_job_running(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    """The whole point: a killed CLI must not destroy a 20-minute build."""
+    stream = converge_events(served, project)
+    submitted = next(stream)
+    job_id = submitted["job"]
+    assert builder.started.wait(10)
+
+    stream.close()  # the client goes away, exactly as a killed CLI would
+    time.sleep(0.2)
+
+    assert served.jobs.get(job_id).state == "running", "the daemon kept the work"
+
+    listed = ipc.send_request(served.port, {"verb": "jobs"})["jobs"]
+    assert [row for row in listed if row["id"] == job_id and row["state"] == "running"]
+
+
+def test_attach_reconnects_to_a_surviving_job(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    stream = converge_events(served, project)
+    job_id = next(stream)["job"]
+    assert builder.started.wait(10)
+    stream.close()
+
+    reattached = ipc.stream_request(served.port, {"verb": "attach", "job": job_id}, timeout=30)
+    first = next(reattached)
+    assert first["event"] == "attached"
+    assert first["job"] == job_id
+    # the output produced while nobody was watching is replayed, not lost
+    assert any("FROM alpine" in e.get("line", "") for e in [next(reattached)])
+
+    builder.release.set()
+    final = [e for e in reattached if e.get("final")]
+    assert final and final[-1]["state"] == "succeeded"
+
+
+def test_rerunning_the_same_verb_reattaches_instead_of_rebuilding(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    stream = converge_events(served, project)
+    first_id = next(stream)["job"]
+    assert builder.started.wait(10)
+    stream.close()
+
+    again = next(converge_events(served, project))
+    assert again["job"] == first_id, "the re-run rejoined the surviving job"
+    assert again["joined"] is True
+
+
+def test_attaching_to_an_unknown_job_says_so(served: Daemon) -> None:
+    events = drain(ipc.stream_request(served.port, {"verb": "attach", "job": "nope"}, timeout=10))
+    assert events[-1]["ok"] is False
+    assert "no such job" in events[-1]["error"]
+
+
+# -- cancellation ----------------------------------------------------------
+
+
+def test_cancel_stops_a_running_build_and_tells_the_watcher(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    stream = converge_events(served, project)
+    job_id = next(stream)["job"]
+    assert builder.started.wait(10)
+
+    reply = ipc.send_request(served.port, {"verb": "cancel", "job": job_id})
+    assert reply["ok"]
+
+    final = [e for e in stream if e.get("final")]
+    assert final and final[-1]["state"] == "cancelled"
+    assert final[-1]["error"]
+
+
+def test_a_cancelled_build_leaves_no_generation_row(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    """A cancelled build must not imply a usable image exists."""
+    from bosn.manifest import generation_digest, load
+
+    manifest = load(project)
+    digest = generation_digest(manifest, manifest.stack(None))
+
+    stream = converge_events(served, project)
+    job_id = next(stream)["job"]
+    assert builder.started.wait(10)
+    ipc.send_request(served.port, {"verb": "cancel", "job": job_id})
+    drain(stream)
+
+    assert served.registry.generation_superseded_at(digest) is None
+    rows = served.registry.conn.execute(
+        "SELECT 1 FROM generations WHERE digest = ?", (digest,)
+    ).fetchall()
+    assert rows == [], "no generation row for a build that never completed"
+    assert served.registry.list_resources() == [], "and no image resource either"
+
+
+def test_cancelling_an_unknown_job_is_an_error(served: Daemon) -> None:
+    reply = ipc.send_request(served.port, {"verb": "cancel", "job": "j0-nope"})
+    assert reply["ok"] is False
+    assert "no such job" in reply["error"]
+
+
+# -- retirement ------------------------------------------------------------
+
+
+def test_a_running_job_blocks_idle_retirement(
+    tmp_path: Path, project: Path, builder: ControlledBuilder
+) -> None:
+    """Retiring mid-build would destroy the build; the old idle-only rule would have."""
+    state_dir = tmp_path / "state2"
+    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=0.2)
+    daemon.jobs.builder = builder
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    try:
+        assert wait_until(lambda: daemon_mod.is_serving(state_dir))
+        stream = ipc.stream_request(
+            daemon.port,
+            {"verb": "converge", "manifest": str(project / "bosn.toml")},
+            timeout=30,
+        )
+        next(stream)
+        assert builder.started.wait(10)
+        stream.close()
+
+        # Note: nothing may poll `is_serving` while waiting on retirement -- a ping is a
+        # request, and a request resets the idle clock this test is measuring.
+        time.sleep(1.0)  # comfortably past the 0.2s idle window
+        assert daemon.should_retire() is False
+        assert thread.is_alive(), "the daemon stayed up for its own build"
+
+        builder.release.set()
+        thread.join(timeout=20)
+        assert not thread.is_alive(), "with the build done, idle retirement proceeds"
+    finally:
+        builder.release.set()
+        daemon.request_stop()
+        thread.join(timeout=15)
+        daemon.shutdown()
+
+
+def test_a_job_that_never_reports_cannot_pin_the_daemon_forever(
+    tmp_path: Path, project: Path
+) -> None:
+    """The TTL is what keeps 'running jobs block retirement' from being a deadlock."""
+    hung = threading.Event()
+
+    def never_finishes(job: Job) -> BuildOutcome:
+        hung.set()
+        while not job.cancelled.is_set():
+            time.sleep(0.01)
+        return BuildOutcome(returncode=130)
+
+    state_dir = tmp_path / "state3"
+    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=0.2, build_ttl_seconds=0.5)
+    daemon.jobs.builder = never_finishes
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    try:
+        assert wait_until(lambda: daemon_mod.is_serving(state_dir))
+        stream = ipc.stream_request(
+            daemon.port,
+            {"verb": "converge", "manifest": str(project / "bosn.toml")},
+            timeout=30,
+        )
+        next(stream)
+        assert hung.wait(10)
+        stream.close()
+
+        # The TTL reaps the hung build, and only then can idle retirement proceed. Waiting
+        # on the thread rather than polling `is_serving`, whose ping would reset the clock.
+        thread.join(timeout=30)
+        assert not thread.is_alive(), "a hung build must not pin the daemon forever"
+    finally:
+        daemon.request_stop()
+        thread.join(timeout=15)
+        daemon.shutdown()
+
+
+def test_shutdown_tells_attached_clients_why_their_build_stopped(
+    tmp_path: Path, project: Path, builder: ControlledBuilder
+) -> None:
+    state_dir = tmp_path / "state4"
+    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=3600)
+    daemon.jobs.builder = builder
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    assert wait_until(lambda: daemon_mod.is_serving(state_dir))
+
+    stream = ipc.stream_request(
+        daemon.port, {"verb": "converge", "manifest": str(project / "bosn.toml")}, timeout=30
+    )
+    job_id = next(stream)["job"]
+    assert builder.started.wait(10)
+
+    daemon.request_stop()
+    thread.join(timeout=15)
+    daemon.shutdown()
+
+    job = daemon.jobs.get(job_id)
+    assert job.state == "cancelled"
+    assert job.error is not None and "shutting down" in job.error
+
+
+# -- reporting -------------------------------------------------------------
+
+
+def test_jobs_verb_reports_real_jobs_not_a_placeholder(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    reply = ipc.send_request(served.port, {"verb": "jobs"})
+    assert reply["jobs"] == []
+    assert reply["max_builds"] >= 1
+
+    stream = converge_events(served, project)
+    job_id = next(stream)["job"]
+    assert builder.started.wait(10)
+
+    listed = ipc.send_request(served.port, {"verb": "jobs"})["jobs"]
+    assert [row for row in listed if row["id"] == job_id]
+    assert listed[0]["stack"] == "dev"
+    stream.close()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -424,6 +424,127 @@ def test_follow_heartbeats_so_a_quiet_build_is_not_mistaken_for_a_dead_daemon(
     assert any(e["event"] == "heartbeat" for e in seen)
 
 
+# -- regressions -----------------------------------------------------------
+
+
+def test_the_terminal_transition_is_atomic_against_watch(manager: JobManager) -> None:
+    """A job must never be observable as "terminal but not yet filled in".
+
+    `watch()` branches on the job's state: terminal means "hand back the summary and do not
+    register". So if the transition set the state first and the fields after, a `watch()`
+    landing between them would synthesize a summary with no returncode, no error and an
+    empty result -- and, having taken the terminal branch, would never be registered for
+    the real event. The client is told its build succeeded and handed an empty
+    ConvergeResult, which downstream becomes `docker run` against an empty image tag.
+
+    Racing that window directly is hopeless -- it is a handful of statements wide, and an
+    earlier version of this test ran 200 attempts without once landing in it. So this tests
+    the property instead: hold the lock `watch()` uses, and no part of the transition may
+    become visible while it is held.
+    """
+    job = submit(manager, "sha256:atomic").job
+    assert wait_until(lambda: job.state == RUNNING)
+
+    finalized = threading.Thread(
+        target=job.finalize,
+        args=(SUCCEEDED,),
+        kwargs={"error": None, "returncode": 0, "result": {"digest": "sha256:atomic"}},
+        daemon=True,
+    )
+    with job._lock:
+        finalized.start()
+        time.sleep(0.1)  # ample time for an unsynchronized write to land
+        assert job.state == RUNNING, "state changed while the watch() lock was held"
+        assert job.result == {}, "fields were written outside the lock"
+
+    finalized.join(timeout=5)
+    assert job.state == SUCCEEDED
+    assert job.result == {"digest": "sha256:atomic"}
+    assert job.returncode == 0
+
+
+def test_a_watcher_registered_before_the_job_settles_gets_the_complete_event(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    """And the other ordering: a watcher already attached receives the full terminal event."""
+    job = submit(manager, "sha256:watched").job
+    assert wait_until(lambda: job.state == RUNNING)
+    watcher = job.watch()
+
+    builder.release.set()
+    assert wait_until(lambda: job.finished)
+
+    events = []
+    while True:
+        event = watcher.get(timeout=5)
+        events.append(event)
+        if event.get("final"):
+            break
+    assert events[-1]["state"] == SUCCEEDED
+    assert events[-1]["result"] == {"digest": "sha256:watched"}
+    assert events[-1]["returncode"] == 0
+
+
+def test_a_watcher_arriving_after_the_job_settles_gets_the_complete_event(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    """...as does one that shows up late, which is what `bosn attach` does."""
+    job = submit(manager, "sha256:late").job
+    builder.release.set()
+    assert wait_until(lambda: job.finished)
+
+    watcher = job.watch()
+    events = []
+    while not watcher.empty():
+        events.append(watcher.get_nowait())
+    assert events[-1]["final"] is True
+    assert events[-1]["result"] == {"digest": "sha256:late"}
+    assert events[-1]["returncode"] == 0
+
+
+def test_a_new_request_does_not_join_a_job_that_is_already_being_cancelled(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    """A cancelled build stays RUNNING until its builder tears down.
+
+    Joining it would hand the newcomer the corpse's CANCELLED event -- so `bosn cancel`
+    followed by `bosn run` would build nothing and exit 5, and after a TTL reap of a build
+    that ignores the kill, every subsequent run for that digest would do the same.
+    """
+    doomed = submit(manager, "sha256:doomed").job
+    assert wait_until(lambda: doomed.state == RUNNING)
+
+    doomed.cancelled.set()  # cancelled, but the builder has not noticed yet
+    assert doomed.state == RUNNING
+
+    again = submit(manager, "sha256:doomed")
+    assert not again.joined, "a dying job must not be joined"
+    assert again.job is not doomed
+    assert again.job.state == PENDING
+
+    builder.release.set()
+    assert wait_until(lambda: again.job.finished)
+    assert again.job.state == SUCCEEDED, "the newcomer got its own real build"
+
+
+def test_the_ttl_reaper_does_not_re_reap_a_build_that_is_still_dying(
+    builder: SlowBuilder,
+) -> None:
+    """reap_expired runs twice a second; a cancelled build can take tens of seconds to go."""
+    manager = JobManager(builder, max_builds=2, ttl_seconds=0.1)
+    job = manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:wedged").job
+    try:
+        assert wait_until(lambda: job.state == RUNNING)
+        time.sleep(0.2)
+
+        assert manager.reap_expired() == [job], "the first pass reaps it"
+        job.state = RUNNING  # simulate a builder that has not torn down yet
+        assert manager.reap_expired() == [], "later passes must not reap it again"
+    finally:
+        job.state = CANCELLED
+        manager.shutdown(timeout=5)
+
+
 # -- reporting -------------------------------------------------------------
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -438,6 +438,42 @@ def test_list_jobs_reports_state_for_every_job(manager: JobManager, builder: Slo
     assert listed[running.id]["workspace"] == WORKSPACE
 
 
+def test_finished_jobs_do_not_accumulate_forever(builder: SlowBuilder) -> None:
+    """An agent loop keeps the daemon resident, so unbounded job history is a real leak."""
+    manager = JobManager(builder, max_builds=4, ttl_seconds=3600, max_history=5)
+    builder.release.set()
+    try:
+        jobs = []
+        for edit in range(20):
+            job = manager.submit(workspace=WORKSPACE, stack=STACK, digest=f"sha256:{edit:064x}").job
+            jobs.append(job)
+            assert wait_until(lambda j=job: j.finished or j.state == PENDING)
+        assert wait_until(lambda: manager.active_count() == 0)
+
+        assert len(manager.list_jobs()) <= 5, "old jobs must be forgotten"
+        newest = manager.list_jobs()[-1]
+        assert newest["id"] == jobs[-1].id, "the most recent job is the one kept"
+    finally:
+        manager.shutdown(timeout=5)
+
+
+def test_pruning_never_forgets_a_running_job(builder: SlowBuilder) -> None:
+    """Forgetting live work would lose the daemon's own build."""
+    manager = JobManager(builder, max_builds=4, ttl_seconds=3600, max_history=1)
+    try:
+        live = manager.submit(workspace="/w/live", stack=STACK, digest="sha256:live").job
+        assert wait_until(lambda: live.state == RUNNING)
+
+        for edit in range(5):
+            other = manager.submit(workspace=f"/w/{edit}", stack=STACK, digest=f"sha256:{edit}").job
+            manager.cancel(other.id)
+
+        assert manager.get(live.id) is live, "the running job survived every prune"
+        assert live.state == RUNNING
+    finally:
+        manager.shutdown(timeout=5)
+
+
 def test_a_builder_that_raises_fails_its_job_and_not_the_daemon() -> None:
     def explode(job: Job) -> BuildOutcome:
         raise RuntimeError("builder blew up")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,455 @@
+"""The build-job concurrency policy: coalesce with queue depth 1, joining by digest.
+
+The bug being pinned is the agent edit loop. An agent edits a Dockerfile and re-runs every
+30 seconds; each edit is a new digest against the same `(workspace, stack)` key. Identical
+requests join and distinct keys parallelize, but *same key, different digest* is neither --
+under plain serialization it queues, and the queue has no bound. Every entry but the last
+is obsolete on arrival, each pins volumes against GC, and running jobs block the daemon's
+idle retirement, so the runaway loop keeps the daemon resident and its resources
+uncollectable at once.
+
+`test_unbounded_serialization_is_the_failure_mode` runs that loop against a reference model
+of the rejected design and shows the queue growing without bound. Everything after it runs
+the same loop against the real JobManager and shows the bound holding.
+
+No Docker here -- the builder is a fake whose completion the test controls.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+import pytest
+
+from bosn.jobs import (
+    CANCELLED,
+    PENDING,
+    QUEUED,
+    RUNNING,
+    SUCCEEDED,
+    SUPERSEDED,
+    BuildOutcome,
+    Job,
+    JobError,
+    JobManager,
+)
+
+WORKSPACE = "/w/one"
+STACK = "dev"
+
+
+def wait_until(predicate, timeout: float = 10.0, interval: float = 0.01) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+class SlowBuilder:
+    """A build that does not finish until the test says so."""
+
+    def __init__(self) -> None:
+        self.release = threading.Event()
+        self.started: list[str] = []
+        self.finished: list[str] = []
+        self._lock = threading.Lock()
+
+    def __call__(self, job: Job) -> BuildOutcome:
+        with self._lock:
+            self.started.append(job.digest)
+        job.log(f"building {job.digest}")
+        while not self.release.is_set():
+            if job.cancelled.is_set():
+                return BuildOutcome(returncode=130)
+            time.sleep(0.005)
+        with self._lock:
+            self.finished.append(job.digest)
+        return BuildOutcome(returncode=0, result={"digest": job.digest})
+
+    def running_count(self) -> int:
+        with self._lock:
+            return len(self.started) - len(self.finished)
+
+
+@pytest.fixture
+def builder() -> SlowBuilder:
+    return SlowBuilder()
+
+
+@pytest.fixture
+def manager(builder: SlowBuilder):
+    mgr = JobManager(builder, max_builds=4, ttl_seconds=3600)
+    try:
+        yield mgr
+    finally:
+        mgr.shutdown(timeout=5)
+
+
+def submit(manager: JobManager, digest: str, *, workspace: str = WORKSPACE, stack: str = STACK):
+    return manager.submit(workspace=workspace, stack=stack, digest=digest)
+
+
+# -- RED: the design we rejected -------------------------------------------
+
+
+class UnboundedSerializer:
+    """Option D, the failure mode: same key serializes, and the queue has no bound.
+
+    This is what §13 literally said before this work, modeled just closely enough to show
+    what the edit loop does to it. It exists so the bound below is a measured improvement
+    over a real alternative rather than an assertion about itself.
+    """
+
+    def __init__(self) -> None:
+        self.queues: dict[tuple[str, str], deque[str]] = {}
+
+    def submit(self, key: tuple[str, str], digest: str) -> None:
+        queue = self.queues.setdefault(key, deque())
+        if digest in queue:
+            return  # identical in-flight requests join
+        queue.append(digest)
+
+    def depth(self, key: tuple[str, str]) -> int:
+        return len(self.queues.get(key, ()))
+
+
+def test_unbounded_serialization_is_the_failure_mode() -> None:
+    """The rejected design: 50 edits become 50 queued builds, 49 of them already obsolete."""
+    serializer = UnboundedSerializer()
+    key = (WORKSPACE, STACK)
+    for edit in range(50):
+        serializer.submit(key, f"sha256:{edit:064x}")
+
+    assert serializer.depth(key) == 50, "this is the pile-up the policy has to prevent"
+
+
+# -- GREEN: the bound the policy guarantees --------------------------------
+
+
+def test_the_edit_loop_never_exceeds_one_running_and_one_pending(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    """The same 50 edits, under the real policy. The bound is structural, not tuned."""
+    for edit in range(50):
+        submit(manager, f"sha256:{edit:064x}")
+        assert manager.depth(WORKSPACE, STACK) <= 2, f"queue grew past the bound at edit {edit}"
+
+    assert manager.depth(WORKSPACE, STACK) == 2
+    assert builder.running_count() == 1, "exactly one build is burning CPU, not 50"
+
+    builder.release.set()
+    assert wait_until(lambda: manager.depth(WORKSPACE, STACK) == 0)
+    # One obsolete build plus the newest one -- never the 48 in between.
+    assert builder.finished == ["sha256:" + f"{0:064x}", "sha256:" + f"{49:064x}"]
+
+
+def test_only_the_newest_digest_survives_the_loop(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    jobs = [submit(manager, f"sha256:{edit:064x}").job for edit in range(10)]
+    builder.release.set()
+    assert wait_until(lambda: all(j.finished for j in jobs))
+
+    survivors = [j for j in jobs if j.state == SUCCEEDED]
+    digests = {j.digest for j in survivors}
+    assert f"sha256:{9:064x}" in digests, "the newest request must be the one that converges"
+
+
+def test_every_dropped_request_is_told_it_was_superseded(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    """No silent no-ops: a dropped request ends in a terminal state naming what happened."""
+    first = submit(manager, "sha256:aaa").job  # starts building
+    dropped = submit(manager, "sha256:bbb").job  # takes the pending slot
+    newest = submit(manager, "sha256:ccc").job  # replaces it
+
+    assert dropped.state == SUPERSEDED
+    assert dropped.error is not None
+    assert "superseded" in dropped.error
+    assert "aaa"[:12] in dropped.error or "bbb" in dropped.error
+    assert "ccc" in dropped.error, "the message must name the digest that replaced it"
+    assert dropped.done.is_set(), "a superseded job must not leave its client hanging"
+    assert first.state == RUNNING
+    assert newest.state == PENDING
+
+
+def test_a_superseded_job_notifies_the_client_watching_it(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    submit(manager, "sha256:aaa")
+    dropped = submit(manager, "sha256:bbb").job
+    watcher = dropped.watch()  # a client is attached, waiting for its build to start
+
+    submit(manager, "sha256:ccc")  # ...and a newer edit takes the slot out from under it
+
+    event = watcher.get(timeout=5)
+    assert event["final"] is True
+    assert event["state"] == SUPERSEDED
+    assert "superseded" in event["error"]
+
+
+def test_identical_digests_join_instead_of_building_twice(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    first = submit(manager, "sha256:same")
+    second = submit(manager, "sha256:same")
+    third = submit(manager, "sha256:same")
+
+    assert second.joined and third.joined
+    assert second.job is first.job is third.job
+    assert manager.depth(WORKSPACE, STACK) == 1
+    assert builder.started == ["sha256:same"], "one build, three watchers"
+
+
+def test_a_second_identical_request_joins_the_pending_slot(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    """Joining applies to the queued request too, not just the running one."""
+    submit(manager, "sha256:running")
+    pending = submit(manager, "sha256:next").job
+    again = submit(manager, "sha256:next")
+
+    assert again.joined and again.job is pending
+    assert manager.depth(WORKSPACE, STACK) == 2
+
+
+def test_the_pending_job_starts_when_the_active_one_finishes(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    active = submit(manager, "sha256:first").job
+    pending = submit(manager, "sha256:second").job
+    assert pending.state == PENDING
+
+    builder.release.set()
+    assert wait_until(lambda: active.finished and pending.finished)
+    assert pending.state == SUCCEEDED
+    assert builder.started == ["sha256:first", "sha256:second"]
+
+
+# -- parallelism across keys -----------------------------------------------
+
+
+def test_distinct_keys_build_in_parallel(manager: JobManager, builder: SlowBuilder) -> None:
+    """A slow build in worktree A must never block worktree B."""
+    a = submit(manager, "sha256:a", workspace="/w/a").job
+    b = submit(manager, "sha256:b", workspace="/w/b").job
+
+    assert wait_until(lambda: a.state == RUNNING and b.state == RUNNING)
+    assert builder.running_count() == 2, "neither worktree waits on the other"
+
+
+def test_the_same_workspace_with_different_stacks_also_parallelizes(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    a = submit(manager, "sha256:a", stack="dev").job
+    b = submit(manager, "sha256:b", stack="ci").job
+    assert wait_until(lambda: a.state == RUNNING and b.state == RUNNING)
+
+
+def test_the_machine_wide_cap_bounds_total_concurrency(builder: SlowBuilder) -> None:
+    """Per-key serialization does not bound host load; N worktrees still can. This does."""
+    manager = JobManager(builder, max_builds=2, ttl_seconds=3600)
+    try:
+        jobs = [
+            manager.submit(workspace=f"/w/{i}", stack=STACK, digest=f"sha256:{i}").job
+            for i in range(6)
+        ]
+        assert wait_until(lambda: builder.running_count() == 2)
+        time.sleep(0.1)
+        assert builder.running_count() == 2, "the cap must hold, not just start out right"
+        assert sum(1 for j in jobs if j.state == QUEUED) == 4
+
+        builder.release.set()
+        assert wait_until(lambda: all(j.finished for j in jobs), timeout=15)
+        assert all(j.state == SUCCEEDED for j in jobs), "capped jobs run later, not never"
+    finally:
+        manager.shutdown(timeout=5)
+
+
+# -- cancellation ----------------------------------------------------------
+
+
+def test_cancelling_a_running_build_stops_it(manager: JobManager, builder: SlowBuilder) -> None:
+    job = submit(manager, "sha256:slow").job
+    assert wait_until(lambda: job.state == RUNNING)
+
+    manager.cancel(job.id)
+    assert wait_until(lambda: job.finished)
+    assert job.state == CANCELLED
+    assert job.error is not None
+
+
+def test_cancelling_a_pending_job_never_starts_it(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    submit(manager, "sha256:running")
+    pending = submit(manager, "sha256:pending").job
+
+    manager.cancel(pending.id)
+    assert pending.state == CANCELLED
+    assert manager.depth(WORKSPACE, STACK) == 1
+    assert "sha256:pending" not in builder.started
+
+
+def test_cancelling_the_active_job_promotes_the_pending_one(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    active = submit(manager, "sha256:active").job
+    pending = submit(manager, "sha256:pending").job
+    assert wait_until(lambda: active.state == RUNNING)
+
+    manager.cancel(active.id)
+    assert wait_until(lambda: pending.state == RUNNING)
+
+
+def test_cancelling_an_unknown_job_is_an_error_not_a_no_op(manager: JobManager) -> None:
+    with pytest.raises(JobError, match="no such job"):
+        manager.cancel("j999-nope")
+
+
+def test_cancelling_a_finished_job_says_so(manager: JobManager, builder: SlowBuilder) -> None:
+    job = submit(manager, "sha256:x").job
+    builder.release.set()
+    assert wait_until(lambda: job.finished)
+    with pytest.raises(JobError, match="already finished"):
+        manager.cancel(job.id)
+
+
+# -- liveness --------------------------------------------------------------
+
+
+def test_a_hung_build_is_reaped_by_its_ttl(builder: SlowBuilder) -> None:
+    """A job that never reports would otherwise pin the daemon forever."""
+    manager = JobManager(builder, max_builds=2, ttl_seconds=0.2)
+    try:
+        job = manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:hung").job
+        assert wait_until(lambda: job.state == RUNNING)
+        time.sleep(0.3)
+
+        assert manager.reap_expired() == [job]
+        assert wait_until(lambda: job.finished)
+        assert job.state == CANCELLED
+        assert job.error is not None and "TTL" in job.error
+        assert manager.active_count() == 0, "the daemon can retire again"
+    finally:
+        manager.shutdown(timeout=5)
+
+
+def test_a_healthy_build_is_not_reaped(manager: JobManager, builder: SlowBuilder) -> None:
+    job = submit(manager, "sha256:fine").job
+    assert wait_until(lambda: job.state == RUNNING)
+    assert manager.reap_expired() == []
+    assert job.state == RUNNING
+
+
+def test_active_count_tracks_work_the_daemon_must_not_abandon(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    assert manager.active_count() == 0
+    submit(manager, "sha256:one")
+    submit(manager, "sha256:two")
+    assert manager.active_count() == 2
+
+    builder.release.set()
+    assert wait_until(lambda: manager.active_count() == 0)
+
+
+def test_shutdown_cancels_in_flight_work_visibly(builder: SlowBuilder) -> None:
+    manager = JobManager(builder, max_builds=2, ttl_seconds=3600)
+    job = manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:x").job
+    assert wait_until(lambda: job.state == RUNNING)
+
+    manager.shutdown(timeout=5)
+    assert job.state == CANCELLED
+    assert job.error is not None and "shutting down" in job.error
+    with pytest.raises(JobError, match="shutting down"):
+        manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:y")
+
+
+# -- watching --------------------------------------------------------------
+
+
+def test_a_late_watcher_still_sees_the_output_it_missed(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    """This is what makes reattaching after a killed CLI useful rather than a blank screen."""
+    job = submit(manager, "sha256:noisy").job
+    assert wait_until(lambda: any(True for _ in [job]) and job.state == RUNNING)
+    assert wait_until(lambda: len(job._log) > 0)
+
+    watcher = job.watch()
+    first = watcher.get(timeout=5)
+    assert first["event"] == "log"
+    assert "building" in first["line"]
+
+
+def test_watching_a_finished_job_yields_its_terminal_event(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    job = submit(manager, "sha256:done").job
+    builder.release.set()
+    assert wait_until(lambda: job.finished)
+
+    events = []
+    watcher = job.watch()
+    while not watcher.empty():
+        events.append(watcher.get_nowait())
+    assert events[-1]["final"] is True
+    assert events[-1]["state"] == SUCCEEDED
+
+
+def test_follow_ends_at_the_terminal_event(manager: JobManager, builder: SlowBuilder) -> None:
+    job = submit(manager, "sha256:follow").job
+    builder.release.set()
+    seen = [event for event in manager.follow(job, heartbeat=5.0)]
+    assert seen[-1]["final"] is True
+    assert seen[-1]["state"] == SUCCEEDED
+    assert seen[-1]["result"] == {"digest": "sha256:follow"}
+
+
+def test_follow_heartbeats_so_a_quiet_build_is_not_mistaken_for_a_dead_daemon(
+    manager: JobManager, builder: SlowBuilder
+) -> None:
+    job = submit(manager, "sha256:quiet").job
+    events = manager.follow(job, heartbeat=0.05)
+    seen = []
+    for event in events:
+        seen.append(event)
+        if len(seen) >= 3:
+            break
+    assert any(e["event"] == "heartbeat" for e in seen)
+
+
+# -- reporting -------------------------------------------------------------
+
+
+def test_list_jobs_reports_state_for_every_job(manager: JobManager, builder: SlowBuilder) -> None:
+    running = submit(manager, "sha256:r").job
+    pending = submit(manager, "sha256:p").job
+    listed = {row["id"]: row for row in manager.list_jobs()}
+
+    assert listed[running.id]["state"] == RUNNING
+    assert listed[pending.id]["state"] == PENDING
+    assert listed[running.id]["stack"] == STACK
+    assert listed[running.id]["workspace"] == WORKSPACE
+
+
+def test_a_builder_that_raises_fails_its_job_and_not_the_daemon() -> None:
+    def explode(job: Job) -> BuildOutcome:
+        raise RuntimeError("builder blew up")
+
+    manager = JobManager(explode, max_builds=2, ttl_seconds=3600)
+    try:
+        job = manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:boom").job
+        assert wait_until(lambda: job.finished)
+        assert job.state == "failed"
+        assert job.error is not None and "builder blew up" in job.error
+
+        later = manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:after").job
+        assert wait_until(lambda: later.finished), "the manager keeps serving after a crash"
+    finally:
+        manager.shutdown(timeout=5)

--- a/tests/test_jobs_docker.py
+++ b/tests/test_jobs_docker.py
@@ -1,0 +1,198 @@
+"""Daemon-owned builds against a real engine: the policy holds with real `docker build`.
+
+The unit tests pin the policy with a fake builder. This one proves the same thing survives
+contact with BuildKit -- real build output streams to an attached client, a real build
+outlives the client that asked for it, and the coalescing bound holds when the "slow build"
+is genuinely slow rather than an Event the test controls.
+
+Docker-marked: Linux CI only.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bosn import daemon as daemon_mod
+from bosn import ipc, labels
+from bosn.daemon import Daemon
+from bosn.engine import Engine
+
+pytestmark = pytest.mark.docker
+
+# `sleep` in the build makes the cold build slow enough to submit against while it runs.
+MANIFEST = """
+[stack.test]
+dockerfile = "Dockerfile"
+family = "jobs"
+default = true
+"""
+
+
+def wait_until(predicate, timeout: float = 120.0, interval: float = 0.05) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+@pytest.fixture
+def engine() -> Engine:
+    return Engine()
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "bosn.toml").write_text(MANIFEST, encoding="utf-8")
+    write_dockerfile(root, seconds=4)
+    return root
+
+
+def write_dockerfile(root: Path, *, seconds: int, marker: str | None = None) -> None:
+    """A fresh marker on every write, so each edit is a genuinely new generation digest."""
+    marker = marker or uuid.uuid4().hex[:8]
+    (root / "Dockerfile").write_text(
+        f"FROM alpine:3.20\nRUN echo {marker} > /marker && sleep {seconds}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def served(tmp_path: Path) -> Iterator[Daemon]:
+    state_dir = tmp_path / "state"
+    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=3600)
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    assert wait_until(lambda: daemon_mod.is_serving(state_dir), timeout=30)
+    try:
+        yield daemon
+    finally:
+        daemon.request_stop()
+        thread.join(timeout=30)
+        daemon.shutdown()
+        _remove_built_images(Engine())
+
+
+def _remove_built_images(engine: Engine) -> None:
+    listed = engine.run(["image", "ls", "--filter", f"label={labels.REGISTRY}", "--quiet"])
+    for image_id in {line.strip() for line in listed.stdout.splitlines() if line.strip()}:
+        engine.run(["image", "rm", "--force", image_id])
+
+
+def converge(daemon: Daemon, project: Path, timeout: float = 300.0):
+    return ipc.stream_request(
+        daemon.port,
+        {"verb": "converge", "manifest": str(project / "bosn.toml")},
+        timeout=timeout,
+    )
+
+
+def test_a_real_build_streams_and_registers(served: Daemon, project: Path) -> None:
+    events = list(converge(served, project))
+
+    assert events[0]["event"] == "submitted"
+    assert any(e.get("event") == "log" for e in events), "real build output must stream"
+    final = events[-1]
+    assert final["final"] is True and final["state"] == "succeeded", final.get("error")
+    assert final["result"]["image_tag"].startswith("bosn/test:")
+
+    kinds = sorted(r.kind for r in served.registry.list_resources())
+    assert "image" in kinds
+
+
+def test_a_real_build_outlives_the_client_that_asked_for_it(served: Daemon, project: Path) -> None:
+    """The failure this whole design exists to fix: a killed CLI must not kill the build."""
+    stream = converge(served, project)
+    job_id = next(stream)["job"]
+    assert wait_until(lambda: served.jobs.get(job_id).state == "running", timeout=30)
+
+    stream.close()  # the CLI dies mid-build
+    time.sleep(0.5)
+    assert served.jobs.get(job_id).state == "running", "the daemon kept building"
+
+    # ...and a re-run reattaches to it rather than starting a second build
+    reattached = ipc.stream_request(served.port, {"verb": "attach", "job": job_id}, timeout=300)
+    assert next(reattached)["event"] == "attached"
+    final = [e for e in reattached if e.get("final")][-1]
+    assert final["state"] == "succeeded", final.get("error")
+
+
+def test_the_edit_loop_bound_holds_against_real_builds(served: Daemon, project: Path) -> None:
+    """Ten edits in a tight loop against one key: at most one running, one pending."""
+    streams = []
+    for _ in range(10):
+        write_dockerfile(project, seconds=4)
+        streams.append(converge(served, project))
+        next(streams[-1])  # the submitted event
+        active = [j for j in served.jobs.list_jobs() if j["state"] in {"running", "queued"}]
+        pending = [j for j in served.jobs.list_jobs() if j["state"] == "pending"]
+        assert len(active) <= 1 and len(pending) <= 1, "the queue grew past the bound"
+
+    finals = [[e for e in stream if e.get("final")][-1] for stream in streams]
+    states = [event["state"] for event in finals]
+
+    assert states[-1] == "succeeded", "the newest edit must be the one that converged"
+    assert set(states) <= {"succeeded", "superseded"}, states
+    # Exact counts depend on how fast BuildKit gets through a layer, so the assertion is the
+    # bound rather than a schedule: the loop cannot produce more builds than the policy
+    # allows, however the timing falls.
+    assert states.count("succeeded") <= 2, "at most the in-flight build plus the newest one"
+    assert states.count("superseded") >= 7, "the obsolete requests were dropped, and told so"
+    for event in finals:
+        if event["state"] == "superseded":
+            assert "superseded" in (event["error"] or ""), "a dropped request must say why"
+
+    images = [r for r in served.registry.list_resources() if r.kind == "image"]
+    assert len(images) == states.count("succeeded"), "no image without a completed build"
+
+
+def test_cancelling_a_real_build_leaves_no_generation_row(served: Daemon, project: Path) -> None:
+    from bosn.manifest import generation_digest, load
+
+    manifest = load(project)
+    digest = generation_digest(manifest, manifest.stack(None))
+
+    stream = converge(served, project)
+    job_id = next(stream)["job"]
+    assert wait_until(lambda: served.jobs.get(job_id).state == "running", timeout=30)
+
+    assert ipc.send_request(served.port, {"verb": "cancel", "job": job_id})["ok"]
+    final = [e for e in stream if e.get("final")][-1]
+    assert final["state"] == "cancelled"
+
+    rows = served.registry.conn.execute(
+        "SELECT 1 FROM generations WHERE digest = ?", (digest,)
+    ).fetchall()
+    assert rows == [], "a cancelled build must not imply a usable image"
+    assert [r for r in served.registry.list_resources() if r.kind == "image"] == []
+
+
+def test_two_workspaces_build_in_parallel(served: Daemon, tmp_path: Path) -> None:
+    """A slow build in worktree A never blocks worktree B."""
+    roots = []
+    for name in ("wt-a", "wt-b"):
+        root = tmp_path / name
+        root.mkdir()
+        (root / "bosn.toml").write_text(MANIFEST, encoding="utf-8")
+        write_dockerfile(root, seconds=6)
+        roots.append(root)
+
+    streams = [converge(served, root) for root in roots]
+    ids = [next(stream)["job"] for stream in streams]
+
+    assert wait_until(
+        lambda: all(served.jobs.get(i).state == "running" for i in ids), timeout=60
+    ), "both worktrees must be building at once"
+
+    for stream in streams:
+        final = [e for e in stream if e.get("final")][-1]
+        assert final["state"] == "succeeded", final.get("error")

--- a/tests/test_jobs_docker.py
+++ b/tests/test_jobs_docker.py
@@ -196,3 +196,39 @@ def test_two_workspaces_build_in_parallel(served: Daemon, tmp_path: Path) -> Non
     for stream in streams:
         final = [e for e in stream if e.get("final")][-1]
         assert final["state"] == "succeeded", final.get("error")
+
+
+# -- the whole path, through the CLI ---------------------------------------
+
+
+@pytest.mark.slow
+def test_bosn_run_converges_through_the_daemon_then_runs_locally(
+    tmp_path: Path, project: Path, capsys
+) -> None:
+    """`bosn run` end to end: a real spawned daemon builds, this process runs the command.
+
+    The split is the design -- the daemon owns the build so it survives a killed CLI, and
+    the CLI runs the container itself so the command keeps this terminal and exit status.
+    Everything else here mocks one side or the other; this is the only test that exercises
+    the seam the way a user does.
+    """
+    from bosn import cli
+
+    write_dockerfile(project, seconds=0)
+    state_dir = tmp_path / "cli-state"
+    args = ["--state-dir", str(state_dir), "run", "--manifest", str(project / "bosn.toml")]
+    try:
+        code = cli.main([*args, "--", "echo", "hello-from-the-stack"])
+        assert code == 0, capsys.readouterr().err
+        assert "hello-from-the-stack" in capsys.readouterr().out
+
+        # ...and the second run reuses the image rather than rebuilding it
+        assert cli.main([*args, "--", "echo", "again"]) == 0
+        assert "again" in capsys.readouterr().out
+
+        listed = daemon_mod.request("jobs", state_dir)["jobs"]
+        assert listed, "the converge really did go through the daemon"
+        assert all(row["state"] == "succeeded" for row in listed), listed
+    finally:
+        daemon_mod.stop(state_dir, timeout=60)
+        _remove_built_images(Engine())


### PR DESCRIPTION
Implements #12. Cold builds move behind the daemon so a killed CLI no longer destroys a 20-minute build.

## The policy

Moving builds into the daemon alone would create a worse failure than the one it fixes: the daemon owns work that outlives its requester, and bosn's primary consumer is an agent in an edit-and-rerun loop whose every edit is a new digest against the same key. Those requests neither join (not identical) nor parallelize (same key), so plain serialization queues them without bound — every entry but the last obsolete on arrival, each pinning volumes against GC while blocking idle retirement.

**Per `(workspace-id, stack)`: at most one running build and one pending request, joining by digest.** Bounded and livelock-free by construction; the worst case is waiting out one obsolete build, which warms BuildKit's layer cache for the one that follows. Cancel-and-replace and fail-fast are rejected in `jobs.py`'s docstring with their reasons, so the decision does not have to be re-litigated at the next edit.

The consequence worth naming: superseding only ever drops a **not-yet-started** entry, so cancellation is never on the hot path. Stopping a running build stays deliberate — `bosn cancel`, daemon shutdown, or the per-job TTL.

## Two bugs found on the way

Neither is part of the feature; both are pre-existing and load-bearing for its acceptance criteria.

- **`converge` recorded the generation and superseded its siblings *before* building.** Retention puts superseded generations on a 24-hour collection clock, so one failed build marked the previous *working* image for early collection in favor of an image that never got built. Nothing about a generation is written now until `docker build` exits 0 — which is also what makes "a cancelled build leaves no generation row" true rather than aspirational.
- **`bosn done` and `converge` disagreed on the workspace key.** `done` looked resources up by a raw `manifest.root` while converge registered them under the resolved path, so the two could silently miss each other. `workspace_of` is now canonical (`resolve()` + `normcase`) and both use it.

A third was caught by a test during development: streaming verbs are generators, so guarding only the `dispatch_stream` *call* let a bad manifest or unknown job id hang the connection up with no message at all. The whole iteration is guarded now.

## What's in it

- `jobs.py` — the job table and policy: depth-1 coalescing, join-by-digest, machine-wide cap (`max(2, cpus/2)`, `BOSN_MAX_BUILDS`), per-job TTL (`BOSN_BUILD_TTL_SECONDS`), watch/replay for late attachers.
- Streaming NDJSON connections with heartbeats, so a silent cold build is distinguishable from a dead daemon without choosing between a timeout that kills long builds and one that hangs forever. `MessageStream` replaces the single-recv reader that discarded everything past the first newline.
- `bosn attach` (was exiting 3 with a stale "phase 6" label) and `bosn cancel`. `bosn jobs` returns real data instead of `[]`.
- Builds and their registry writes move into the daemon; the CLI still runs the container itself so the command keeps the caller's terminal and exit status.
- `should_retire` is job-aware — it would previously have retired mid-build.
- Distinct exit codes so an agent can tell outcomes apart: `4` superseded, `5` cancelled, `1` build failed.

No `--detach`: it is the easiest way to recreate the pile-up, and fan-out already works by running from multiple worktrees.

## Testing

`tests/test_jobs.py` opens with a RED demonstration — the same 50-edit loop run against a reference model of the rejected unbounded design, showing the queue reach 50 — then runs it against the real manager and shows the bound hold. 63 new tests across the policy, the daemon/IPC integration, the CLI exit-code contract, and workspace identity (same worktree different cwds, symlinked paths, Windows case).

`tests/test_jobs_docker.py` covers the same ground end-to-end against real BuildKit under the `docker` marker on Linux CI: real output streams, a real build outlives its client, the bound holds with genuinely slow builds, and two worktrees build in parallel. Docker was not reachable locally, so those run for the first time in this PR's CI.

Local: 207 passed, 22 skipped (Docker), lint clean (ruff format, ruff check, pyright, KBI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
