### PR TITLE
Add machine policy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ writer. The daemon is the registry's only writer and the only executor of reap a
 lazily spawned, autostarted at login, and idle-retired with a scheduled catch-up tick so
 maintenance still runs unattended.
 
+## Configuration
+
+Machine policy lives in `~/.config/bosn/config.toml` (or `$XDG_CONFIG_HOME/bosn/config.toml`;
+set `BOSN_CONFIG` to select another file). Values use `default < file < environment < CLI flag`
+precedence and invalid values stop the command while naming the bad key. The `[policy]` table
+accepts `container_idle_stop`, `container_remove`, `warm_volume_ttl`, `superseded_cap`,
+`shared_cache_ceiling`, `run_max_duration`, `idle_retire_seconds`, `build_ttl_seconds`, and
+`max_builds`; environment overrides are their uppercase `BOSN_` equivalents. `bosn status`
+reports each effective value and its origin.
+
 Losing the database is survivable: **ownership lives in the labels, and the registry is
 authoritative only for time and leases.** A lost registry rebuilds by rescanning Docker
 labels, with adoption time as last-use and a 24 h quiet period so recovery is never followed

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -114,6 +114,8 @@ def cmd_doctor(engine_binary: str) -> int:
 
 def cmd_daemon(opts: Options) -> int:
     from bosn import daemon as daemon_mod
+    from bosn.config import ConfigError
+    from bosn.config import load as load_config
 
     state_dir = opts.state_dir
 
@@ -137,21 +139,26 @@ def cmd_daemon(opts: Options) -> int:
             print("no daemon was running")
         return 0
 
-    idle = (
-        opts.idle_retire_seconds
-        if opts.idle_retire_seconds is not None
-        else daemon_mod.DEFAULT_IDLE_RETIRE_SECONDS
-    )
     try:
+        config = load_config(
+            flags={
+                "idle_retire_seconds": opts.idle_retire_seconds,
+                "max_builds": opts.max_builds,
+                "build_ttl_seconds": opts.build_ttl_seconds,
+            }
+        )
         daemon = daemon_mod.Daemon(
             state_dir=state_dir,
             port=opts.port,
-            idle_retire_seconds=idle,
-            max_builds=opts.max_builds,
-            build_ttl_seconds=opts.build_ttl_seconds,
+            idle_retire_seconds=config.get("idle_retire_seconds"),
+            max_builds=int(config.get("max_builds")),
+            build_ttl_seconds=config.get("build_ttl_seconds"),
             engine_binary=opts.engine,
         )
         return daemon.serve_forever()
+    except ConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     except daemon_mod.DaemonError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -400,14 +407,19 @@ def cmd_cancel(opts: Options) -> int:
 
 
 def cmd_status(opts: Options) -> int:
+    from bosn.config import ConfigError
     from bosn.gc import status
     from bosn.registry import Registry, default_db_path
 
     state_dir = opts.state_dir
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
-    with Registry(db_path) as registry:
-        print(json.dumps(status(registry, Engine(opts.engine)), indent=2))
-    return 0
+    try:
+        with Registry(db_path) as registry:
+            print(json.dumps(status(registry, Engine(opts.engine)), indent=2))
+        return 0
+    except ConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
 
 def cmd_gc(opts: Options) -> int:

