### PR TITLE
Authenticate daemon IPC

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -18,6 +18,7 @@ import errno
 import hashlib
 import json
 import os
+import secrets
 import socket
 import socketserver
 import subprocess
@@ -62,6 +63,17 @@ def state_file(state_dir: Path | None = None) -> Path:
 def heartbeat_file(state_dir: Path | None = None) -> Path:
     """A host-visible heartbeat consumed by persistent container PID 1 watchdogs."""
     return (state_dir or default_state_dir()) / "daemon.heartbeat"
+
+
+def secret_file(state_dir: Path | None = None) -> Path:
+    return (state_dir or default_state_dir()) / "daemon.secret"
+
+
+def _secret(state_dir: Path | None = None) -> str:
+    try:
+        return secret_file(state_dir).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
 
 
 def port_for(state_dir: Path | None = None) -> int:
@@ -109,7 +121,9 @@ class DaemonState:
 def is_serving(state_dir: Path | None = None, *, timeout: float = 2.0) -> bool:
     """True when something answers the ping on this state dir's port."""
     try:
-        reply = ipc.send_request(port_for(state_dir), {"verb": "ping"}, timeout=timeout)
+        reply = ipc.send_request(
+            port_for(state_dir), {"verb": "ping", "auth": _secret(state_dir)}, timeout=timeout
+        )
     except ipc.TransportError:
         return False
     return bool(reply.get("ok"))
@@ -129,8 +143,19 @@ def running_state(state_dir: Path | None = None) -> DaemonState | None:
         path.unlink(missing_ok=True)
         return None
     if state is None:
-        # Serving but no readable metadata: report what we can prove.
-        return DaemonState(pid=0, port=port_for(state_dir), started_at=0.0, version="unknown")
+        # Serving but no readable metadata: report what the authenticated ping proves.
+        try:
+            reply = ipc.send_request(
+                port_for(state_dir), {"verb": "ping", "auth": _secret(state_dir)}
+            )
+            return DaemonState(
+                pid=int(reply.get("pid") or 0),
+                port=port_for(state_dir),
+                started_at=0.0,
+                version=str(reply.get("version") or "unknown"),
+            )
+        except ipc.TransportError:
+            return None
     return state
 
 
@@ -142,6 +167,24 @@ class _Handler(socketserver.StreamRequestHandler):
         daemon_ref: Daemon = self.server.daemon_ref  # type: ignore[attr-defined]
         daemon_ref.note_activity()
         verb = str(request.get("verb", ""))
+        if not secrets.compare_digest(str(request.get("auth") or ""), daemon_ref.secret):
+            daemon_ref.registry.log_event("ipc.unauthenticated", verb)
+            ipc.send_response(
+                self.connection, {"ok": False, "error": "unauthenticated IPC request"}
+            )
+            return
+        if str(request.get("version") or __version__) != __version__ and verb in {
+            "cancel",
+            "shutdown",
+        }:
+            ipc.send_response(
+                self.connection,
+                {
+                    "ok": False,
+                    "error": "daemon version differs; restart the daemon before destructive use",
+                },
+            )
+            return
         try:
             if verb in STREAMING_VERBS:
                 self._stream(daemon_ref, verb, request)
@@ -230,6 +273,7 @@ class Daemon:
         self.heartbeat_at = self.started_at
         self._server: _Server | None = None
         self._stop = threading.Event()
+        self.secret = secrets.token_urlsafe(32)
         self.registry = Registry(self.state_dir / "registry.sqlite3")
         self.jobs = JobManager(
             self._build,
@@ -287,6 +331,11 @@ class Daemon:
             version=__version__,
         ).write(state_file(self.state_dir))
         self._write_heartbeat()
+        secret_file(self.state_dir).write_text(self.secret, encoding="utf-8")
+        try:
+            os.chmod(secret_file(self.state_dir), 0o600)
+        except OSError:
+            pass
         self.registry.log_event("daemon.started", f"pid={os.getpid()} port={self.port}")
 
         threading.Thread(target=self._idle_watchdog, daemon=True).start()
@@ -331,6 +380,7 @@ class Daemon:
             self._server = None
         state_file(self.state_dir).unlink(missing_ok=True)
         heartbeat_file(self.state_dir).unlink(missing_ok=True)
+        secret_file(self.state_dir).unlink(missing_ok=True)
         try:
             self.registry.log_event("daemon.stopped", "")
             self.registry.close()
