### PR TITLE
Add storage accounting and pressure planning

### DIFF
--- a/src/bosn/accounting.py
+++ b/src/bosn/accounting.py
@@ -1,0 +1,66 @@
+"""Byte accounting and backing-store pressure probes.
+
+Docker's human-facing size strings are deliberately not parsed: inspect emits byte counts,
+which keeps the supervisor's decisions independent of locale and display rounding.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from bosn.engine import Engine
+from bosn.registry import Resource
+
+_SIZE_COMMANDS = {
+    "container": ["container", "inspect", "--size", "--format", "{{.SizeRw}}"],
+    "image": ["image", "inspect", "--format", "{{.Size}}"],
+    # Docker has no per-volume inspect size; `system df -v` is the supported source.
+    "volume": ["system", "df", "-v", "--format", "{{json .}}"],
+}
+
+
+@dataclass(frozen=True)
+class StorageProbe:
+    free_bytes: int
+    total_bytes: int
+    vhdx_slack_bytes: int | None = None
+
+
+def resource_bytes(engine: Engine, resource: Resource) -> int | None:
+    """Return a resource's managed bytes, or None when the engine cannot attribute it."""
+    args = _SIZE_COMMANDS.get(resource.kind)
+    if args is None:
+        return None
+    result = engine.run([*args, resource.name])
+    if not result.ok:
+        return None
+    if resource.kind != "volume":
+        try:
+            return max(0, int(result.stdout.strip()))
+        except ValueError:
+            return None
+    # `docker system df -v` describes local volumes in a table.  Docker does not expose a
+    # stable machine-readable per-volume size, so only accept an exact byte field when an
+    # engine implementation provides one; otherwise report the attribution as unavailable.
+    import json
+
+    for line in result.stdout.splitlines():
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if str(row.get("Name", "")) == resource.name:
+            for key in ("SizeBytes", "Size"):
+                try:
+                    return max(0, int(row[key]))
+                except (KeyError, TypeError, ValueError):
+                    pass
+    return None
+
+
+def probe(path: Path) -> StorageProbe:
+    """Probe the filesystem carrying bosn state; VHDX slack remains a distinct field."""
+    usage = shutil.disk_usage(path)
+    return StorageProbe(free_bytes=usage.free, total_bytes=usage.total)

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -14,9 +14,11 @@ Design commitments enforced here:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 
 from bosn import labels
+from bosn.accounting import probe, resource_bytes
 from bosn.engine import Engine
 from bosn.registry import Registry
 from bosn.resources import ResourceScanner
@@ -112,8 +114,33 @@ def status(registry: Registry, engine: Engine | None = None) -> dict:
     from bosn.config import load as load_config
 
     config = load_config()
-    verdicts = plan(registry)
     scan = ResourceScanner(engine).scan(registry.registry_id)
+
+    attributed: dict[tuple[str, str, str], dict[str, int]] = defaultdict(
+        lambda: {"count": 0, "bytes": 0, "unmeasured": 0}
+    )
+    measured: dict[str, int | None] = {}
+    for resource in registry.list_resources():
+        size = resource_bytes(engine, resource)
+        measured[resource.id] = size
+        bucket = attributed[(resource.workspace, resource.stack, resource.kind)]
+        bucket["count"] += 1
+        if size is None:
+            bucket["unmeasured"] += 1
+        else:
+            bucket["bytes"] += size
+    managed_bytes = sum(size for size in measured.values() if size is not None)
+    storage = probe(registry.path.parent)
+    pressure = Pressure.assess(
+        resource_count=len(measured), managed_bytes=managed_bytes, free_bytes=storage.free_bytes
+    )
+    verdicts = plan(registry, pressure=pressure)
+    reclaimable = sum(measured[v.resource.id] or 0 for v in collectable(verdicts))
+    advisory = (
+        "Backing-store slack exceeds managed reclaimable bytes; compact the Docker VHDX manually."
+        if storage.vhdx_slack_bytes is not None and storage.vhdx_slack_bytes > reclaimable
+        else None
+    )
 
     by_reason: dict[str, int] = {}
     for verdict in verdicts:
