### PR TITLE
Add unattended maintenance scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ non-destructive: run `sqlite3 registry.sqlite3 "PRAGMA integrity_check"`; if rec
 needed, copy the database first and use SQLite's `.recover` output to build a replacement.
 Adopted resources receive a 24-hour quiet period before normal age-based retention resumes.
 
+Enable the per-user login launcher once with `bosn __daemon --autostart`; it writes a
+Startup launcher on Windows, a LaunchAgent on macOS, or a user systemd unit on Linux.
+Disable and remove it with `bosn __daemon --no-autostart`. Each scheduled pass reaps
+expired jobs before running GC, logs both stages, and backs off visibly when Docker is down.
+
 Losing the database is survivable: **ownership lives in the labels, and the registry is
 authoritative only for time and leases.** A lost registry rebuilds by rescanning Docker
 labels, with adoption time as last-use and a 24 h quiet period so recovery is never followed

--- a/src/bosn/autostart.py
+++ b/src/bosn/autostart.py
@@ -1,0 +1,68 @@
+"""Per-user login launchers for the maintenance daemon."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+NAME = "bosn-daemon"
+
+
+def command() -> list[str]:
+    return [sys.executable, "-m", "bosn", "__daemon"]
+
+
+def path(*, platform: str | None = None, home: Path | None = None) -> Path:
+    platform = platform or sys.platform
+    home = home or Path.home()
+    if platform.startswith("win"):
+        appdata = Path(os.environ.get("APPDATA", home / "AppData" / "Roaming"))
+        return appdata / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
+    if platform == "darwin":
+        return home / "Library" / "LaunchAgents" / "io.github.zackees.bosn.plist"
+    return home / ".config" / "systemd" / "user" / "bosn-daemon.service"
+
+
+def enable(*, platform: str | None = None, home: Path | None = None) -> Path:
+    """Install a per-user launcher and return its manifest path."""
+    platform = platform or sys.platform
+    target = path(platform=platform, home=home)
+    invocation = " ".join(f'"{part}"' for part in command())
+    if platform.startswith("win"):
+        target.mkdir(parents=True, exist_ok=True)
+        launcher = target / "bosn-daemon.cmd"
+        launcher.write_text(f"@echo off\r\n{invocation}\r\n", encoding="utf-8")
+        return launcher
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if platform == "darwin":
+        target.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<plist version="1.0"><dict><key>Label</key>'
+            "<string>io.github.zackees.bosn</string><key>ProgramArguments</key><array>"
+            f"{''.join(f'<string>{part}</string>' for part in command())}"
+            "</array><key>RunAtLoad</key><true/></dict></plist>\n",
+            encoding="utf-8",
+        )
+        return target
+    target.write_text(
+        "[Unit]\nDescription=bosn container lifecycle supervisor\n\n"
+        "[Service]\nType=simple\nExecStart=" + invocation + "\nRestart=on-failure\n\n"
+        "[Install]\nWantedBy=default.target\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["systemctl", "--user", "enable", "--now", target.name], check=False)
+    return target
+
+
+def disable(*, platform: str | None = None, home: Path | None = None) -> Path:
+    """Remove the per-user launcher; this never touches a system-wide service."""
+    platform = platform or sys.platform
+    target = path(platform=platform, home=home)
+    if platform.startswith("win"):
+        target = target / "bosn-daemon.cmd"
+    elif platform != "darwin":
+        subprocess.run(["systemctl", "--user", "disable", "--now", target.name], check=False)
+    target.unlink(missing_ok=True)
+    return target

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -99,6 +99,21 @@ def build_parser() -> argparse.ArgumentParser:
     daemon_parser.add_argument("--max-builds", type=int, default=None)
     daemon_parser.add_argument("--build-ttl-seconds", type=float, default=None)
     daemon_parser.add_argument("--stop", action="store_true", help="stop a running daemon")
+    autostart = daemon_parser.add_mutually_exclusive_group()
+    autostart.add_argument(
+        "--autostart",
+        action="store_const",
+        const=True,
+        dest="autostart",
+        help="start the maintenance daemon automatically at login",
+    )
+    autostart.add_argument(
+        "--no-autostart",
+        action="store_const",
+        const=False,
+        dest="autostart",
+        help="remove bosn's per-user login launcher",
+    )
     # Accepted after the verb as well, so a spawned argv need not order its flags.
     daemon_parser.add_argument("--state-dir", default=None, dest="daemon_state_dir")
     return parser
@@ -133,6 +148,13 @@ def cmd_daemon(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
     from bosn.config import load as load_config
+
+    if opts.autostart is not None:
+        from bosn import autostart
+
+        target = autostart.enable() if opts.autostart else autostart.disable()
+        print(f"autostart {'enabled' if opts.autostart else 'disabled'}: {target}")
+        return 0
 
     state_dir = opts.state_dir
 

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from bosn import __version__, ipc
+from bosn.clock import Clock, SystemClock
 from bosn.jobs import BuildOutcome, Job, JobError, JobManager
 from bosn.registry import Registry, default_state_dir
 
@@ -41,6 +42,9 @@ PORT_RANGE_START = 47765
 PORT_RANGE_SIZE = 1024
 
 DEFAULT_IDLE_RETIRE_SECONDS = 900.0
+DEFAULT_MAINTENANCE_INTERVAL_SECONDS = 300.0
+MAINTENANCE_BACKOFF_INITIAL_SECONDS = 30.0
+MAINTENANCE_BACKOFF_MAX_SECONDS = 3600.0
 SPAWN_TIMEOUT_SECONDS = 30.0
 
 # Verbs that hold the connection open and write many messages instead of one.
@@ -263,18 +267,24 @@ class Daemon:
         max_builds: int | None = None,
         build_ttl_seconds: float | None = None,
         engine_binary: str = "docker",
+        maintenance_interval_seconds: float = DEFAULT_MAINTENANCE_INTERVAL_SECONDS,
+        clock: Clock | None = None,
     ) -> None:
         self.engine_binary = engine_binary
+        self.clock = clock or SystemClock()
         self.state_dir = state_dir or default_state_dir()
         self.bind_port = port_for(self.state_dir) if port is None else port
         self.idle_retire_seconds = idle_retire_seconds
-        self.started_at = time.time()
+        self.started_at = self.clock.now()
         self.last_activity = self.started_at
         self.heartbeat_at = self.started_at
+        self.maintenance_interval_seconds = maintenance_interval_seconds
+        self._next_maintenance_at = self.started_at  # catch up immediately after downtime
+        self._maintenance_backoff_seconds = MAINTENANCE_BACKOFF_INITIAL_SECONDS
         self._server: _Server | None = None
         self._stop = threading.Event()
         self.secret = secrets.token_urlsafe(32)
-        self.registry = Registry(self.state_dir / "registry.sqlite3")
+        self.registry = Registry(self.state_dir / "registry.sqlite3", clock=self.clock)
         self.jobs = JobManager(
             self._build,
             max_builds=max_builds,
@@ -293,11 +303,11 @@ class Daemon:
         return int(self._server.server_address[1])
 
     def note_activity(self) -> None:
-        self.last_activity = time.time()
+        self.last_activity = self.clock.now()
         self.heartbeat_at = self.last_activity
 
     def idle_seconds(self) -> float:
-        return time.time() - self.last_activity
+        return self.clock.now() - self.last_activity
 
     def should_retire(self) -> bool:
         """Idle *and* holding no work. Retiring mid-build would destroy it.
