### PR TITLE
Add persistent interactive containers

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -464,9 +464,29 @@ def cmd_done(opts: Options) -> int:
 
 
 def cmd_shell(opts: Options) -> int:
-    from dataclasses import replace
+    from bosn import daemon as daemon_mod
+    from bosn.converge import Converger, workspace_of
+    from bosn.engine import EngineError
+    from bosn.manifest import ManifestError
 
-    return cmd_run(replace(opts, args=("sh",), task=None))
+    try:
+        manifest, registry = _open_manifest_and_registry(opts)
+    except ManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    try:
+        converged = _converge_via_daemon(opts, manifest, opts.stack)
+        return Converger(manifest, registry, Engine(opts.engine)).shell_converged(
+            converged, stack_name=opts.stack, workspace=workspace_of(manifest)
+        )
+    except JobFailed as exc:
+        print(str(exc), file=sys.stderr)
+        return exc.exit_code
+    except (daemon_mod.DaemonError, ipc.TransportError, EngineError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    finally:
+        registry.close()
 
 
 def cmd_ensure(opts: Options) -> int:

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -9,6 +9,8 @@ whose remedy is always the same mechanical command is just a forced retry loop.
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
+import os
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -22,6 +24,8 @@ from bosn.registry import Registry
 REUSED = "reused"
 REGISTERED = "registered"
 ROLLED = "rolled"
+CONTAINER_HEARTBEAT_TIMEOUT_SECONDS = 600
+RUN_MAX_DURATION_SECONDS = 8 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -264,6 +268,55 @@ class Converger:
 
     # -- running -----------------------------------------------------------
 
+    @staticmethod
+    def container_name(workspace: str, stack: str) -> str:
+        """Stable, Docker-safe container identity for one workspace and stack."""
+        digest = hashlib.sha256(f"{workspace}\0{stack}".encode()).hexdigest()[:16]
+        return f"bosn-{stack}-{digest}"
+
+    def ensure_container(
+        self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
+    ) -> str:
+        """Create/start the persistent execution container, or reuse its existing one."""
+        stack = self.manifest.stack(stack_name)
+        name = self.container_name(workspace, stack.name)
+        inspected = self.engine.run(["container", "inspect", name])
+        if not inspected.ok:
+            labels = self._resource_labels(stack, "container", converged.digest, "stack", workspace)
+            # Docker removes an orphan automatically once PID 1's watchdog exits.
+            args = ["create", "--rm", "--name", name, *labels.to_docker_args()]
+            for volume in stack.volumes:
+                volume_name = volume_name_for(
+                    stack,
+                    volume.scope,
+                    volume.name,
+                    digest=converged.digest,
+                    workspace=workspace,
+                    family=stack.family,
+                )
+                args += ["--volume", f"{volume_name}:/bosn/{volume.name}"]
+            heartbeat = self.registry.path.parent / "daemon.heartbeat"
+            heartbeat.touch(exist_ok=True)
+            args += ["--volume", f"{heartbeat.resolve()}:/bosn-daemon/heartbeat:ro"]
+            # PID 1 exits when the daemon heartbeat goes stale or a run is orphaned for
+            # too long.  `--rm` above then removes the stopped container automatically.
+            watchdog = (
+                "started=$(date +%s); while :; do now=$(date +%s); "
+                "beat=$(stat -c %Y /bosn-daemon/heartbeat 2>/dev/null || echo 0); "
+                f"[ $((now-beat)) -gt {CONTAINER_HEARTBEAT_TIMEOUT_SECONDS} ] && exit 0; "
+                f"[ $((now-started)) -gt {RUN_MAX_DURATION_SECONDS} ] && exit 0; "
+                "sleep 30; done"
+            )
+            args += [converged.image_tag, "sh", "-c", watchdog]
+            created = self.engine.run(args)
+            if not created.ok:
+                raise EngineError(f"creating persistent container {name} failed: {created.stderr}")
+            self._register(stack, "container", name, converged.digest, "stack", workspace)
+        started = self.engine.run(["start", name])
+        if not started.ok and "already started" not in (started.stderr or started.stdout).lower():
+            raise EngineError(f"starting persistent container {name} failed: {started.stderr}")
+        return name
+
     def run(
         self,
         command: list[str],
@@ -292,24 +345,36 @@ class Converger:
         caller's terminal and exit status.
         """
         workspace = workspace or workspace_of(self.manifest)
-        stack = self.manifest.stack(stack_name)
-
-        args = ["run", "--rm"]
-        for volume in stack.volumes:
-            name = volume_name_for(
-                stack,
-                volume.scope,
-                volume.name,
-                digest=converged.digest,
-                workspace=workspace,
-                family=stack.family,
-            )
-            args += ["--volume", f"{name}:/bosn/{volume.name}"]
-        args += [converged.image_tag, *command]
-
-        result = self.engine.run(args)
+        name = self.ensure_container(converged, stack_name=stack_name, workspace=workspace)
+        args = ["exec", name, *command]
+        resource = next(
+            r for r in self.registry.list_resources() if r.kind == "container" and r.name == name
+        )
+        lease = self.registry.acquire_lease(
+            resource.id, pid=os.getpid(), proc_start=self.registry.clock.now()
+        )
+        try:
+            result = self.engine.run(args)
+        finally:
+            self.registry.release_lease(lease.id)
         self.registry.log_event("run", f"{converged.stack} rc={result.returncode}")
         return converged, result.returncode, result.stdout or result.stderr
+
+    def shell_converged(
+        self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
+    ) -> int:
+        """Attach a real interactive shell to the persistent container."""
+        name = self.ensure_container(converged, stack_name=stack_name, workspace=workspace)
+        resource = next(
+            r for r in self.registry.list_resources() if r.kind == "container" and r.name == name
+        )
+        lease = self.registry.acquire_lease(
+            resource.id, pid=os.getpid(), proc_start=self.registry.clock.now()
+        )
+        try:
+            return self.engine.interactive(["exec", "-it", name, "sh"])
+        finally:
+            self.registry.release_lease(lease.id)
 
 
 def run_task(

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -59,6 +59,11 @@ def state_file(state_dir: Path | None = None) -> Path:
     return (state_dir or default_state_dir()) / "daemon.json"
 
 
+def heartbeat_file(state_dir: Path | None = None) -> Path:
+    """A host-visible heartbeat consumed by persistent container PID 1 watchdogs."""
+    return (state_dir or default_state_dir()) / "daemon.heartbeat"
+
+
 def port_for(state_dir: Path | None = None) -> int:
     """The deterministic loopback port that owns this state directory.
 
@@ -281,6 +286,7 @@ class Daemon:
             started_at=self.started_at,
             version=__version__,
         ).write(state_file(self.state_dir))
+        self._write_heartbeat()
         self.registry.log_event("daemon.started", f"pid={os.getpid()} port={self.port}")
 
         threading.Thread(target=self._idle_watchdog, daemon=True).start()
@@ -292,12 +298,16 @@ class Daemon:
 
     def _idle_watchdog(self) -> None:
         while not self._stop.wait(0.5):
+            self._write_heartbeat()
             for job in self.jobs.reap_expired():
                 self.registry.log_event("job.expired", f"{job.id} {job.stack}")
             if self.should_retire():
                 self.registry.log_event("daemon.idle_retired", f"idle={self.idle_seconds():.0f}s")
                 self.request_stop()
                 return
+
+    def _write_heartbeat(self) -> None:
+        heartbeat_file(self.state_dir).touch()
 
     def request_stop(self) -> None:
         self._stop.set()
@@ -320,6 +330,7 @@ class Daemon:
             self._server.server_close()
             self._server = None
         state_file(self.state_dir).unlink(missing_ok=True)
+        heartbeat_file(self.state_dir).unlink(missing_ok=True)
         try:
             self.registry.log_event("daemon.stopped", "")
             self.registry.close()

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -8,6 +8,7 @@ never shell strings.
 from __future__ import annotations
 
 import shutil
+import subprocess
 import threading
 import time
 from collections.abc import Callable
@@ -138,6 +139,16 @@ class Engine:
         if killed:
             return EngineResult(returncode=returncode or -1, stdout=output, stderr="cancelled")
         return EngineResult(returncode=returncode, stdout=output, stderr="")
+
+    def interactive(self, args: list[str]) -> int:
+        """Run an engine command attached to this process's terminal.
+
+        Unlike :meth:`run`, stdio is inherited, so Docker receives the caller's stdin,
+        terminal resize/signals, and can allocate a real TTY for ``exec -it``.
+        """
+        if not self.available():
+            raise EngineError(f"{self.binary!r} is not on PATH")
+        return subprocess.run([self.binary, *args], check=False).returncode
 
     def info(self) -> EngineInfo:
         """Probe the engine. Never raises — the result carries the diagnosis."""

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -86,7 +86,11 @@ class Collector:
                             f"{verdict.name}: {stopped.stderr or stopped.stdout}",
                         )
 
