### PR TITLE
Normalize workspace paths across shells

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -455,6 +455,15 @@ def cmd_shell(opts: Options) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    from bosn.paths import in_wsl
+
+    if in_wsl():
+        print(
+            "bosn v1 does not support WSL: its Windows loopback daemon is unreachable "
+            "from WSL; use a native Windows shell or wait for the v2 transport.",
+            file=sys.stderr,
+        )
+        return 1
     parser = build_parser()
     ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
     opts = from_namespace(ns)

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -9,11 +9,9 @@ whose remedy is always the same mechanical command is just a forced retry loop.
 from __future__ import annotations
 
 import datetime as dt
-import os
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
 
 from bosn import labels
 from bosn.engine import Engine, EngineError
@@ -341,4 +339,6 @@ def workspace_of(manifest: Manifest) -> str:
     drive-letter and case differences that would otherwise split it in two. Keying on the
     cwd instead is the per-worktree path-hashing that produced the volume explosion in #1.
     """
-    return os.path.normcase(str(Path(manifest.root).resolve()))
+    from bosn.paths import normalize_workspace_path
+
+    return normalize_workspace_path(manifest.root)

--- a/src/bosn/paths.py
+++ b/src/bosn/paths.py
@@ -1,0 +1,30 @@
+"""Canonical path identities across native Windows, MSYS, WSL and UNC spellings."""
+
+from __future__ import annotations
+
+import ntpath
+import os
+import re
+from pathlib import Path
+
+
+def normalize_workspace_path(path: str | Path) -> str:
+    raw = str(path).replace("\\", "/")
+    raw = re.sub(r"^//\?/", "", raw)
+    match = re.match(r"^/(?:mnt/)?([a-zA-Z])/(.*)$", raw)
+    if match:
+        raw = f"{match.group(1).upper()}:/{match.group(2)}"
+    if re.match(r"^[a-zA-Z]:/", raw) or raw.startswith("//"):
+        # ntpath is deliberately used even on non-Windows hosts so persisted identities
+        # remain stable when a registry is inspected from another supported shell.
+        return ntpath.normcase(ntpath.normpath(raw.replace("/", "\\")))
+    return os.path.normcase(str(Path(raw).resolve()))
+
+
+def in_wsl() -> bool:
+    if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
+        return True
+    try:
+        return "microsoft" in Path("/proc/sys/kernel/osrelease").read_text().lower()
+    except OSError:
+        return False

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,22 @@
+from bosn.paths import normalize_workspace_path
+
+
+def test_windows_native_msys_wsl_and_extended_spellings_share_an_identity() -> None:
+    expected = normalize_workspace_path(r"C:\Users\Me\work")
+    assert normalize_workspace_path("/c/Users/Me/work") == expected
+    assert normalize_workspace_path("/mnt/c/Users/Me/work") == expected
+    assert normalize_workspace_path(r"\\?\C:\Users\Me\work") == expected
+
+
+def test_unc_case_and_separator_spellings_share_an_identity() -> None:
+    assert normalize_workspace_path(r"\\Server\Share\Work") == normalize_workspace_path(
+        "//server/share/work"
+    )
+
+
+def test_wsl_is_rejected_with_the_transport_explanation(monkeypatch, capsys) -> None:
+    import bosn.cli
+
+    monkeypatch.setattr("bosn.paths.in_wsl", lambda: True)
+    assert bosn.cli.main(["--version"]) == 1
+    assert "does not support WSL" in capsys.readouterr().err


### PR DESCRIPTION
## What changed
- Normalize native Windows, MSYS, WSL-form, extended-length, and UNC workspace spellings.
- Route workspace identity through one normalization function.
- Reject WSL with the documented v1 loopback transport explanation.

## Validation
- python -m pytest tests/test_paths.py tests/test_converge.py tests/test_cli_smoke.py -q
- python -m ruff check src tests
- python -m pyright

Closes #19