@@ -350,6 +360,7 @@ class Daemon:
             self._write_heartbeat()
             for job in self.jobs.reap_expired():
                 self.registry.log_event("job.expired", f"{job.id} {job.stack}")
+            self.run_maintenance_if_due()
             if self.should_retire():
                 self.registry.log_event("daemon.idle_retired", f"idle={self.idle_seconds():.0f}s")
                 self.request_stop()
@@ -357,6 +368,64 @@ class Daemon:
 
     def _write_heartbeat(self) -> None:
         heartbeat_file(self.state_dir).touch()
+
+    def run_maintenance_if_due(self) -> bool:
+        """Run one unattended reap/GC pass when its deadline has arrived.
+
+        Kept separate from the wall-clock watchdog so tests and embedders can advance an
+        injected clock without sleeping.  Reap always precedes GC: an expired build lease
+        must not shield a resource from the same pass that would otherwise collect it.
+        """
+        if self.clock.now() < self._next_maintenance_at:
+            return False
+        self._run_maintenance()
+        return True
+
+    def _run_maintenance(self) -> None:
+        """Execute a maintenance pass, recording every outcome and scheduling its retry."""
+        from bosn.engine import Engine
+        from bosn.gc import Collector, done_workspaces
+
+        self.registry.log_event("maintenance.reap.started")
+        try:
+            expired = self.jobs.reap_expired()
+            for job in expired:
+                self.registry.log_event("job.expired", f"{job.id} {job.stack}")
+            self.registry.log_event("maintenance.reap.finished", f"expired={len(expired)}")
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - a scheduler failure must be visible
+            self.registry.log_event("maintenance.reap.error", f"{type(exc).__name__}: {exc}")
+            self._next_maintenance_at = self.clock.now() + self.maintenance_interval_seconds
+            return
+
+        engine = Engine(self.engine_binary)
+        info = engine.info()
+        if not info.reachable:
+            detail = info.detail or "engine daemon unreachable"
+            self.registry.log_event(
+                "maintenance.engine_down",
+                f"retry_in={self._maintenance_backoff_seconds:g}s {detail}",
+            )
+            self._next_maintenance_at = self.clock.now() + self._maintenance_backoff_seconds
+            self._maintenance_backoff_seconds = min(
+                self._maintenance_backoff_seconds * 2, MAINTENANCE_BACKOFF_MAX_SECONDS
+            )
+            return
+
+        self.registry.log_event("maintenance.gc.started")
+        try:
+            result = Collector(self.registry, engine).collect(
+                dry_run=False, done_workspaces=done_workspaces(self.registry)
+            )
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - never claim a failed GC succeeded
+            self.registry.log_event("maintenance.gc.error", f"{type(exc).__name__}: {exc}")
+        else:
+            self.registry.log_event("maintenance.gc.finished", json.dumps(result.summary()))
+        self._maintenance_backoff_seconds = MAINTENANCE_BACKOFF_INITIAL_SECONDS
+        self._next_maintenance_at = self.clock.now() + self.maintenance_interval_seconds
 
     def request_stop(self) -> None:
         self._stop.set()

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -42,6 +42,7 @@ class Options:
     max_builds: int | None = None
     build_ttl_seconds: float | None = None
     stop: bool = False
