### PR TITLE
Fix GC idle-stop safety

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -472,6 +472,10 @@ def cmd_gc(opts: Options) -> int:
         result = collector.collect(dry_run=opts.dry_run, done_workspaces=done_workspaces(registry))
 
     print(json.dumps({**result.summary(), "dry_run": result.dry_run}, indent=2))
+    for name in result.would_stop:
+        print(f"would stop {name}")
+    for name in result.stopped:
+        print(f"stopped {name}")
     for name in result.removed:
         print(("would remove " if result.dry_run else "removed ") + name)
     for message in result.errors:

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -22,7 +22,16 @@ from bosn.accounting import probe, resource_bytes
 from bosn.engine import Engine
 from bosn.registry import Registry
 from bosn.resources import ResourceScanner
-from bosn.retention import Pressure, Verdict, collectable, container_should_stop, plan
+from bosn.retention import (
+    KEPT_LEASED,
+    KEPT_QUIET_PERIOD,
+    Pressure,
+    Verdict,
+    collectable,
+    container_should_stop,
+    evaluate,
+    plan,
+)
 
 _REMOVE_COMMANDS: dict[str, list[str]] = {
     "container": ["rm", "--force"],
@@ -34,6 +43,8 @@ _REMOVE_COMMANDS: dict[str, list[str]] = {
 @dataclass
 class GCResult:
     dry_run: bool
+    stopped: list[str] = field(default_factory=list)
+    would_stop: list[str] = field(default_factory=list)
     removed: list[str] = field(default_factory=list)
     kept: list[str] = field(default_factory=list)
     skipped_unproven: list[str] = field(default_factory=list)
@@ -41,6 +52,8 @@ class GCResult:
 
     def summary(self) -> dict[str, int]:
         return {
+            "stopped": len(self.stopped),
+            "would_stop": len(self.would_stop),
             "removed": len(self.removed),
             "kept": len(self.kept),
             "skipped_unproven": len(self.skipped_unproven),
@@ -70,6 +83,7 @@ class Collector:
         done_workspaces: set[str] | None = None,
         pressure: Pressure | None = None,
     ) -> GCResult:
+        done_workspaces = done_workspaces or set()
         verdicts: list[Verdict] = plan(
             self.registry, done_workspaces=done_workspaces, pressure=pressure
         )
@@ -78,15 +92,46 @@ class Collector:
         for verdict in verdicts:
             if not verdict.collect:
                 result.kept.append(verdict.name)
-                if container_should_stop(verdict.resource, self.registry.clock.now()):
-                    stopped = self.engine.run(["container", "stop", verdict.name])
+                if not container_should_stop(verdict.resource, self.registry.clock.now()):
+                    continue
+                # The planning snapshot is not a mutation boundary: another client may
+                # acquire a lease while the rest of the plan is evaluated. Serialize all
+                # registry writers, re-read the resource and its leases, re-confirm engine
+                # ownership, and only then stop it while the guard remains held.
+                with self.registry.lifecycle_guard():
+                    resource = self.registry.get_resource(verdict.resource.id)
+                    if resource is None:
+                        continue
+                    current = evaluate(
+                        self.registry,
+                        resource,
+                        superseded=self.registry.generation_superseded_at(resource.generation)
+                        is not None,
+                        workspace_done=resource.workspace in done_workspaces,
+                        pressure=pressure,
+                    )
+                    protected = current.reason in {KEPT_LEASED, KEPT_QUIET_PERIOD}
+                    if (
+                        current.collect
+                        or protected
+                        or not container_should_stop(resource, self.registry.clock.now())
+                    ):
+                        continue
+                    if not self._ownership_proven(resource.kind, resource.name):
+                        result.skipped_unproven.append(resource.name)
+                        self.registry.log_event("gc.skipped_unproven", resource.name)
+                        continue
+                    if dry_run:
+                        result.would_stop.append(resource.name)
+                        continue
+                    stopped = self.engine.run(["container", "stop", resource.name])
                     if stopped.ok:
-                        self.registry.log_event("container.stopped_idle", verdict.name)
+                        result.stopped.append(resource.name)
+                        self.registry.log_event("container.stopped_idle", resource.name)
                     else:
-                        self.registry.log_event(
-                            "container.stop_error",
-                            f"{verdict.name}: {stopped.stderr or stopped.stdout}",
-                        )
+                        message = f"{resource.name}: {stopped.stderr or stopped.stdout}"
+                        result.errors.append(message)
+                        self.registry.log_event("container.stop_error", message)
 
         # Containers retain their volumes even after they have stopped. Remove them
         # first so a done workspace can be collected in one pass.

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -14,6 +14,8 @@ import os
 import sqlite3
 import threading
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -161,6 +163,29 @@ class Registry:
         """Every statement goes through here so the daemon stays single-writer."""
         with self._lock:
             return self.conn.execute(sql, params)
+
+    @contextmanager
+    def lifecycle_guard(self) -> Iterator[None]:
+        """Serialize a lifecycle decision and its engine mutation across registry writers.
+
+        GC must not validate that a container is unleased, release the database lock, and
+        then stop it after another connection has acquired a lease. ``BEGIN IMMEDIATE``
+        excludes writes from other sqlite connections while the in-process lock covers the
+        daemon's worker threads. The guarded sections are deliberately narrow and reserved
+        for lifecycle mutations that must be atomic with their final registry recheck.
+        """
+        with self._lock:
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                yield
+            except KeyboardInterrupt:
+                self.conn.execute("ROLLBACK")
+                raise
+            except Exception:
+                self.conn.execute("ROLLBACK")
+                raise
+            else:
+                self.conn.execute("COMMIT")
 
     def _ensure_meta(self) -> None:
         self._exec(

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
+import threading
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -24,11 +27,22 @@ class FakeEngine:
         self.label_map = label_map
         self.commands: list[list[str]] = []
         self.fail_on: set[str] = set()
+        self.on_inspect: Callable[[], None] | None = None
+        self.lease_acquired = threading.Event()
+        self.lease_was_active_when_stopped = False
 
     def run(self, args: list[str], *, check: bool = False) -> EngineResult:
         self.commands.append(list(args))
         if "inspect" in args:
+            if self.on_inspect is not None:
+                self.on_inspect()
             return EngineResult(0, json.dumps(self.label_map.get(args[-1], {})), "")
+        if args[:2] == ["container", "stop"]:
+            self.lease_was_active_when_stopped = self.lease_acquired.is_set()
+            name = args[-1]
+            if name in self.fail_on:
+                return EngineResult(1, "", "stop failed")
+            return EngineResult(0, name, "")
         if args[0] in {"rm", "volume", "image"} and "rm" in args:
             name = args[-1]
             if name in self.fail_on:
@@ -40,10 +54,10 @@ class FakeEngine:
         return [c[-1] for c in self.commands if "rm" in c]
 
 
-def label_dict(registry: str = OURS, **overrides: str) -> dict[str, str]:
+def label_dict(registry: str = OURS, kind: str = "volume", **overrides: str) -> dict[str, str]:
     base = labels.ResourceLabels(
         registry=registry,
-        kind="volume",
+        kind=kind,
         stack="s",
         generation="g",
         scope="spec",
@@ -65,9 +79,9 @@ def registry(tmp_path: Path, clock: FakeClock):
         yield reg
 
 
-def add(registry: Registry, name: str, scope="spec", workspace="/w"):
+def add(registry: Registry, name: str, scope="spec", workspace="/w", kind="volume"):
     return registry.register_resource(
-        kind="volume", name=name, stack="s", generation="g", scope=scope, workspace=workspace
+        kind=kind, name=name, stack="s", generation="g", scope=scope, workspace=workspace
     )
 
 
@@ -144,6 +158,121 @@ def test_dry_run_removes_nothing(registry: Registry, clock: FakeClock) -> None:
     assert result.removed == ["ours"], "dry run still reports what would go"
     assert engine.removals() == []
     assert len(registry.list_resources()) == 1
+
+
+def test_dry_run_plans_idle_stop_without_mutating_engine(
+    registry: Registry, clock: FakeClock
+) -> None:
+    add(registry, "idle", kind="container")
+    engine = FakeEngine({"idle": label_dict(registry=registry.registry_id, kind="container")})
+    clock.advance(2 * 3600)
+
+    result = Collector(registry, engine).collect(dry_run=True)  # type: ignore[arg-type]
+
+    assert result.would_stop == ["idle"]
+    assert result.stopped == []
+    assert [cmd for cmd in engine.commands if cmd[:2] == ["container", "stop"]] == []
+
+
+def test_live_lease_prevents_idle_stop_even_in_apply_mode(
+    registry: Registry, clock: FakeClock
+) -> None:
+    resource = add(registry, "active", kind="container")
+    registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+    engine = FakeEngine({"active": label_dict(registry=registry.registry_id, kind="container")})
+    clock.advance(2 * 3600)
+
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.kept == ["active"]
+    assert result.stopped == []
+    assert [cmd for cmd in engine.commands if cmd[:2] == ["container", "stop"]] == []
+
+
+def test_apply_stops_an_unleased_idle_container_and_reports_failure(
+    registry: Registry, clock: FakeClock
+) -> None:
+    add(registry, "idle", kind="container")
+    engine = FakeEngine({"idle": label_dict(registry=registry.registry_id, kind="container")})
+    clock.advance(2 * 3600)
+
+    stopped = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+    assert stopped.stopped == ["idle"]
+    assert any(row["kind"] == "container.stopped_idle" for row in registry.events())
+
+    engine.fail_on.add("idle")
+    failed = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+    assert failed.stopped == []
+    assert failed.errors == ["idle: stop failed"]
+    assert any(row["kind"] == "container.stop_error" for row in registry.events())
+
+
+@pytest.mark.parametrize("engine_labels", [{}, label_dict(registry="foreign", kind="container")])
+def test_idle_stop_requires_complete_current_ownership(
+    registry: Registry, clock: FakeClock, engine_labels: dict[str, str]
+) -> None:
+    add(registry, "not-ours", kind="container")
+    engine = FakeEngine({"not-ours": engine_labels})
+    clock.advance(2 * 3600)
+
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.skipped_unproven == ["not-ours"]
+    assert [cmd for cmd in engine.commands if cmd[:2] == ["container", "stop"]] == []
+
+
+def test_lease_acquired_after_planning_is_seen_before_idle_stop(
+    registry: Registry, clock: FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import bosn.gc as gc_mod
+
+    resource = add(registry, "active", kind="container")
+    engine = FakeEngine({"active": label_dict(registry=registry.registry_id, kind="container")})
+    clock.advance(2 * 3600)
+    original_plan = gc_mod.plan
+
+    def plan_then_lease(*args, **kwargs):
+        verdicts = original_plan(*args, **kwargs)
+        registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+        return verdicts
+
+    monkeypatch.setattr(gc_mod, "plan", plan_then_lease)
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.stopped == []
+    assert [cmd for cmd in engine.commands if cmd[:2] == ["container", "stop"]] == []
+
+
+def test_idle_stop_serializes_concurrent_lease_acquisition(
+    registry: Registry, clock: FakeClock
+) -> None:
+    resource = add(registry, "idle", kind="container")
+    engine = FakeEngine({"idle": label_dict(registry=registry.registry_id, kind="container")})
+    clock.advance(2 * 3600)
+    other = Registry(registry.path, clock=clock)
+    attempting = threading.Event()
+
+    def acquire() -> None:
+        attempting.set()
+        other.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+        engine.lease_acquired.set()
+
+    thread = threading.Thread(target=acquire)
+
+    def race_at_ownership_check() -> None:
+        thread.start()
+        assert attempting.wait(1)
+
+    engine.on_inspect = race_at_ownership_check
+    try:
+        result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+        thread.join(timeout=2)
+    finally:
+        other.close()
+
+    assert result.stopped == ["idle"]
+    assert not engine.lease_was_active_when_stopped
+    assert engine.lease_acquired.is_set()
 
 
 # -- errors are observable -------------------------------------------------


### PR DESCRIPTION
﻿## Summary

- make `gc --dry-run` report idle-stop plans without mutating Docker
- revalidate live leases under a cross-connection SQLite lifecycle guard before stopping
- require complete current ownership proof for idle stop
- report successful/planned stops and surface stop failures in results and events

## Root cause

Idle stop was executed while walking the original set of kept retention verdicts. That path neither checked dry-run nor ownership, and it trusted a lease snapshot that could be stale by the time Docker was mutated.

## Validation

- `uv run python ci/lint.py`
- `uv run pytest -q -m 'not docker'` (241 passed, 1 skipped, 22 deselected)
- focused GC/retention/registry tests (41 passed)
- pre-push `clud-review`: clean

Closes #33
