### PR TITLE
Fix persistent container replacement (#34)

### DIFF
--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from bosn import labels
 from bosn.engine import Engine, EngineError
 from bosn.manifest import Manifest, StackSpec, dockerfile_external_images, generation_digest
-from bosn.registry import Registry
+from bosn.registry import Lease, Registry, Resource
 
 # What converge did, in the order of increasing work.
 REUSED = "reused"
@@ -443,27 +443,58 @@ class Converger:
     def ensure_container(
         self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
     ) -> str:
-        """Create/start the persistent execution container, or reuse its existing one."""
+        """Validate and create, replace, or reuse the persistent execution container."""
+        with self.registry.lifecycle_guard():
+            name, _container_id, _resource, _created = self._ensure_container_locked(
+                converged, stack_name=stack_name, workspace=workspace
+            )
+        return name
+
+    def _ensure_container_locked(
+        self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
+    ) -> tuple[str, str, Resource, bool]:
         stack = self.manifest.stack(stack_name)
+        self._validate_converged_contract(stack, converged, workspace)
         name = self.container_name(workspace, stack.name)
-        inspected = self.engine.run(["container", "inspect", name])
-        if not inspected.ok:
-            labels = self._resource_labels(stack, "container", converged.digest, "stack", workspace)
+        expected_mounts = self._expected_container_mounts(stack, converged.volumes)
+        expected_image = self._expected_image_id(converged.image_tag)
+        existing = self._inspect_container(name)
+        container_id = self._container_id(name, existing) if existing is not None else ""
+        created_container_id: str | None = None
+        if existing is not None:
+            stale = self._container_stale_reasons(
+                name,
+                existing,
+                stack=stack,
+                workspace=workspace,
+                digest=converged.digest,
+                image_id=expected_image,
+                mounts=expected_mounts,
+            )
+            if stale:
+                self._refuse_if_container_leased(name)
+                # Mutate the exact object whose ownership was proved. A name could be
+                # externally reused between inspect and remove; deleting by name would
+                # then destroy a foreign replacement we never validated.
+                removed = self.engine.run(["container", "rm", "--force", container_id])
+                if not removed.ok and self._inspect_container(name) is not None:
+                    raise EngineError(
+                        f"replacing persistent container {name} failed: "
+                        f"{removed.stderr or removed.stdout}"
+                    )
+                self.registry.log_event("container.replaced", f"{name}: {', '.join(stale)}")
+                existing = None
+                container_id = ""
+
+        if existing is None:
+            resource_labels = self._resource_labels(
+                stack, "container", converged.digest, "stack", workspace
+            )
             # Docker removes an orphan automatically once PID 1's watchdog exits.
-            args = ["create", "--rm", "--name", name, *labels.to_docker_args()]
-            for volume in stack.volumes:
-                volume_name = volume_name_for(
-                    stack,
-                    volume.scope,
-                    volume.name,
-                    digest=converged.digest,
-                    workspace=workspace,
-                    family=stack.family,
-                )
-                args += ["--volume", f"{volume_name}:/bosn/{volume.name}"]
-            heartbeat = self.registry.path.parent / "daemon.heartbeat"
-            heartbeat.touch(exist_ok=True)
-            args += ["--volume", f"{heartbeat.resolve()}:/bosn-daemon/heartbeat:ro"]
+            args = ["create", "--rm", "--name", name, *resource_labels.to_docker_args()]
+            for mount in expected_mounts.values():
+                suffix = ":ro" if not mount["rw"] else ""
+                args += ["--volume", f"{mount['source']}:{mount['destination']}{suffix}"]
             # PID 1 exits when the daemon heartbeat goes stale or a run is orphaned for
             # too long.  `--rm` above then removes the stopped container automatically.
             watchdog = (
@@ -477,11 +508,311 @@ class Converger:
             created = self.engine.run(args)
             if not created.ok:
                 raise EngineError(f"creating persistent container {name} failed: {created.stderr}")
-            self._register(stack, "container", name, converged.digest, "stack", workspace)
-        started = self.engine.run(["start", name])
-        if not started.ok and "already started" not in (started.stderr or started.stdout).lower():
-            raise EngineError(f"starting persistent container {name} failed: {started.stderr}")
-        return name
+            created_container_id = created.stdout.strip()
+            if not created_container_id:
+                raise EngineError(
+                    f"creating persistent container {name} succeeded without returning its "
+                    "immutable object id; refusing to continue"
+                )
+            try:
+                existing = self._inspect_container(name)
+                if existing is None:
+                    raise EngineError(
+                        f"created persistent container {name} disappeared before validation"
+                    )
+                container_id = self._container_id(name, existing)
+                if container_id != created_container_id:
+                    raise EngineError(
+                        f"persistent container name collision: {name} was replaced between "
+                        "creation and validation; refusing to touch the replacement"
+                    )
+                stale = self._container_stale_reasons(
+                    name,
+                    existing,
+                    stack=stack,
+                    workspace=workspace,
+                    digest=converged.digest,
+                    image_id=expected_image,
+                    mounts=expected_mounts,
+                )
+                if stale:
+                    raise EngineError(
+                        f"created persistent container {name} does not match its specification: "
+                        f"{', '.join(stale)}"
+                    )
+            except KeyboardInterrupt:
+                self._cleanup_created_container(name, created_container_id)
+                raise
+            except Exception as exc:
+                cleanup_error = self._cleanup_created_container(name, created_container_id)
+                if cleanup_error:
+                    raise EngineError(f"{exc}; {cleanup_error}") from exc
+                raise
+        try:
+            started = self.engine.run(["start", container_id])
+            if (
+                not started.ok
+                and "already started" not in (started.stderr or started.stdout).lower()
+            ):
+                raise EngineError(f"starting persistent container {name} failed: {started.stderr}")
+            resource = self.registry.reconcile_resource(
+                kind="container",
+                name=name,
+                stack=stack.name,
+                generation=converged.digest,
+                scope="stack",
+                workspace=workspace,
+            )
+        except KeyboardInterrupt:
+            if created_container_id is not None:
+                self._cleanup_created_container(name, created_container_id)
+            raise
+        except Exception as exc:
+            if created_container_id is not None:
+                cleanup_error = self._cleanup_created_container(name, created_container_id)
+                if cleanup_error:
+                    raise EngineError(f"{exc}; {cleanup_error}") from exc
+            raise
+        return name, container_id, resource, created_container_id is not None
+
+    def _cleanup_created_container(self, name: str, container_id: str) -> str | None:
+        """Remove only the object this call created after validation/start fails."""
+        try:
+            removed = self.engine.run(["container", "rm", "--force", container_id])
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - report cleanup without masking root failure
+            return f"cleanup of newly created container {name} failed: {exc}"
+        if removed.ok:
+            return None
+        return (
+            f"cleanup of newly created container {name} failed: {removed.stderr or removed.stdout}"
+        )
+
+    def _expected_image_id(self, image: str) -> str:
+        inspected = self.engine.run(["image", "inspect", "--format", "{{.Id}}", image])
+        identity = inspected.stdout.strip()
+        if not inspected.ok or not identity:
+            raise EngineError(
+                f"cannot validate execution image {image!r}: {inspected.stderr or inspected.stdout}"
+            )
+        return identity
+
+    def _expected_container_mounts(
+        self, stack: StackSpec, volume_names: tuple[str, ...]
+    ) -> dict[str, dict[str, str | bool]]:
+        mounts: dict[str, dict[str, str | bool]] = {}
+        for volume, volume_name in zip(stack.volumes, volume_names, strict=True):
+            destination = f"/bosn/{volume.name}"
+            mounts[destination] = {
+                "type": "volume",
+                "source": volume_name,
+                "destination": destination,
+                "rw": True,
+            }
+        heartbeat = (self.registry.path.parent / "daemon.heartbeat").resolve()
+        heartbeat.touch(exist_ok=True)
+        mounts["/bosn-daemon/heartbeat"] = {
+            "type": "bind",
+            "source": str(heartbeat),
+            "destination": "/bosn-daemon/heartbeat",
+            "rw": False,
+        }
+        return mounts
+
+    @staticmethod
+    def _validate_converged_contract(
+        stack: StackSpec, converged: ConvergeResult, workspace: str
+    ) -> None:
+        if converged.stack != stack.name:
+            raise EngineError(
+                f"daemon converged stack {converged.stack!r}, but the client selected "
+                f"{stack.name!r}; reload the manifest and retry"
+            )
+        expected_volumes = tuple(
+            volume_name_for(
+                stack,
+                volume.scope,
+                volume.name,
+                digest=converged.digest,
+                workspace=workspace,
+                family=stack.family,
+            )
+            for volume in stack.volumes
+        )
+        if expected_volumes != converged.volumes:
+            raise EngineError(
+                "the manifest's volume contract changed while the daemon converged it; "
+                "reload the manifest and retry"
+            )
+
+    def _inspect_container(self, name: str) -> dict[str, object] | None:
+        inspected = self.engine.run(["container", "inspect", "--format", "{{json .}}", name])
+        if not inspected.ok:
+            detail = (inspected.stderr or inspected.stdout).lower()
+            if not detail or "no such" in detail or "not found" in detail:
+                return None
+            raise EngineError(f"inspecting persistent container {name} failed: {detail}")
+        try:
+            parsed = json.loads(inspected.stdout)
+        except json.JSONDecodeError as exc:
+            raise EngineError(
+                f"persistent container {name} returned invalid inspect data; refusing to touch it"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise EngineError(
+                f"persistent container {name} returned unexpected inspect data; "
+                "refusing to touch it"
+            )
+        return parsed
+
+    @staticmethod
+    def _container_id(name: str, inspected: dict[str, object]) -> str:
+        container_id = str(inspected.get("Id") or "")
+        if not container_id:
+            raise EngineError(
+                f"persistent container {name} inspect data has no object id; refusing to touch it"
+            )
+        return container_id
+
+    def _container_stale_reasons(
+        self,
+        name: str,
+        inspected: dict[str, object],
+        *,
+        stack: StackSpec,
+        workspace: str,
+        digest: str,
+        image_id: str,
+        mounts: dict[str, dict[str, str | bool]],
+    ) -> list[str]:
+        config = inspected.get("Config")
+        raw_labels = config.get("Labels") if isinstance(config, dict) else None
+        engine_labels = (
+            {str(key): str(value) for key, value in raw_labels.items() if value is not None}
+            if isinstance(raw_labels, dict)
+            else {}
+        )
+        if not labels.is_owned_by(engine_labels, self.registry.registry_id):
+            kind = "foreign" if labels.is_complete(engine_labels) else "incompletely labeled"
+            raise EngineError(
+                f"persistent container name collision: {name} is {kind}; "
+                "refusing to start, remove, or replace it"
+            )
+        try:
+            parsed = labels.ResourceLabels.from_dict(engine_labels)
+        except labels.LabelError as exc:
+            raise EngineError(
+                f"persistent container name collision: {name} has invalid labels; "
+                "refusing to touch it"
+            ) from exc
+        if (
+            parsed.kind != "container"
+            or parsed.scope != "stack"
+            or parsed.stack != stack.name
+            or parsed.workspace != workspace
+        ):
+            raise EngineError(
+                f"persistent container name collision: {name} belongs to another bosn resource; "
+                "refusing to start, remove, or replace it"
+            )
+
+        stale: list[str] = []
+        if parsed.generation != digest:
+            stale.append("generation changed")
+        if str(inspected.get("Image") or "") != image_id:
+            stale.append("image changed")
+        if not self._container_mounts_match(inspected.get("Mounts"), mounts):
+            stale.append("mounts changed")
+        return stale
+
+    @staticmethod
+    def _container_mounts_match(
+        raw_mounts: object, expected: dict[str, dict[str, str | bool]]
+    ) -> bool:
+        if not isinstance(raw_mounts, list):
+            return False
+        actual = {
+            str(mount.get("Destination") or ""): mount
+            for mount in raw_mounts
+            if isinstance(mount, dict) and mount.get("Destination")
+        }
+        managed_destinations = {
+            destination
+            for destination in actual
+            if destination.startswith("/bosn/") or destination == "/bosn-daemon/heartbeat"
+        }
+        if managed_destinations != set(expected):
+            return False
+        for destination, wanted in expected.items():
+            found = actual.get(destination)
+            if found is None or str(found.get("Type") or "") != wanted["type"]:
+                return False
+            if bool(found.get("RW")) != wanted["rw"]:
+                return False
+            if wanted["type"] == "volume":
+                if str(found.get("Name") or "") != wanted["source"]:
+                    return False
+            elif not Converger._bind_sources_match(
+                str(found.get("Source") or ""), str(wanted["source"])
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def _bind_sources_match(actual: str, expected: str) -> bool:
+        if os.path.normcase(os.path.normpath(actual)) == os.path.normcase(
+            os.path.normpath(expected)
+        ):
+            return True
+        normalized = expected.replace("\\", "/")
+        drive = re.match(r"^([A-Za-z]):/(.*)$", normalized)
+        if drive is None:
+            return False
+        letter, tail = drive.groups()
+        translated = actual.replace("\\", "/").rstrip("/").casefold()
+        candidates = {
+            f"/run/desktop/mnt/host/{letter}/{tail}",
+            f"/host_mnt/{letter}/{tail}",
+        }
+        return translated in {candidate.rstrip("/").casefold() for candidate in candidates}
+
+    def _refuse_if_container_leased(self, name: str) -> None:
+        from bosn.resources import resource_is_leased
+
+        rows = [
+            resource
+            for resource in self.registry.list_resources()
+            if resource.kind == "container" and resource.name == name
+        ]
+        if any(resource_is_leased(self.registry, resource.id) for resource in rows):
+            raise EngineError(
+                f"persistent container {name} is from an old generation but has an active "
+                "execution lease; retry after that command exits"
+            )
+
+    def _acquire_execution_container(
+        self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
+    ) -> tuple[str, Lease]:
+        with self.registry.lifecycle_guard():
+            name, container_id, resource, created = self._ensure_container_locked(
+                converged, stack_name=stack_name, workspace=workspace
+            )
+            try:
+                lease = self.registry.acquire_lease(
+                    resource.id, pid=os.getpid(), proc_start=self.registry.clock.now()
+                )
+            except KeyboardInterrupt:
+                if created:
+                    self._cleanup_created_container(name, container_id)
+                raise
+            except Exception as exc:
+                if created:
+                    cleanup_error = self._cleanup_created_container(name, container_id)
+                    if cleanup_error:
+                        raise EngineError(f"{exc}; {cleanup_error}") from exc
+                raise
+        return container_id, lease
 
     def run(
         self,
@@ -511,14 +842,10 @@ class Converger:
         caller's terminal and exit status.
         """
         workspace = workspace or workspace_of(self.manifest)
-        name = self.ensure_container(converged, stack_name=stack_name, workspace=workspace)
+        name, lease = self._acquire_execution_container(
+            converged, stack_name=stack_name, workspace=workspace
+        )
         args = ["exec", name, *command]
-        resource = next(
-            r for r in self.registry.list_resources() if r.kind == "container" and r.name == name
-        )
-        lease = self.registry.acquire_lease(
-            resource.id, pid=os.getpid(), proc_start=self.registry.clock.now()
-        )
         try:
             result = self.engine.run(args)
         finally:
@@ -530,12 +857,8 @@ class Converger:
         self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
     ) -> int:
         """Attach a real interactive shell to the persistent container."""
-        name = self.ensure_container(converged, stack_name=stack_name, workspace=workspace)
-        resource = next(
-            r for r in self.registry.list_resources() if r.kind == "container" and r.name == name
-        )
-        lease = self.registry.acquire_lease(
-            resource.id, pid=os.getpid(), proc_start=self.registry.clock.now()
+        name, lease = self._acquire_execution_container(
+            converged, stack_name=stack_name, workspace=workspace
         )
         try:
             return self.engine.interactive(["exec", "-it", name, "sh"])

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -244,6 +244,47 @@ class Registry:
         assert resource is not None
         return resource
 
+    def reconcile_resource(
+        self,
+        *,
+        kind: str,
+        name: str,
+        stack: str,
+        generation: str,
+        scope: str,
+        workspace: str,
+    ) -> Resource:
+        """Make existing rows for one engine name describe its current owned object.
+
+        Container names are stable across generation replacement. Updating their row in
+        place preserves identity for leases while correcting stale generation metadata;
+        issue #35 separately owns enforcing uniqueness for every resource kind.
+        """
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT id FROM resources WHERE kind = ? AND name = ? ORDER BY created_at",
+                (kind, name),
+            ).fetchall()
+            if not rows:
+                return self.register_resource(
+                    kind=kind,
+                    name=name,
+                    stack=stack,
+                    generation=generation,
+                    scope=scope,
+                    workspace=workspace,
+                )
+            now = self.clock.now()
+            self.conn.execute(
+                "UPDATE resources SET stack = ?, generation = ?, scope = ?, workspace = ?, "
+                "last_used = ?, state = 'active' WHERE kind = ? AND name = ?",
+                (stack, generation, scope, workspace, now, kind, name),
+            )
+            self.log_event("resource.reconciled", f"{kind}:{name}")
+            resource = self.get_resource(str(rows[0]["id"]))
+            assert resource is not None
+            return resource
+
     def get_resource(self, resource_id: str) -> Resource | None:
         row = self._exec("SELECT * FROM resources WHERE id = ?", (resource_id,)).fetchone()
         return _resource_from_row(row) if row else None

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import os
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
+from bosn import labels
 from bosn.converge import (
     REGISTERED,
     REUSED,
@@ -16,8 +20,9 @@ from bosn.converge import (
     generation_coalescing_key,
     resolved_generation,
     volume_name_for,
+    workspace_of,
 )
-from bosn.engine import EngineResult
+from bosn.engine import EngineError, EngineResult
 from bosn.manifest import load
 from bosn.registry import Registry
 
@@ -42,16 +47,23 @@ class FakeEngine:
         self.existing: set[str] = set()
         self.image_ids: dict[str, str] = {"alpine": "sha256:alpine-v1"}
         self.image_platforms: dict[str, str] = {"alpine": "linux/amd64"}
+        self.container_specs: dict[str, dict[str, object]] = {}
+        self.container_serial = 0
 
     def run(self, args: list[str], *, check: bool = False) -> EngineResult:
         self.commands.append(list(args))
         if args[:2] == ["version", "--format"]:
             return EngineResult(0, "linux/amd64", "")
+        if args[:2] == ["container", "inspect"] and "{{json .}}" in args:
+            spec = self.container_specs.get(args[-1])
+            return EngineResult(0 if spec else 1, json.dumps(spec) if spec else "", "")
         if args[:2] == ["image", "inspect"] and "{{.Id}}" in args:
             requested_platform = (
                 args[args.index("--platform") + 1] if "--platform" in args else None
             )
             identity = self.image_ids.get(args[-1])
+            if identity is None and args[-1] in self.image_ids.values():
+                identity = args[-1]
             platform_matches = requested_platform is None or (
                 self.image_platforms.get(args[-1]) == requested_platform
             )
@@ -68,10 +80,60 @@ class FakeEngine:
                 self.image_platforms.setdefault(args[-1], "linux/amd64")
         if args[:2] == ["volume", "create"]:
             self.existing.add(args[-1])
+        if args[:3] == ["container", "rm", "--force"]:
+            target = args[-1]
+            name = next(
+                (
+                    candidate
+                    for candidate, spec in self.container_specs.items()
+                    if candidate == target or spec.get("Id") == target
+                ),
+                target,
+            )
+            self.existing.discard(name)
+            self.container_specs.pop(name, None)
         if args[0] == "create":
-            self.existing.add(args[args.index("--name") + 1])
+            name = args[args.index("--name") + 1]
+            self.existing.add(name)
+            self.container_serial += 1
+            identity = f"{name}\0{self.container_serial}"
+            container_id = f"sha256:{hashlib.sha256(identity.encode()).hexdigest()}"
+            raw_labels = {
+                args[index + 1].split("=", 1)[0]: args[index + 1].split("=", 1)[1]
+                for index, value in enumerate(args[:-1])
+                if value == "--label"
+            }
+            mounts: list[dict[str, object]] = []
+            for index, value in enumerate(args[:-1]):
+                if value != "--volume":
+                    continue
+                rendered = args[index + 1]
+                read_only = rendered.endswith(":ro")
+                core = rendered[:-3] if read_only else rendered
+                source, destination = core.rsplit(":", 1)
+                mount_type = "bind" if destination == "/bosn-daemon/heartbeat" else "volume"
+                mounts.append(
+                    {
+                        "Type": mount_type,
+                        "Name": source if mount_type == "volume" else "",
+                        "Source": source,
+                        "Destination": destination,
+                        "RW": not read_only,
+                    }
+                )
+            image = args[-4]
+            self.container_specs[name] = {
+                "Id": container_id,
+                "Config": {"Labels": raw_labels, "Image": image},
+                "Image": self.image_ids.get(image, image),
+                "Mounts": mounts,
+            }
+            return EngineResult(0, container_id, "")
         if args[0] == "build":
-            self.existing.add(args[args.index("--tag") + 1])
+            tag = args[args.index("--tag") + 1]
+            self.existing.add(tag)
+            self.image_ids[tag] = f"sha256:{hashlib.sha256(tag.encode()).hexdigest()}"
+            self.image_platforms[tag] = "linux/amd64"
         return EngineResult(0, "ok", "")
 
     def stream(
@@ -505,18 +567,293 @@ def test_run_mounts_every_declared_volume(converger: Converger) -> None:
 
 
 def test_second_run_reuses_the_same_persistent_container(converger: Converger) -> None:
-    converger.run(["true"])
-    converger.run(["true"])
+    converged, _code, _output = converger.run(["true"])
     engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    name = converger.container_name(workspace_of(converger.manifest), converged.stack)
+    container_id = str(engine.container_specs[name]["Id"])
+
+    converger.run(["true"])
+
     assert len(engine.ran("create")) == 1
     assert len(engine.ran("exec")) == 2
+    assert {command[-1] for command in engine.ran("start")} == {container_id}
+    assert {command[1] for command in engine.ran("exec")} == {container_id}
+
+
+def test_generation_roll_replaces_the_container_and_reconciles_its_row(
+    project: Path, registry: Registry
+) -> None:
+    engine = FakeEngine()
+    first_converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+    first, code, _output = first_converger.run(["true"])
+    assert code == 0
+    name = first_converger.container_name(workspace_of(first_converger.manifest), first.stack)
+    first_container_id = str(engine.container_specs[name]["Id"])
+
+    (project / "Dockerfile").write_text("FROM alpine\nRUN echo changed\n", encoding="utf-8")
+    second_converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+    second, code, _output = second_converger.run(["true"])
+
+    assert code == 0
+    assert second.digest != first.digest
+    assert len(engine.ran("container", "rm", "--force")) == 1
+    assert engine.ran("container", "rm", "--force")[0][-1] == first_container_id
+    assert len(engine.ran("create")) == 2
+    assert engine.ran("create")[-1][-4] == second.image_tag
+    second_container_id = str(engine.container_specs[name]["Id"])
+    assert second_container_id != first_container_id
+    assert engine.ran("start")[-1][-1] == second_container_id
+    assert engine.ran("exec")[-1][1] == second_container_id
+    container_rows = [row for row in registry.list_resources() if row.kind == "container"]
+    assert container_rows
+    assert {row.generation for row in container_rows} == {second.digest}
+
+
+@pytest.mark.parametrize("collision", ["foreign", "incomplete"])
+def test_foreign_and_incomplete_container_collisions_are_refused_untouched(
+    converger: Converger, registry: Registry, collision: str
+) -> None:
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    converged = converger.converge()
+    workspace = workspace_of(converger.manifest)
+    name = converger.container_name(workspace, converged.stack)
+    if collision == "foreign":
+        raw_labels = labels.ResourceLabels(
+            registry="another-registry",
+            kind="container",
+            stack=converged.stack,
+            generation=converged.digest,
+            scope="stack",
+            workspace=workspace,
+            created="2026-01-01T00:00:00Z",
+        ).to_dict()
+    else:
+        raw_labels = {labels.REGISTRY: registry.registry_id}
+    engine.existing.add(name)
+    engine.container_specs[name] = {
+        "Id": "sha256:colliding-container",
+        "Config": {"Labels": raw_labels},
+        "Image": "sha256:collision",
+        "Mounts": [],
+    }
+
+    with pytest.raises(EngineError, match="name collision"):
+        converger.run_converged(converged, ["true"], stack_name=None, workspace=workspace)
+
+    assert engine.ran("container", "rm", "--force") == []
+    assert engine.ran("start") == []
+    assert name in engine.container_specs
+
+
+def test_changed_required_mount_recreates_an_owned_container(converger: Converger) -> None:
+    converged, code, _output = converger.run(["true"])
+    assert code == 0
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    name = converger.container_name(workspace_of(converger.manifest), converged.stack)
+    mounts = engine.container_specs[name]["Mounts"]
+    assert isinstance(mounts, list)
+    mounts.pop()
+
+    converger.run(["true"])
+
+    assert len(engine.ran("container", "rm", "--force")) == 1
+    assert len(engine.ran("create")) == 2
+
+
+def test_changed_image_id_recreates_an_owned_container(converger: Converger) -> None:
+    converged, code, _output = converger.run(["true"])
+    assert code == 0
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    name = converger.container_name(workspace_of(converger.manifest), converged.stack)
+    engine.container_specs[name]["Image"] = "sha256:not-the-converged-image"
+
+    converger.run(["true"])
+
+    assert len(engine.ran("container", "rm", "--force")) == 1
+    assert len(engine.ran("create")) == 2
+
+
+@pytest.mark.parametrize("failure", ["validation", "start"])
+def test_failed_new_container_is_removed_by_immutable_id(
+    project: Path, registry: Registry, failure: str
+) -> None:
+    class PostCreateFailingEngine(FakeEngine):
+        def __init__(self) -> None:
+            super().__init__()
+            self.created_id = ""
+
+        def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+            result = super().run(args, check=check)
+            if args[0] == "create":
+                self.created_id = result.stdout
+                if failure == "validation":
+                    name = args[args.index("--name") + 1]
+                    self.container_specs[name]["Mounts"] = []
+            if args[0] == "start" and failure == "start":
+                return EngineResult(1, "", "start failed")
+            return result
+
+    engine = PostCreateFailingEngine()
+    converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+
+    with pytest.raises(EngineError, match="does not match|starting .* failed"):
+        converger.run(["true"])
+
+    assert engine.created_id
+    assert engine.ran("container", "rm", "--force") == [
+        ["container", "rm", "--force", engine.created_id]
+    ]
+    assert engine.container_specs == {}
+    assert all(resource.kind != "container" for resource in registry.list_resources())
+
+
+def test_new_container_is_removed_if_lease_acquisition_fails(
+    project: Path, registry: Registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class TrackingEngine(FakeEngine):
+        def __init__(self) -> None:
+            super().__init__()
+            self.created_id = ""
+
+        def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+            result = super().run(args, check=check)
+            if args[0] == "create":
+                self.created_id = result.stdout
+            return result
+
+    engine = TrackingEngine()
+    converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+    converged = converger.converge()
+
+    def fail_acquire(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected lease failure")
+
+    monkeypatch.setattr(registry, "acquire_lease", fail_acquire)
+    with pytest.raises(RuntimeError, match="injected lease failure"):
+        converger.run_converged(
+            converged,
+            ["true"],
+            workspace=workspace_of(converger.manifest),
+        )
+
+    assert engine.ran("container", "rm", "--force") == [
+        ["container", "rm", "--force", engine.created_id]
+    ]
+    assert engine.container_specs == {}
+    assert all(resource.kind != "container" for resource in registry.list_resources())
+
+
+def test_reused_container_is_not_removed_if_lease_acquisition_fails(
+    converger: Converger, registry: Registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    converged, code, _output = converger.run(["true"])
+    assert code == 0
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    name = converger.container_name(workspace_of(converger.manifest), converged.stack)
+    container_id = engine.container_specs[name]["Id"]
+
+    def fail_acquire(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected lease failure")
+
+    monkeypatch.setattr(registry, "acquire_lease", fail_acquire)
+    with pytest.raises(RuntimeError, match="injected lease failure"):
+        converger.run_converged(
+            converged,
+            ["true"],
+            workspace=workspace_of(converger.manifest),
+        )
+
+    assert engine.ran("container", "rm", "--force") == []
+    assert engine.container_specs[name]["Id"] == container_id
+
+
+def test_client_manifest_volume_drift_is_refused_before_container_mutation(
+    converger: Converger,
+) -> None:
+    converged = converger.converge()
+    stale_snapshot = replace(converged, volumes=("wrong-volume", *converged.volumes[1:]))
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+
+    with pytest.raises(EngineError, match="volume contract changed"):
+        converger.run_converged(
+            stale_snapshot,
+            ["true"],
+            stack_name=None,
+            workspace=workspace_of(converger.manifest),
+        )
+
+    assert engine.ran("container", "inspect") == []
+    assert engine.ran("create") == []
+
+
+def test_active_execution_lease_prevents_generation_replacement(
+    project: Path, registry: Registry
+) -> None:
+    engine = FakeEngine()
+    converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+    first, code, _output = converger.run(["true"])
+    assert code == 0
+    resource = next(row for row in registry.list_resources() if row.kind == "container")
+    lease = registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=registry.clock.now())
+    try:
+        (project / "Dockerfile").write_text("FROM alpine\nRUN echo changed\n", encoding="utf-8")
+        rolled_converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+        rolled = rolled_converger.converge()
+        assert rolled.digest != first.digest
+
+        with pytest.raises(EngineError, match="active execution lease"):
+            rolled_converger.run_converged(
+                rolled,
+                ["true"],
+                stack_name=None,
+                workspace=workspace_of(rolled_converger.manifest),
+            )
+    finally:
+        registry.release_lease(lease.id)
+
+    assert engine.ran("container", "rm", "--force") == []
 
 
 def test_shell_uses_an_interactive_tty_exec(converger: Converger) -> None:
     converged = converger.converge()
-    assert converger.shell_converged(converged, stack_name=None, workspace="/workspace") == 7
+    assert (
+        converger.shell_converged(
+            converged,
+            stack_name=None,
+            workspace=workspace_of(converger.manifest),
+        )
+        == 7
+    )
     engine: FakeEngine = converger.engine  # type: ignore[assignment]
     assert engine.ran("exec")[-1][1] == "-it"
+    name = converger.container_name(workspace_of(converger.manifest), converged.stack)
+    assert engine.ran("exec")[-1][2] == engine.container_specs[name]["Id"]
+
+
+@pytest.mark.parametrize(
+    ("actual", "expected", "matches"),
+    [
+        (r"C:\Users\Alice\state\heartbeat", r"C:\Users\Alice\state\heartbeat", True),
+        (
+            "/run/desktop/mnt/host/c/Users/Alice/state/heartbeat",
+            r"C:\Users\Alice\state\heartbeat",
+            True,
+        ),
+        (
+            "/host_mnt/c/Users/Alice/state/heartbeat",
+            r"C:\Users\Alice\state\heartbeat",
+            True,
+        ),
+        (
+            "/run/desktop/mnt/host/d/Users/Alice/state/heartbeat",
+            r"C:\Users\Alice\state\heartbeat",
+            False,
+        ),
+        ("/different/path", r"C:\Users\Alice\state\heartbeat", False),
+    ],
+)
+def test_docker_desktop_bind_source_equivalence(actual: str, expected: str, matches: bool) -> None:
+    assert Converger._bind_sources_match(actual, expected) is matches
 
 
 def test_persistent_container_has_daemon_loss_and_run_duration_watchdogs(

--- a/tests/test_converge_docker.py
+++ b/tests/test_converge_docker.py
@@ -5,6 +5,7 @@ Docker-marked: Linux CI only.
 
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
@@ -12,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from bosn import labels
-from bosn.converge import Converger, run_task
+from bosn.converge import Converger, run_task, workspace_of
 from bosn.engine import Engine
 from bosn.manifest import load
 from bosn.registry import Registry
@@ -123,6 +124,37 @@ def test_editing_a_copy_input_rolls_and_builds_a_new_image(
     assert second.image_tag != first.image_tag
     assert engine.run(["image", "inspect", first.image_tag]).ok
     assert engine.run(["image", "inspect", second.image_tag]).ok
+
+
+def test_run_after_copy_roll_uses_a_recreated_current_container(
+    project: Path, converger: Converger, registry: Registry, engine: Engine
+) -> None:
+    (project / "Dockerfile").write_text(
+        "FROM alpine:3.20\nCOPY payload /payload\n", encoding="utf-8"
+    )
+    payload = project / "payload"
+    payload.write_text("one", encoding="utf-8")
+    first, code, output = converger.run(["cat", "/payload"])
+    assert code == 0, output
+    assert output.strip() == "one"
+
+    payload.write_text("two", encoding="utf-8")
+    second, code, output = converger.run(["cat", "/payload"])
+
+    assert code == 0, output
+    assert output.strip() == "two"
+    assert second.digest != first.digest
+    name = converger.container_name(workspace_of(converger.manifest), second.stack)
+    inspected = engine.run(["container", "inspect", "--format", "{{json .}}", name])
+    assert inspected.ok
+    details = json.loads(inspected.stdout)
+    expected_image = engine.run(
+        ["image", "inspect", "--format", "{{.Id}}", second.image_tag]
+    ).stdout
+    assert details["Image"] == expected_image
+    assert details["Config"]["Labels"][labels.GENERATION] == second.digest
+    rows = [row for row in registry.list_resources() if row.kind == "container"]
+    assert rows and {row.generation for row in rows} == {second.digest}
 
 
 def test_a_manifest_task_runs(project: Path, registry: Registry, engine: Engine) -> None:


### PR DESCRIPTION
## Summary

- Validate stable persistent containers against bosn ownership, generation, immutable image identity, and required mounts.
- Replace stale owned containers by immutable ID while refusing foreign or incomplete name collisions.
- Keep registry metadata and execution leases atomic with creation, replacement, and failure cleanup.
- Reject daemon/client manifest volume drift and normalize Docker Desktop Windows bind paths.

## Root cause

The persistent container name is intentionally stable per workspace and stack, but reuse previously depended only on a successful inspect. That allowed old-generation, wrong-image, or wrong-mount containers to survive a converge and made name collisions unsafe.

## Validation

- uv run python ci/lint.py
- uv run pytest -q -m not-docker: 279 passed, 1 skipped
- uv run pytest -q tests/test_converge_docker.py: 9 passed
- clud-review: clean

Closes #34