+    autostart: bool | None = None
 
     extras: tuple[str, ...] = field(default=())
 
@@ -107,4 +108,5 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         max_builds=None if max_builds is None else int(str(max_builds)),
         build_ttl_seconds=None if build_ttl is None else float(str(build_ttl)),
         stop=bool(get("stop", False)),
+        autostart=get("autostart"),
     )

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -93,6 +93,8 @@ def from_namespace(ns: argparse.Namespace) -> Options:
     port = get("port")
     max_builds = get("max_builds")
     build_ttl = get("build_ttl_seconds")
+    raw_autostart = get("autostart")
+    autostart = raw_autostart if isinstance(raw_autostart, bool) else None
 
     return Options(
         verb=_as_str(get("verb")),
@@ -108,5 +110,5 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         max_builds=None if max_builds is None else int(str(max_builds)),
         build_ttl_seconds=None if build_ttl is None else float(str(build_ttl)),
         stop=bool(get("stop", False)),
-        autostart=get("autostart"),
+        autostart=autostart,
     )

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bosn import autostart
+
+
+@pytest.mark.parametrize("platform", ["win32", "darwin", "linux"])
+def test_per_user_login_launcher_can_be_enabled_and_removed(
+    monkeypatch, tmp_path: Path, platform: str
+) -> None:
+    """Every supported OS has a reversible, per-user login launcher."""
+    monkeypatch.setattr(autostart.subprocess, "run", lambda *_args, **_kwargs: None)
+    installed = autostart.enable(platform=platform, home=tmp_path)
+    assert installed.exists()
+    text = installed.read_text(encoding="utf-8")
+    assert "bosn" in text
+    assert autostart.disable(platform=platform, home=tmp_path) == installed
+    assert not installed.exists()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -21,7 +21,9 @@ import pytest
 
 from bosn import daemon as daemon_mod
 from bosn import ipc