@@ -562,7 +612,7 @@ def spawn(state_dir: Path | None = None, *, timeout: float = SPAWN_TIMEOUT_SECON
     state_dir = state_dir or default_state_dir()
     if is_serving(state_dir):
         state = running_state(state_dir)
-        if state is not None:
+        if state is not None and state.pid:
             return state
 
     _detach(state_dir)
@@ -570,7 +620,7 @@ def spawn(state_dir: Path | None = None, *, timeout: float = SPAWN_TIMEOUT_SECON
     deadline = time.time() + timeout
     while time.time() < deadline:
         state = running_state(state_dir)
-        if state is not None:
+        if state is not None and state.pid:
             return state
         time.sleep(0.1)
     raise DaemonError(f"daemon did not answer on port {port_for(state_dir)} within {timeout:.0f}s")
@@ -593,7 +643,10 @@ def request(
         if not autostart:
             raise DaemonError("no bosn daemon is running")
         spawn(state_dir)
-    return ipc.send_request(port_for(state_dir), {"verb": verb, **payload})
+    return ipc.send_request(
+        port_for(state_dir),
+        {"verb": verb, "auth": _secret(state_dir), "version": __version__, **payload},
+    )
 
 
 def stream(
@@ -609,7 +662,10 @@ def stream(
         if not autostart:
             raise DaemonError("no bosn daemon is running")
         spawn(state_dir)
-    return ipc.stream_request(port_for(state_dir), {"verb": verb, **payload})
+    return ipc.stream_request(
+        port_for(state_dir),
+        {"verb": verb, "auth": _secret(state_dir), "version": __version__, **payload},
+    )
 
 
 def stop(state_dir: Path | None = None, *, timeout: float = 10.0) -> bool:
@@ -618,7 +674,11 @@ def stop(state_dir: Path | None = None, *, timeout: float = 10.0) -> bool:
     if not is_serving(state_dir):
         return False
     try:
-        ipc.send_request(port_for(state_dir), {"verb": "shutdown"}, timeout=timeout)
+        ipc.send_request(
+            port_for(state_dir),
+            {"verb": "shutdown", "auth": _secret(state_dir), "version": __version__},
+            timeout=timeout,
+        )
     except ipc.TransportError:
         pass
     deadline = time.time() + timeout

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -125,20 +125,20 @@ def test_daemon_publishes_state_and_answers_ping(served: Daemon, tmp_path: Path)
     assert state is not None
     assert state.port == served.port == daemon_mod.port_for(tmp_path)
     assert state.pid == os.getpid()
-    reply = ipc.send_request(state.port, {"verb": "ping"})
+    reply = ipc.send_request(state.port, {"verb": "ping", "auth": served.secret})
     assert reply["ok"] and reply["pong"]
     assert daemon_mod.heartbeat_file(tmp_path).exists()
 
 
 def test_status_reports_registry_id_and_uptime(served: Daemon) -> None:
-    reply = ipc.send_request(served.port, {"verb": "status"})
+    reply = ipc.send_request(served.port, {"verb": "status", "auth": served.secret})
     assert reply["ok"]
     assert reply["registry_id"] == served.registry.registry_id
     assert reply["uptime_seconds"] >= 0
 
 
 def test_unknown_verb_is_rejected_not_ignored(served: Daemon) -> None:
-    reply = ipc.send_request(served.port, {"verb": "definitely-not-a-verb"})
+    reply = ipc.send_request(served.port, {"verb": "definitely-not-a-verb", "auth": served.secret})
     assert reply["ok"] is False
     assert "unknown daemon verb" in reply["error"]
 
@@ -153,7 +153,7 @@ def test_requests_refresh_the_heartbeat(served: Daemon) -> None:
 def test_registry_is_usable_from_the_server_threads(served: Daemon) -> None:
     """The daemon serves on threads; a thread-affine sqlite handle would fail here."""
     for _ in range(5):
-        assert ipc.send_request(served.port, {"verb": "status"})["ok"]
+        assert ipc.send_request(served.port, {"verb": "status", "auth": served.secret})["ok"]
 
 
 # -- shutdown and retirement -----------------------------------------------
@@ -239,7 +239,9 @@ def test_real_detached_spawn_and_autostart(tmp_path: Path) -> None:
     try:
         assert state.port == daemon_mod.port_for(tmp_path)
         assert state.pid != os.getpid(), "daemon must be a separate process"
-        assert ipc.send_request(state.port, {"verb": "ping"})["ok"]
+        assert ipc.send_request(state.port, {"verb": "ping", "auth": daemon_mod._secret(tmp_path)})[
+            "ok"
+        ]
 
         # spawn is idempotent and autostart reaches the same daemon
         assert daemon_mod.spawn(tmp_path).pid == state.pid

--- a/tests/test_daemon_jobs.py
+++ b/tests/test_daemon_jobs.py
@@ -93,7 +93,12 @@ def served(tmp_path: Path, builder: ControlledBuilder) -> Iterator[Daemon]:
 def converge_events(daemon: Daemon, project: Path, **extra):
     return ipc.stream_request(
         daemon.port,
-        {"verb": "converge", "manifest": str(project / "bosn.toml"), **extra},
+        {
+            "verb": "converge",
+            "manifest": str(project / "bosn.toml"),
+            "auth": daemon.secret,
+            **extra,
+        },
         timeout=30,
     )
 
@@ -136,7 +141,11 @@ def test_an_unreadable_manifest_is_reported_not_swallowed(served: Daemon, tmp_pa
     events = drain(
         ipc.stream_request(
             served.port,
-            {"verb": "converge", "manifest": str(tmp_path / "nope" / "bosn.toml")},
+            {
+                "verb": "converge",
+                "manifest": str(tmp_path / "nope" / "bosn.toml"),
+                "auth": served.secret,
+            },
             timeout=30,
         )
     )
@@ -161,7 +170,7 @@ def test_hanging_up_mid_build_leaves_the_job_running(
 
     assert served.jobs.get(job_id).state == "running", "the daemon kept the work"
 
-    listed = ipc.send_request(served.port, {"verb": "jobs"})["jobs"]
+    listed = ipc.send_request(served.port, {"verb": "jobs", "auth": served.secret})["jobs"]
     assert [row for row in listed if row["id"] == job_id and row["state"] == "running"]
 
 
@@ -173,7 +182,9 @@ def test_attach_reconnects_to_a_surviving_job(
     assert builder.started.wait(10)
     stream.close()
 
-    reattached = ipc.stream_request(served.port, {"verb": "attach", "job": job_id}, timeout=30)
+    reattached = ipc.stream_request(
+        served.port, {"verb": "attach", "job": job_id, "auth": served.secret}, timeout=30
+    )
     first = next(reattached)
     assert first["event"] == "attached"
     assert first["job"] == job_id
@@ -199,7 +210,11 @@ def test_rerunning_the_same_verb_reattaches_instead_of_rebuilding(
 
 
 def test_attaching_to_an_unknown_job_says_so(served: Daemon) -> None:
-    events = drain(ipc.stream_request(served.port, {"verb": "attach", "job": "nope"}, timeout=10))
+    events = drain(
+        ipc.stream_request(
+            served.port, {"verb": "attach", "job": "nope", "auth": served.secret}, timeout=10
+        )
+    )
     assert events[-1]["ok"] is False
     assert "no such job" in events[-1]["error"]
 
@@ -214,7 +229,7 @@ def test_cancel_stops_a_running_build_and_tells_the_watcher(
     job_id = next(stream)["job"]
     assert builder.started.wait(10)
 
-    reply = ipc.send_request(served.port, {"verb": "cancel", "job": job_id})
+    reply = ipc.send_request(served.port, {"verb": "cancel", "job": job_id, "auth": served.secret})
     assert reply["ok"]
 
     final = [e for e in stream if e.get("final")]
@@ -234,7 +249,7 @@ def test_a_cancelled_build_leaves_no_generation_row(
     stream = converge_events(served, project)
     job_id = next(stream)["job"]
     assert builder.started.wait(10)
-    ipc.send_request(served.port, {"verb": "cancel", "job": job_id})
+    ipc.send_request(served.port, {"verb": "cancel", "job": job_id, "auth": served.secret})
     drain(stream)
 
     assert served.registry.generation_superseded_at(digest) is None
@@ -246,7 +261,9 @@ def test_a_cancelled_build_leaves_no_generation_row(
 
 
 def test_cancelling_an_unknown_job_is_an_error(served: Daemon) -> None:
-    reply = ipc.send_request(served.port, {"verb": "cancel", "job": "j0-nope"})
+    reply = ipc.send_request(
+        served.port, {"verb": "cancel", "job": "j0-nope", "auth": served.secret}
+    )
     assert reply["ok"] is False
     assert "no such job" in reply["error"]
 
@@ -267,7 +284,7 @@ def test_a_running_job_blocks_idle_retirement(
         assert wait_until(lambda: daemon_mod.is_serving(state_dir))
         stream = ipc.stream_request(
             daemon.port,
-            {"verb": "converge", "manifest": str(project / "bosn.toml")},
+            {"verb": "converge", "manifest": str(project / "bosn.toml"), "auth": daemon.secret},
             timeout=30,
         )
         next(stream)
@@ -311,7 +328,7 @@ def test_a_job_that_never_reports_cannot_pin_the_daemon_forever(
         assert wait_until(lambda: daemon_mod.is_serving(state_dir))
         stream = ipc.stream_request(
             daemon.port,
-            {"verb": "converge", "manifest": str(project / "bosn.toml")},
+            {"verb": "converge", "manifest": str(project / "bosn.toml"), "auth": daemon.secret},
             timeout=30,
         )
         next(stream)
@@ -339,7 +356,9 @@ def test_shutdown_tells_attached_clients_why_their_build_stopped(
     assert wait_until(lambda: daemon_mod.is_serving(state_dir))
 
     stream = ipc.stream_request(
-        daemon.port, {"verb": "converge", "manifest": str(project / "bosn.toml")}, timeout=30
+        daemon.port,
+        {"verb": "converge", "manifest": str(project / "bosn.toml"), "auth": daemon.secret},
+        timeout=30,
     )
     job_id = next(stream)["job"]
     assert builder.started.wait(10)
@@ -359,7 +378,7 @@ def test_shutdown_tells_attached_clients_why_their_build_stopped(
 def test_jobs_verb_reports_real_jobs_not_a_placeholder(
     served: Daemon, project: Path, builder: ControlledBuilder
 ) -> None:
-    reply = ipc.send_request(served.port, {"verb": "jobs"})
+    reply = ipc.send_request(served.port, {"verb": "jobs", "auth": served.secret})
     assert reply["jobs"] == []
     assert reply["max_builds"] >= 1
 
@@ -367,7 +386,7 @@ def test_jobs_verb_reports_real_jobs_not_a_placeholder(
     job_id = next(stream)["job"]
     assert builder.started.wait(10)
 
-    listed = ipc.send_request(served.port, {"verb": "jobs"})["jobs"]
+    listed = ipc.send_request(served.port, {"verb": "jobs", "auth": served.secret})["jobs"]
     assert [row for row in listed if row["id"] == job_id]
     assert listed[0]["stack"] == "dev"
     stream.close()

--- a/tests/test_jobs_docker.py
+++ b/tests/test_jobs_docker.py
@@ -91,7 +91,7 @@ def _remove_built_images(engine: Engine) -> None:
 def converge(daemon: Daemon, project: Path, timeout: float = 300.0):
     return ipc.stream_request(
         daemon.port,
-        {"verb": "converge", "manifest": str(project / "bosn.toml")},
+        {"verb": "converge", "manifest": str(project / "bosn.toml"), "auth": daemon.secret},
         timeout=timeout,
     )
 
@@ -120,7 +120,9 @@ def test_a_real_build_outlives_the_client_that_asked_for_it(served: Daemon, proj
     assert served.jobs.get(job_id).state == "running", "the daemon kept building"
 
     # ...and a re-run reattaches to it rather than starting a second build
-    reattached = ipc.stream_request(served.port, {"verb": "attach", "job": job_id}, timeout=300)
+    reattached = ipc.stream_request(
+        served.port, {"verb": "attach", "job": job_id, "auth": served.secret}, timeout=300
+    )
     assert next(reattached)["event"] == "attached"
     final = [e for e in reattached if e.get("final")][-1]
     assert final["state"] == "succeeded", final.get("error")
@@ -165,7 +167,9 @@ def test_cancelling_a_real_build_leaves_no_generation_row(served: Daemon, projec
     job_id = next(stream)["job"]
     assert wait_until(lambda: served.jobs.get(job_id).state == "running", timeout=30)
 
-    assert ipc.send_request(served.port, {"verb": "cancel", "job": job_id})["ok"]
+    assert ipc.send_request(served.port, {"verb": "cancel", "job": job_id, "auth": served.secret})[
+        "ok"
+    ]
     final = [e for e in stream if e.get("final")][-1]
     assert final["state"] == "cancelled"
 


### PR DESCRIPTION
## What changed
- Rotate a state-directory secret at daemon startup and require it on every IPC request.
- Restrict secret permissions, remove it at shutdown, and log rejected requests.
- Advertise client version and refuse destructive IPC across a version mismatch.

## Validation
- python -m pytest tests/test_daemon.py -q
- python -m ruff check src tests
- python -m pyright

Closes #20