--- a/src/bosn/config.py
+++ b/src/bosn/config.py
@@ -1,0 +1,98 @@
+"""Typed machine policy configuration with explicit precedence and origins."""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ConfigError(ValueError):
+    """A policy value is invalid; callers must stop rather than silently use a default."""
+
+
+@dataclass(frozen=True)
+class Value:
+    value: float
+    origin: str
+
+
+_DEFAULTS = {
+    "container_idle_stop": 3600.0,
+    "container_remove": 86400.0,
+    "warm_volume_ttl": 259200.0,
+    "superseded_cap": 86400.0,
+    "shared_cache_ceiling": float(100 * 1024**3),
+    "run_max_duration": 28800.0,
+    "idle_retire_seconds": 900.0,
+    "build_ttl_seconds": 3600.0,
+    "max_builds": float(max(2, (os.cpu_count() or 2) // 2)),
+}
+_ENV = {key: f"BOSN_{key.upper()}" for key in _DEFAULTS}
+
+
+def default_path() -> Path:
+    explicit = os.environ.get("BOSN_CONFIG")
+    if explicit:
+        return Path(explicit)
+    base = os.environ.get("XDG_CONFIG_HOME")
+    if base:
+        return Path(base) / "bosn" / "config.toml"
+    return Path.home() / ".config" / "bosn" / "config.toml"
+
+
+def _number(key: str, value: Any, origin: str) -> float:
+    if isinstance(value, bool):
+        raise ConfigError(f"invalid config key {key!r} from {origin}: expected a positive number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(
+            f"invalid config key {key!r} from {origin}: expected a positive number"
+        ) from exc
+    if number <= 0:
+        raise ConfigError(f"invalid config key {key!r} from {origin}: expected a positive number")
+    return number
+
+
+@dataclass(frozen=True)
+class Config:
+    values: dict[str, Value]
+
+    def get(self, key: str) -> float:
+        return self.values[key].value
+
+    def report(self) -> dict[str, dict[str, float | str]]:
+        return {
+            key: {"value": value.value, "origin": value.origin}
+            for key, value in self.values.items()
+        }
+
+
+def load(*, path: Path | None = None, flags: dict[str, float | None] | None = None) -> Config:
+    """Load policy with file < environment < CLI-flag precedence."""
+    target = path or default_path()
+    result = {key: Value(value, "default") for key, value in _DEFAULTS.items()}
+    if target.exists():
+        try:
+            raw = tomllib.loads(target.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise ConfigError(f"invalid config file {target}: {exc}") from exc
+        policy = raw.get("policy", raw)
+        if not isinstance(policy, dict):
+            raise ConfigError(f"invalid config file {target}: [policy] must be a table")
+        for key, value in policy.items():
+            if key not in result:
+                raise ConfigError(f"invalid config key {key!r} in {target}")
+            result[key] = Value(_number(key, value, str(target)), str(target))
+    for key, env in _ENV.items():
+        if env in os.environ:
+            result[key] = Value(_number(key, os.environ[env], env), env)
+    for key, value in (flags or {}).items():
+        if value is not None:
+            if key not in result:
+                raise ConfigError(f"invalid config flag {key!r}")
+            result[key] = Value(_number(key, value, "flag"), "flag")
+    return Config(result)

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -109,6 +109,9 @@ class Collector:
 def status(registry: Registry, engine: Engine | None = None) -> dict:
     """Tiers, leases, and foreign registries. Read-only: works with the daemon dead."""
     engine = engine or Engine()
+    from bosn.config import load as load_config
+
+    config = load_config()
     verdicts = plan(registry)
     scan = ResourceScanner(engine).scan(registry.registry_id)
 
@@ -118,6 +121,7 @@ def status(registry: Registry, engine: Engine | None = None) -> dict:
 
     return {
         "registry_id": registry.registry_id,
+        "config": config.report(),
         "registered": len(verdicts),
         "collectable": len(collectable(verdicts)),
         "by_reason": by_reason,

--- a/src/bosn/jobs.py
+++ b/src/bosn/jobs.py
@@ -43,7 +43,6 @@ terminates with a reason its clients can read.
 from __future__ import annotations
 
 import itertools
-import os
 import queue
 import threading
 import time
@@ -84,23 +83,15 @@ def default_max_builds() -> int:
     own distinct key are all individually legal and can still saturate the machine. #1 caps
     bytes; this is the CPU-side analogue of the same commitment.
     """
-    override = os.environ.get("BOSN_MAX_BUILDS")
-    if override:
-        try:
-            return max(1, int(override))
-        except ValueError:
-            pass
-    return max(2, (os.cpu_count() or 2) // 2)
+    from bosn.config import load
+
+    return int(load().get("max_builds"))
 
 
 def default_ttl_seconds() -> float:
-    override = os.environ.get("BOSN_BUILD_TTL_SECONDS")
-    if override:
-        try:
-            return max(1.0, float(override))
-        except ValueError:
-            pass
-    return DEFAULT_TTL_SECONDS
+    from bosn.config import load
+
+    return load().get("build_ttl_seconds")
 
 
 class JobError(RuntimeError):

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -63,13 +63,19 @@ class Pressure:
 
 
 def container_should_stop(resource: Resource, now: float) -> bool:
-    return resource.kind == "container" and (now - resource.last_used) >= CONTAINER_IDLE_STOP
+    from bosn.config import load
+
+    return resource.kind == "container" and (now - resource.last_used) >= load().get(
+        "container_idle_stop"
+    )
 
 
 def _ttl_for(resource: Resource) -> float:
+    from bosn.config import load
+
     if resource.kind == "container":
-        return CONTAINER_REMOVE
-    return VOLUME_WARM_TTL
+        return load().get("container_remove")
+    return load().get("warm_volume_ttl")
 
 
 def evaluate(
@@ -98,7 +104,9 @@ def evaluate(
         return Verdict(resource, False, KEPT_QUIET_PERIOD)
 
     if superseded:
-        if age >= SUPERSEDED_CAP:
+        from bosn.config import load
+
+        if age >= load().get("superseded_cap"):
             return Verdict(resource, True, COLLECT_SUPERSEDED)
         return Verdict(resource, False, KEPT_WARM)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from bosn.config import ConfigError, load
+
+
+def test_config_precedence_and_origins(monkeypatch, tmp_path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text("[policy]\nwarm_volume_ttl = 12\n", encoding="utf-8")
+    monkeypatch.setenv("BOSN_WARM_VOLUME_TTL", "24")
+    config = load(path=path, flags={"warm_volume_ttl": 48})
+    assert config.get("warm_volume_ttl") == 48
+    assert config.report()["warm_volume_ttl"]["origin"] == "flag"
+
+
+def test_invalid_config_fails_closed_naming_the_key(tmp_path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text("[policy]\nwarm_volume_ttl = 0\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="warm_volume_ttl"):
+        load(path=path)


### PR DESCRIPTION
## What changed
- Add strict TOML policy configuration with defaults, environment and CLI precedence, and origins.
- Route retention, daemon retirement, and job policy controls through effective configuration.
- Report effective policy in status and document every supported key.

## Validation
- python -m pytest tests/test_config.py tests/test_retention.py tests/test_jobs.py tests/test_options.py tests/test_gc.py -q
- python -m ruff check src tests
- python -m pyright

Closes #17