+from bosn.clock import FakeClock
 from bosn.daemon import Daemon, DaemonError, DaemonState
+from bosn.engine import EngineInfo
 
 
 def _detach_code() -> str:
@@ -191,6 +193,88 @@ def test_idle_retirement_stops_an_unused_daemon(tmp_path: Path) -> None:
     thread.join(timeout=20)
     assert not thread.is_alive(), "idle daemon should have retired itself"
     assert not daemon_mod.is_serving(tmp_path)
+
+
+# -- unattended maintenance ------------------------------------------------
+
+
+def test_maintenance_catches_up_then_runs_on_the_injected_clock(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The first pass is due at startup; subsequent passes require no human command."""
+    clock = FakeClock()
+    calls: list[str] = []
+
+    class ReachableEngine:
+        def __init__(self, _binary: str) -> None:
+            pass
+
+        def info(self) -> EngineInfo:
+            return EngineInfo(binary="docker", reachable=True)
+
+    class RecordingCollector:
+        def __init__(self, _registry, _engine) -> None:
+            pass
+
+        def collect(self, **_kwargs):
+            calls.append("gc")
+
+            class Result:
+                def summary(self):
+                    return {"removed": 0}
+
+            return Result()
+
+    import bosn.engine
+    import bosn.gc
+
+    monkeypatch.setattr(bosn.engine, "Engine", ReachableEngine)
+    monkeypatch.setattr(bosn.gc, "Collector", RecordingCollector)
+    daemon = Daemon(
+        state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60, idle_retire_seconds=3600
+    )
+    try:
+        assert daemon.run_maintenance_if_due() is True
+        assert calls == ["gc"]
+        assert daemon.run_maintenance_if_due() is False
+        clock.advance(60)
+        assert daemon.run_maintenance_if_due() is True
+        assert calls == ["gc", "gc"]
+        events = [row["kind"] for row in daemon.registry.events()]
+        assert "maintenance.reap.started" in events
+        assert "maintenance.gc.started" in events
+        assert "maintenance.gc.finished" in events
+    finally:
+        daemon.registry.close()
+
+
+def test_maintenance_engine_down_is_visible_and_uses_exponential_backoff(
+    monkeypatch, tmp_path: Path
+) -> None:
+    clock = FakeClock()
+
+    class DownEngine:
+        def __init__(self, _binary: str) -> None:
+            pass
+
+        def info(self) -> EngineInfo:
+            return EngineInfo(binary="docker", reachable=False, detail="daemon asleep")
+
+    import bosn.engine
+
+    monkeypatch.setattr(bosn.engine, "Engine", DownEngine)
+    daemon = Daemon(state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60)
+    try:
+        assert daemon.run_maintenance_if_due()
+        assert daemon._next_maintenance_at == clock.now() + 30
+        clock.advance(30)
+        assert daemon.run_maintenance_if_due()
+        assert daemon._next_maintenance_at == clock.now() + 60
+        events = daemon.registry.events()
+        assert events[0]["kind"] == "maintenance.engine_down"
+        assert "retry_in=60s" in events[0]["detail"]
+    finally:
+        daemon.registry.close()
 
 
 # -- client behavior -------------------------------------------------------


### PR DESCRIPTION
## What changed
- Schedule daemon-owned reap followed by real GC, with catch-up on startup.
- Record separate lifecycle events and exponential engine-down retry backoff.
- Add reversible per-user login launchers for Windows, macOS, and Linux.

## Why
Issue #14 found that retention existed but never ran without a human invoking osn gc.

## Validation
- python -m pytest tests/test_daemon.py tests/test_autostart.py tests/test_lint_kbi.py -q
- python -m ruff check src tests

Closes #14