-        for verdict in collectable(verdicts):
+        # Containers retain their volumes even after they have stopped. Remove them
+        # first so a done workspace can be collected in one pass.
+        for verdict in sorted(
+            collectable(verdicts), key=lambda verdict: verdict.resource.kind != "container"
+        ):
             resource = verdict.resource
             if not self._ownership_proven(resource.kind, resource.name):
                 result.skipped_unproven.append(resource.name)

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -20,7 +20,7 @@ from bosn import labels
 from bosn.engine import Engine
 from bosn.registry import Registry
 from bosn.resources import ResourceScanner
-from bosn.retention import Pressure, Verdict, collectable, plan
+from bosn.retention import Pressure, Verdict, collectable, container_should_stop, plan
 
 _REMOVE_COMMANDS: dict[str, list[str]] = {
     "container": ["rm", "--force"],
@@ -76,6 +76,15 @@ class Collector:
         for verdict in verdicts:
             if not verdict.collect:
                 result.kept.append(verdict.name)
+                if container_should_stop(verdict.resource, self.registry.clock.now()):
+                    stopped = self.engine.run(["container", "stop", verdict.name])
+                    if stopped.ok:
+                        self.registry.log_event("container.stopped_idle", verdict.name)
+                    else:
+                        self.registry.log_event(
+                            "container.stop_error",
+                            f"{verdict.name}: {stopped.stderr or stopped.stdout}",
+                        )
 
         for verdict in collectable(verdicts):
             resource = verdict.resource

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -44,6 +44,8 @@ class FakeEngine:
             return EngineResult(0 if args[-1] in self.existing else 1, "", "")
         if args[:2] == ["volume", "create"]:
             self.existing.add(args[-1])
+        if args[0] == "create":
+            self.existing.add(args[args.index("--name") + 1])
         if args[0] == "build":
             self.existing.add(args[args.index("--tag") + 1])
         return EngineResult(0, "ok", "")
@@ -59,6 +61,10 @@ class FakeEngine:
         if on_line is not None:
             on_line(f"fake build: {' '.join(args[:2])}")
         return self.run(args)
+
+    def interactive(self, args: list[str]) -> int:
+        self.commands.append(list(args))
+        return 7
 
     def ran(self, *prefix: str) -> list[list[str]]:
         return [c for c in self.commands if c[: len(prefix)] == list(prefix)]
@@ -356,13 +362,39 @@ def test_run_converges_first_then_runs(converger: Converger) -> None:
     engine: FakeEngine = converger.engine  # type: ignore[assignment]
     assert code == 0
     assert engine.ran("build"), "converge must have happened before the run"
-    run_cmd = engine.ran("run")[0]
-    assert run_cmd[-2:] == ["echo", "hi"]
-    assert "--rm" in run_cmd
+    exec_cmd = engine.ran("exec")[0]
+    assert exec_cmd[-2:] == ["echo", "hi"]
+    assert engine.ran("create"), "the first run creates the persistent container"
 
 
 def test_run_mounts_every_declared_volume(converger: Converger) -> None:
     converger.run(["true"])
     engine: FakeEngine = converger.engine  # type: ignore[assignment]
-    mounts = [a for a in engine.ran("run")[0] if a.startswith("bosn-")]
+    mounts = [a for a in engine.ran("create")[0] if a.startswith("bosn-") and ":/bosn/" in a]
     assert len(mounts) == 3
+
+
+def test_second_run_reuses_the_same_persistent_container(converger: Converger) -> None:
+    converger.run(["true"])
+    converger.run(["true"])
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    assert len(engine.ran("create")) == 1
+    assert len(engine.ran("exec")) == 2
+
+
+def test_shell_uses_an_interactive_tty_exec(converger: Converger) -> None:
+    converged = converger.converge()
+    assert converger.shell_converged(converged, stack_name=None, workspace="/workspace") == 7
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    assert engine.ran("exec")[-1][1] == "-it"
+
+
+def test_persistent_container_has_daemon_loss_and_run_duration_watchdogs(
+    converger: Converger,
+) -> None:
+    converger.run(["true"])
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    create = engine.ran("create")[0]
+    assert "--rm" in create
+    assert any("daemon.heartbeat:/bosn-daemon/heartbeat:ro" in arg for arg in create)
+    assert any("stat -c %Y" in arg and "started" in arg for arg in create)

--- a/tests/test_converge_docker.py
+++ b/tests/test_converge_docker.py
@@ -57,7 +57,9 @@ def converger(project: Path, registry: Registry, engine: Engine) -> Iterator[Con
         yield conv
     finally:
         for resource in registry.list_resources():
-            if resource.kind == "volume":
+            if resource.kind == "container":
+                engine.run(["rm", "--force", resource.name])
+            elif resource.kind == "volume":
                 engine.run(["volume", "rm", "--force", resource.name])
             elif resource.kind == "image":
                 engine.run(["image", "rm", "--force", resource.name])
@@ -110,7 +112,9 @@ def test_a_manifest_task_runs(project: Path, registry: Registry, engine: Engine)
         assert "task-ran" in output
     finally:
         for resource in registry.list_resources():
-            if resource.kind == "volume":
+            if resource.kind == "container":
+                engine.run(["rm", "--force", resource.name])
+            elif resource.kind == "volume":
                 engine.run(["volume", "rm", "--force", resource.name])
             elif resource.kind == "image":
                 engine.run(["image", "rm", "--force", resource.name])

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -127,6 +127,7 @@ def test_daemon_publishes_state_and_answers_ping(served: Daemon, tmp_path: Path)
     assert state.pid == os.getpid()
     reply = ipc.send_request(state.port, {"verb": "ping"})
     assert reply["ok"] and reply["pong"]
+    assert daemon_mod.heartbeat_file(tmp_path).exists()
 
 
 def test_status_reports_registry_id_and_uptime(served: Daemon) -> None:
@@ -168,6 +169,7 @@ def test_shutdown_verb_stops_the_daemon_and_clears_state(tmp_path: Path) -> None
     thread.join(timeout=15)
     assert not daemon_mod.is_serving(tmp_path)
     assert not daemon_mod.state_file(tmp_path).exists()
+    assert not daemon_mod.heartbeat_file(tmp_path).exists()
 
 
 def test_the_port_is_released_for_the_next_daemon(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed
- Create and reuse one labeled persistent container per workspace and stack.
- Run commands with docker exec and attach osn shell through a genuine docker exec -it terminal.
- Add live-session leases, idle stopping, and a PID-1 heartbeat/max-duration watchdog with Docker auto-removal.
- Ensure Docker test fixtures remove persistent containers.

## Validation
- python -m pytest tests/test_converge.py tests/test_daemon.py tests/test_converge_docker.py tests/test_gc.py -q
- python -m ruff check src tests
- python -m pyright

Closes #16