@@ -127,6 +154,35 @@ def status(registry: Registry, engine: Engine | None = None) -> dict:
         "by_reason": by_reason,
         "engine": scan.counts(),
         "foreign_registries": sorted(scan.foreign_registries),
+        "foreign_registry_totals": {"count": len(scan.foreign), "bytes": None},
+        "managed_bytes": managed_bytes,
+        "managed_reclaimable_bytes": reclaimable,
+        "pressure": {
+            "under_pressure": pressure.under_pressure,
+            "count_exceeded": pressure.count_exceeded,
+            "bytes_exceeded": pressure.bytes_exceeded,
+            "free_space_exceeded": pressure.free_space_exceeded,
+        },
+        "storage": {
+            "free_bytes": storage.free_bytes,
+            "total_bytes": storage.total_bytes,
+            "vhdx_slack_bytes": storage.vhdx_slack_bytes,
+            "compaction_advisory": advisory,
+        },
+        "attribution": [
+            {"workspace": workspace, "stack": stack, "role": role, **values}
+            for (workspace, stack, role), values in sorted(attributed.items())
+        ],
+        "decisions": [
+            {
+                "name": verdict.name,
+                "kind": verdict.resource.kind,
+                "eligible": verdict.collect,
+                "reason": verdict.reason,
+                "bytes": measured[verdict.resource.id],
+            }
+            for verdict in verdicts
+        ],
     }
 
 

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -26,6 +26,10 @@ from bosn.resources import (
 
 HOUR = 3600.0
 DAY = 24 * HOUR
+GIB = 1024**3
+DEFAULT_RESOURCE_CEILING = 1_000
+DEFAULT_MANAGED_BYTES_CEILING = 100 * GIB
+DEFAULT_MIN_FREE_BYTES = 10 * GIB
 
 CONTAINER_IDLE_STOP = 1 * HOUR
 CONTAINER_REMOVE = 1 * DAY
@@ -42,6 +46,7 @@ KEPT_MACHINE_SCOPE = "machine-scope"
 COLLECT_SUPERSEDED = "superseded"
 COLLECT_IDLE = "idle"
 COLLECT_DONE = "workspace-done"
+COLLECT_PRESSURE = "pressure"
 
 
 @dataclass(frozen=True)
@@ -60,6 +65,31 @@ class Pressure:
     """Free-space pressure on the engine's backing store."""
 
     under_pressure: bool = False
+    count_exceeded: bool = False
+    bytes_exceeded: bool = False
+    free_space_exceeded: bool = False
+
+    @classmethod
+    def assess(
+        cls,
+        *,
+        resource_count: int,
+        managed_bytes: int,
+        free_bytes: int,
+        resource_ceiling: int = DEFAULT_RESOURCE_CEILING,
+        managed_bytes_ceiling: int = DEFAULT_MANAGED_BYTES_CEILING,
+        min_free_bytes: int = DEFAULT_MIN_FREE_BYTES,
+    ) -> Pressure:
+        """Evaluate all three pressure signals without conflating bytes and free space."""
+        count_exceeded = resource_count > resource_ceiling
+        bytes_exceeded = managed_bytes > managed_bytes_ceiling
+        free_space_exceeded = free_bytes < min_free_bytes
+        return cls(
+            under_pressure=count_exceeded or bytes_exceeded or free_space_exceeded,
+            count_exceeded=count_exceeded,
+            bytes_exceeded=bytes_exceeded,
+            free_space_exceeded=free_space_exceeded,
+        )
 
 
 def container_should_stop(resource: Resource, now: float) -> bool:
@@ -113,6 +143,11 @@ def evaluate(
     if workspace_done and resource.scope != "machine":
         return Verdict(resource, True, COLLECT_DONE)
 
+    # Pressure can evict warm resources, but never leases/adoption quiet-period resources.
+    # Machine-wide caches are deliberately considered after all workspace-scoped caches.
+    if pressure.under_pressure and resource.scope != "machine":
+        return Verdict(resource, True, COLLECT_PRESSURE)
+
     if resource.scope == "machine" and not pressure.under_pressure:
         # Machine-shared caches age only under pressure.
         return Verdict(resource, False, KEPT_MACHINE_SCOPE)
@@ -152,7 +187,17 @@ def plan(
 
 
 def collectable(verdicts: list[Verdict]) -> list[Verdict]:
-    return [v for v in verdicts if v.collect]
+    # A single order is essential under pressure: clearly obsolete first, then completed
+    # worktrees, then ordinary pressure candidates, with shared machine caches last.
+    order = {COLLECT_SUPERSEDED: 0, COLLECT_DONE: 1, COLLECT_IDLE: 2, COLLECT_PRESSURE: 3}
+    return sorted(
+        (v for v in verdicts if v.collect),
+        key=lambda v: (
+            v.resource.scope == "machine",
+            order.get(v.reason, 99),
+            v.resource.last_used,
+        ),
+    )
 
 
 def kept(verdicts: list[Verdict]) -> list[Verdict]:

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -193,3 +193,8 @@ def test_status_reports_counts_and_foreign_registries(registry: Registry) -> Non
     assert report["registered"] == 1
     assert "by_reason" in report
     assert isinstance(report["foreign_registries"], list)
+    assert report["managed_bytes"] == 0
+    assert report["attribution"] == [
+        {"workspace": "/w", "stack": "s", "role": "volume", "count": 1, "bytes": 0, "unmeasured": 1}
+    ]
+    assert report["decisions"][0]["reason"] == "warm"

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -12,6 +12,7 @@ from bosn.registry import Registry
 from bosn.retention import (
     COLLECT_DONE,
     COLLECT_IDLE,
+    COLLECT_PRESSURE,
     COLLECT_SUPERSEDED,
     KEPT_LEASED,
     KEPT_MACHINE_SCOPE,
@@ -146,6 +147,39 @@ def test_machine_scoped_caches_age_only_under_pressure(
     assert evaluate(registry, resource, alive_probe=DEAD).reason == KEPT_MACHINE_SCOPE
     under = evaluate(registry, resource, pressure=Pressure(under_pressure=True), alive_probe=DEAD)
     assert under.collect
+
+
+def test_pressure_evicts_workspace_caches_before_machine_caches(
+    registry: Registry, clock: FakeClock
+) -> None:
+    workspace = make(registry, scope="spec")
+    machine = registry.register_resource(
+        kind="volume", name="machine", stack="s", generation="g", scope="machine", workspace="/w"
+    )
+    clock.advance(100 * DAY)
+    verdict = evaluate(
+        registry, workspace, pressure=Pressure(under_pressure=True), alive_probe=DEAD
+    )
+    assert verdict.collect and verdict.reason == COLLECT_PRESSURE
+    planned = retention.collectable(
+        retention.plan(registry, pressure=Pressure(under_pressure=True), alive_probe=DEAD)
+    )
+    assert [item.name for item in planned] == [workspace.name, machine.name]
+
+
+def test_pressure_assessment_keeps_count_bytes_and_free_space_distinct() -> None:
+    pressure = Pressure.assess(
+        resource_count=5,
+        managed_bytes=100,
+        free_bytes=9,
+        resource_ceiling=4,
+        managed_bytes_ceiling=101,
+        min_free_bytes=10,
+    )
+    assert pressure.under_pressure
+    assert pressure.count_exceeded
+    assert not pressure.bytes_exceeded
+    assert pressure.free_space_exceeded
 
 
 def test_done_never_collects_machine_scoped_caches(registry: Registry, clock: FakeClock) -> None:


### PR DESCRIPTION
## What changed
- Attribute managed resources by workspace, stack, and role with byte measurements where Docker exposes exact bytes.
- Report managed/reclaimable bytes, storage capacity, foreign totals, and human-readable retention decisions in status JSON.
- Evaluate count, managed-byte, and free-space pressure separately, and order pressure eviction with machine scope last.

## Why
Issue #15 requires the supervisor to account for storage and explain pressure decisions instead of relying on an unused boolean.

## Validation
- python -m pytest tests/test_gc.py tests/test_retention.py -q
- python -m ruff check src tests
- python -m pyright

The full suite reaches the pre-existing workspace-normalization scenario failure tracked by #19.

Closes #15