### PR TITLE
Fix resource liveness and shared cache retention

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -465,14 +465,14 @@ def cmd_status(opts: Options) -> int:
 
 
 def cmd_gc(opts: Options) -> int:
-    from bosn.gc import Collector, done_workspaces
+    from bosn.gc import Collector
     from bosn.registry import Registry, default_db_path
 
     state_dir = opts.state_dir
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
     with Registry(db_path) as registry:
         collector = Collector(registry, Engine(opts.engine))
-        result = collector.collect(dry_run=opts.dry_run, done_workspaces=done_workspaces(registry))
+        result = collector.collect(dry_run=opts.dry_run)
 
     print(json.dumps({**result.summary(), "dry_run": result.dry_run}, indent=2))
     for name in result.would_stop:

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -21,6 +21,7 @@ from bosn import labels
 from bosn.engine import Engine, EngineError
 from bosn.manifest import Manifest, StackSpec, dockerfile_external_images, generation_digest
 from bosn.registry import Lease, Registry, Resource
+from bosn.resources import ResourceScanner
 
 # What converge did, in the order of increasing work.
 REUSED = "reused"
@@ -85,7 +86,8 @@ def volume_name_for(
 ) -> str:
     """Volume identity follows its scope.
 
-    - `spec`    keyed by the generation digest, so a spec edit gets a fresh volume
+    - `spec`    keyed by workspace + generation digest, so a spec edit gets a fresh
+                  volume without another worktree sharing it accidentally
     - `stack`   keyed by workspace + stack, surviving spec edits in this workspace
     - `machine` keyed by family only -- one per machine, shared across every repo and
                 worktree. This is what kills the incident's dominant multiplier.
@@ -96,7 +98,7 @@ def volume_name_for(
         return f"bosn-m-{family or stack.name}-{volume_name}"
     if volume_scope == "stack":
         return f"bosn-s-{stack.name}-{workspace_key}-{volume_name}"
-    return f"bosn-g-{stack.name}-{short_digest}-{volume_name}"
+    return f"bosn-g-{stack.name}-{workspace_key}-{short_digest}-{volume_name}"
 
 
 def _stable_key(value: str) -> str:
@@ -287,8 +289,12 @@ class Converger:
         digest, resolved_image = self._resolved_generation(stack)
         workspace = workspace or workspace_of(self.manifest)
 
-        known = self.registry.generation_superseded_at(digest)
-        is_new_generation = known is None and not self._generation_recorded(digest)
+        known = self.registry.generation_superseded_at(
+            digest, stack=stack.name, workspace=workspace
+        )
+        is_new_generation = known is None and not self._generation_recorded(
+            digest, stack=stack.name, workspace=workspace
+        )
 
         # Build first, register second. The ordering is load-bearing, not stylistic: a
         # build can now be cancelled (by `bosn cancel`, daemon shutdown, or the job TTL),
@@ -312,9 +318,11 @@ class Converger:
         # on retention's 24-hour clock is worse than either outcome on its own.
         self._abort_if_cancelled()
 
-        self.registry.record_generation(digest, stack.name)
+        self.registry.record_generation(digest, stack.name, workspace)
         volumes = self._ensure_volumes(stack, digest, workspace)
-        superseded = self.registry.supersede_generations(stack.name, keep_digest=digest)
+        superseded = self.registry.supersede_generations(
+            stack.name, keep_digest=digest, workspace=workspace
+        )
 
         if superseded:
             action = ROLLED
@@ -346,11 +354,11 @@ class Converger:
         if self.cancelled is not None and self.cancelled.is_set():
             raise EngineError("converge was cancelled")
 
-    def _generation_recorded(self, digest: str) -> bool:
+    def _generation_recorded(self, digest: str, *, stack: str, workspace: str) -> bool:
         # Through the registry's own accessor, not `registry.conn` directly: that accessor
         # holds the lock keeping this one sqlite connection single-writer, and converge now
         # runs on up to `max_builds` daemon threads at once rather than alone in the CLI.
-        return self.registry.generation_recorded(digest)
+        return self.registry.generation_recorded(digest, stack, workspace)
 
     def _resource_labels(
         self, stack: StackSpec, kind: str, digest: str, scope: str, workspace: str
@@ -369,6 +377,16 @@ class Converger:
         if stack.image:
             return  # a pulled image is not ours to label or collect
         if self.engine.run(["image", "inspect", tag]).ok:
+            image_id = self._expected_image_id(tag)
+            self._reconcile_reused_resource(
+                stack,
+                kind="image",
+                engine_name=image_id,
+                inspect_name=tag,
+                digest=digest,
+                scope="spec",
+                workspace=workspace,
+            )
             return
 
         dockerfile = self.manifest.root / str(stack.dockerfile)
@@ -395,7 +413,14 @@ class Converger:
         # Registration happens only after the build exits 0, which is what makes a
         # cancelled or failed build safe: it can never leave a generation row implying a
         # usable image exists. Do not hoist this above the build.
-        self._register(stack, "image", tag, digest, "spec", workspace)
+        self._register(
+            stack,
+            "image",
+            self._expected_image_id(tag),
+            digest,
+            "spec",
+            workspace,
+        )
 
     def _ensure_volumes(self, stack: StackSpec, digest: str, workspace: str) -> list[str]:
         created: list[str] = []
@@ -410,6 +435,15 @@ class Converger:
             )
             created.append(name)
             if self.engine.run(["volume", "inspect", name]).ok:
+                self._reconcile_reused_resource(
+                    stack,
+                    kind="volume",
+                    engine_name=name,
+                    inspect_name=name,
+                    digest=digest,
+                    scope=volume.scope,
+                    workspace=workspace,
+                )
                 continue
             label_args = self._resource_labels(
                 stack, "volume", digest, volume.scope, workspace
@@ -419,6 +453,43 @@ class Converger:
                 raise EngineError(f"creating volume {name} failed: {result.stderr}")
             self._register(stack, "volume", name, digest, volume.scope, workspace)
         return created
+
+    def _reconcile_reused_resource(
+        self,
+        stack: StackSpec,
+        *,
+        kind: str,
+        engine_name: str,
+        inspect_name: str,
+        digest: str,
+        scope: str,
+        workspace: str,
+    ) -> None:
+        """Prove ownership before reviving a reused engine object in the registry."""
+        raw = ResourceScanner(self.engine).inspect_labels(kind, inspect_name)
+        if not labels.is_owned_by(raw, self.registry.registry_id):
+            ownership = "foreign" if labels.is_complete(raw) else "unlabeled or incomplete"
+            raise EngineError(
+                f"existing {kind} {inspect_name!r} is {ownership}; refusing to reuse it"
+            )
+        try:
+            parsed = labels.ResourceLabels.from_dict(raw)
+        except labels.LabelError as exc:
+            raise EngineError(
+                f"existing {kind} {inspect_name!r} has invalid ownership labels"
+            ) from exc
+        if parsed.kind != kind:
+            raise EngineError(f"existing {kind} {inspect_name!r} has a conflicting bosn kind label")
+        if kind == "image":
+            self.registry.canonicalize_image_identity(inspect_name, engine_name)
+        self.registry.reconcile_resource(
+            kind=kind,
+            name=engine_name,
+            stack=stack.name,
+            generation=digest,
+            scope=scope,
+            workspace=workspace,
+        )
 
     def _register(
         self, stack: StackSpec, kind: str, name: str, digest: str, scope: str, workspace: str
@@ -793,14 +864,30 @@ class Converger:
 
     def _acquire_execution_container(
         self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
-    ) -> tuple[str, Lease]:
+    ) -> tuple[str, tuple[Lease, ...]]:
         with self.registry.lifecycle_guard():
             name, container_id, resource, created = self._ensure_container_locked(
                 converged, stack_name=stack_name, workspace=workspace
             )
             try:
-                lease = self.registry.acquire_lease(
-                    resource.id, pid=os.getpid(), proc_start=self.registry.clock.now()
+                dependencies = [resource]
+                image_id = self._expected_image_id(converged.image_tag)
+                for kind, dependency_name in [
+                    ("image", image_id),
+                    *(("volume", volume_name) for volume_name in converged.volumes),
+                ]:
+                    dependency = self.registry.get_resource_by_engine_identity(
+                        kind, dependency_name
+                    )
+                    if dependency is not None:
+                        dependencies.append(dependency)
+                leases = tuple(
+                    self.registry.acquire_lease(
+                        dependency.id,
+                        pid=os.getpid(),
+                        proc_start=self.registry.clock.now(),
+                    )
+                    for dependency in dependencies
                 )
             except KeyboardInterrupt:
                 if created:
@@ -812,7 +899,7 @@ class Converger:
                     if cleanup_error:
                         raise EngineError(f"{exc}; {cleanup_error}") from exc
                 raise
-        return container_id, lease
+        return container_id, leases
 
     def run(
         self,
@@ -842,14 +929,15 @@ class Converger:
         caller's terminal and exit status.
         """
         workspace = workspace or workspace_of(self.manifest)
-        name, lease = self._acquire_execution_container(
+        name, leases = self._acquire_execution_container(
             converged, stack_name=stack_name, workspace=workspace
         )
         args = ["exec", name, *command]
         try:
             result = self.engine.run(args)
         finally:
-            self.registry.release_lease(lease.id)
+            for lease in leases:
+                self.registry.release_lease(lease.id)
         self.registry.log_event("run", f"{converged.stack} rc={result.returncode}")
         return converged, result.returncode, result.stdout or result.stderr
 
@@ -857,13 +945,14 @@ class Converger:
         self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
     ) -> int:
         """Attach a real interactive shell to the persistent container."""
-        name, lease = self._acquire_execution_container(
+        name, leases = self._acquire_execution_container(
             converged, stack_name=stack_name, workspace=workspace
         )
         try:
             return self.engine.interactive(["exec", "-it", name, "sh"])
         finally:
-            self.registry.release_lease(lease.id)
+            for lease in leases:
+                self.registry.release_lease(lease.id)
 
 
 def run_task(

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -384,7 +384,7 @@ class Daemon:
     def _run_maintenance(self) -> None:
         """Execute a maintenance pass, recording every outcome and scheduling its retry."""
         from bosn.engine import Engine
-        from bosn.gc import Collector, done_workspaces
+        from bosn.gc import Collector
 
         self.registry.log_event("maintenance.reap.started")
         try:
@@ -415,9 +415,7 @@ class Daemon:
 
         self.registry.log_event("maintenance.gc.started")
         try:
-            result = Collector(self.registry, engine).collect(
-                dry_run=False, done_workspaces=done_workspaces(self.registry)
-            )
+            result = Collector(self.registry, engine).collect(dry_run=False)
         except KeyboardInterrupt:
             raise
         except Exception as exc:  # noqa: BLE001 - never claim a failed GC succeeded

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -14,8 +14,10 @@ Design commitments enforced here:
 
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from bosn import labels
 from bosn.accounting import probe, resource_bytes
@@ -80,13 +82,9 @@ class Collector:
         self,
         *,
         dry_run: bool = True,
-        done_workspaces: set[str] | None = None,
         pressure: Pressure | None = None,
     ) -> GCResult:
-        done_workspaces = done_workspaces or set()
-        verdicts: list[Verdict] = plan(
-            self.registry, done_workspaces=done_workspaces, pressure=pressure
-        )
+        verdicts: list[Verdict] = plan(self.registry, pressure=pressure)
         result = GCResult(dry_run=dry_run)
 
         for verdict in verdicts:
@@ -102,12 +100,14 @@ class Collector:
                     resource = self.registry.get_resource(verdict.resource.id)
                     if resource is None:
                         continue
+                    superseded, workspace_done = self.registry.resource_retention_signals(
+                        resource.id
+                    )
                     current = evaluate(
                         self.registry,
                         resource,
-                        superseded=self.registry.generation_superseded_at(resource.generation)
-                        is not None,
-                        workspace_done=resource.workspace in done_workspaces,
+                        superseded=superseded,
+                        workspace_done=workspace_done,
                         pressure=pressure,
                     )
                     protected = current.reason in {KEPT_LEASED, KEPT_QUIET_PERIOD}
@@ -138,30 +138,44 @@ class Collector:
         for verdict in sorted(
             collectable(verdicts), key=lambda verdict: verdict.resource.kind != "container"
         ):
-            resource = verdict.resource
-            if not self._ownership_proven(resource.kind, resource.name):
-                result.skipped_unproven.append(resource.name)
-                self.registry.log_event("gc.skipped_unproven", resource.name)
-                continue
+            with self.registry.lifecycle_guard():
+                resource = self.registry.get_resource(verdict.resource.id)
+                if resource is None:
+                    continue
+                superseded, workspace_done = self.registry.resource_retention_signals(resource.id)
+                current = evaluate(
+                    self.registry,
+                    resource,
+                    superseded=superseded,
+                    workspace_done=workspace_done,
+                    pressure=pressure,
+                )
+                if not current.collect:
+                    result.kept.append(resource.name)
+                    continue
+                if not self._ownership_proven(resource.kind, resource.name):
+                    result.skipped_unproven.append(resource.name)
+                    self.registry.log_event("gc.skipped_unproven", resource.name)
+                    continue
 
-            if dry_run:
-                result.removed.append(resource.name)
-                continue
+                if dry_run:
+                    result.removed.append(resource.name)
+                    continue
 
-            args = _REMOVE_COMMANDS.get(resource.kind)
-            if args is None:
-                result.errors.append(f"{resource.name}: unknown kind {resource.kind}")
-                continue
+                args = _REMOVE_COMMANDS.get(resource.kind)
+                if args is None:
+                    result.errors.append(f"{resource.name}: unknown kind {resource.kind}")
+                    continue
 
-            removal = self.engine.run([*args, resource.name])
-            if removal.ok:
-                self.registry.remove_resource(resource.id)
-                self.registry.log_event("gc.removed", f"{resource.kind}:{resource.name}")
-                result.removed.append(resource.name)
-            else:
-                message = f"{resource.name}: {removal.stderr or removal.stdout}"
-                result.errors.append(message)
-                self.registry.log_event("gc.error", message)
+                removal = self.engine.run([*args, resource.name])
+                if removal.ok:
+                    self.registry.remove_resource(resource.id)
+                    self.registry.log_event("gc.removed", f"{resource.kind}:{resource.name}")
+                    result.removed.append(resource.name)
+                else:
+                    message = f"{resource.name}: {removal.stderr or removal.stdout}"
+                    result.errors.append(message)
+                    self.registry.log_event("gc.error", message)
 
         return result
 
@@ -250,14 +264,16 @@ def mark_done(registry: Registry, workspace: str) -> int:
     Dirty work is never destroyed on inference: this is the first-party signal, the
     strongest one there is. Derived signals are the caller's responsibility.
     """
-    marked = 0
-    for resource in registry.list_resources():
-        if resource.workspace == workspace and resource.scope != "machine":
-            registry.set_resource_state(resource.id, "done")
-            marked += 1
+    marked = registry.mark_workspace_done(workspace)
+    path = Path(workspace)
+    if marked == 0 and path.exists():
+        canonical = os.path.normcase(str(path.resolve()))
+        if canonical != workspace:
+            marked = registry.mark_workspace_done(canonical)
+            workspace = canonical
     registry.log_event("workspace.done", f"{workspace} ({marked} resources)")
     return marked
 
 
 def done_workspaces(registry: Registry) -> set[str]:
-    return {r.workspace for r in registry.list_resources() if r.state == "done"}
+    return registry.done_workspace_ids()

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from bosn.clock import Clock, SystemClock
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS meta (
@@ -45,6 +45,18 @@ CREATE TABLE IF NOT EXISTS resources (
 CREATE INDEX IF NOT EXISTS idx_resources_stack ON resources(stack);
 CREATE INDEX IF NOT EXISTS idx_resources_state ON resources(state);
 
+CREATE TABLE IF NOT EXISTS resource_uses (
+    resource_id  TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
+    workspace    TEXT NOT NULL,
+    stack        TEXT NOT NULL,
+    generation   TEXT NOT NULL,
+    last_used    REAL NOT NULL,
+    state        TEXT NOT NULL DEFAULT 'active',
+    PRIMARY KEY (resource_id, workspace, stack, generation)
+);
+
+CREATE INDEX IF NOT EXISTS idx_resource_uses_workspace ON resource_uses(workspace);
+
 CREATE TABLE IF NOT EXISTS leases (
     id            TEXT PRIMARY KEY,
     resource_id   TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
@@ -58,10 +70,12 @@ CREATE TABLE IF NOT EXISTS leases (
 CREATE INDEX IF NOT EXISTS idx_leases_resource ON leases(resource_id);
 
 CREATE TABLE IF NOT EXISTS generations (
-    digest      TEXT PRIMARY KEY,
+    workspace   TEXT NOT NULL,
     stack       TEXT NOT NULL,
+    digest      TEXT NOT NULL,
     created_at  REAL NOT NULL,
-    superseded_at REAL
+    superseded_at REAL,
+    PRIMARY KEY (workspace, stack, digest)
 );
 
 CREATE TABLE IF NOT EXISTS events (
@@ -146,6 +160,7 @@ class Registry:
             if not read_only:
                 self.conn.executescript(SCHEMA)
                 self._ensure_meta()
+                self._migrate_schema()
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -197,6 +212,99 @@ class Registry:
             (str(uuid.uuid4()),),
         )
 
+    def _migrate_schema(self) -> None:
+        """Upgrade old registries without losing ownership, liveness, or leases."""
+        raw_version = self.meta("schema_version")
+        version = int(raw_version) if raw_version is not None else 1
+        if version > SCHEMA_VERSION:
+            raise RuntimeError(
+                f"registry schema {version} is newer than supported version {SCHEMA_VERSION}"
+            )
+        if version < 2:
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._deduplicate_resources()
+                self.conn.execute(
+                    "CREATE TABLE generations_v2 ("
+                    "workspace TEXT NOT NULL, stack TEXT NOT NULL, digest TEXT NOT NULL, "
+                    "created_at REAL NOT NULL, superseded_at REAL, "
+                    "PRIMARY KEY (workspace, stack, digest))"
+                )
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO generations_v2 "
+                    "(workspace, stack, digest, created_at, superseded_at) "
+                    "SELECT resources.workspace, generations.stack, generations.digest, "
+                    "generations.created_at, generations.superseded_at FROM generations "
+                    "JOIN resources ON resources.stack = generations.stack "
+                    "AND resources.generation = generations.digest"
+                )
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO generations_v2 "
+                    "(workspace, stack, digest, created_at, superseded_at) "
+                    "SELECT '', generations.stack, generations.digest, "
+                    "generations.created_at, generations.superseded_at FROM generations "
+                    "WHERE NOT EXISTS (SELECT 1 FROM generations_v2 "
+                    "WHERE generations_v2.stack = generations.stack "
+                    "AND generations_v2.digest = generations.digest)"
+                )
+                self.conn.execute("DROP TABLE generations")
+                self.conn.execute("ALTER TABLE generations_v2 RENAME TO generations")
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO resource_uses"
+                    "(resource_id, workspace, stack, generation, last_used, state) "
+                    "SELECT id, workspace, stack, generation, last_used, state FROM resources"
+                )
+                self.conn.execute(
+                    "UPDATE meta SET value = ? WHERE key = 'schema_version'",
+                    (str(SCHEMA_VERSION),),
+                )
+                self.conn.execute("COMMIT")
+            except KeyboardInterrupt:
+                self.conn.execute("ROLLBACK")
+                raise
+            except Exception:
+                self.conn.execute("ROLLBACK")
+                raise
+
+        # Fresh v2 databases and migrated databases both get the invariant. Keeping the
+        # index creation out of SCHEMA lets migration collapse legacy duplicates first.
+        self._deduplicate_resources()
+        self.conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_engine_identity "
+            "ON resources(kind, name)"
+        )
+        self.conn.execute(
+            "INSERT OR IGNORE INTO resource_uses"
+            "(resource_id, workspace, stack, generation, last_used, state) "
+            "SELECT id, workspace, stack, generation, last_used, state FROM resources"
+        )
+
+    def _deduplicate_resources(self) -> None:
+        duplicates = self.conn.execute(
+            "SELECT kind, name FROM resources GROUP BY kind, name HAVING COUNT(*) > 1"
+        ).fetchall()
+        for duplicate in duplicates:
+            rows = self.conn.execute(
+                "SELECT * FROM resources WHERE kind = ? AND name = ? "
+                "ORDER BY last_used DESC, created_at DESC, id DESC",
+                (duplicate["kind"], duplicate["name"]),
+            ).fetchall()
+            keeper = rows[0]
+            for stale in rows[1:]:
+                self.conn.execute(
+                    "UPDATE leases SET resource_id = ? WHERE resource_id = ?",
+                    (keeper["id"], stale["id"]),
+                )
+                self.conn.execute("DELETE FROM resources WHERE id = ?", (stale["id"],))
+            self.conn.execute(
+                "UPDATE resources SET created_at = ?, last_used = ? WHERE id = ?",
+                (
+                    min(float(row["created_at"]) for row in rows),
+                    max(float(row["last_used"]) for row in rows),
+                    keeper["id"],
+                ),
+            )
+
     def meta(self, key: str) -> str | None:
         row = self._exec("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
         return row["value"] if row else None
@@ -230,19 +338,16 @@ class Registry:
         resource_id: str | None = None,
         created_at: float | None = None,
     ) -> Resource:
-        now = self.clock.now()
-        rid = resource_id or str(uuid.uuid4())
-        created = now if created_at is None else created_at
-        self._exec(
-            "INSERT OR REPLACE INTO resources"
-            "(id, kind, name, stack, generation, scope, workspace, created_at, last_used, state)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')",
-            (rid, kind, name, stack, generation, scope, workspace, created, created),
+        return self._reconcile_resource(
+            kind=kind,
+            name=name,
+            stack=stack,
+            generation=generation,
+            scope=scope,
+            workspace=workspace,
+            resource_id=resource_id,
+            created_at=created_at,
         )
-        self.log_event("resource.registered", f"{kind}:{name}")
-        resource = self.get_resource(rid)
-        assert resource is not None
-        return resource
 
     def reconcile_resource(
         self,
@@ -254,40 +359,177 @@ class Registry:
         scope: str,
         workspace: str,
     ) -> Resource:
-        """Make existing rows for one engine name describe its current owned object.
+        """Make one engine object have one current, freshly-used registry identity."""
+        return self._reconcile_resource(
+            kind=kind,
+            name=name,
+            stack=stack,
+            generation=generation,
+            scope=scope,
+            workspace=workspace,
+        )
 
-        Container names are stable across generation replacement. Updating their row in
-        place preserves identity for leases while correcting stale generation metadata;
-        issue #35 separately owns enforcing uniqueness for every resource kind.
-        """
+    def _reconcile_resource(
+        self,
+        *,
+        kind: str,
+        name: str,
+        stack: str,
+        generation: str,
+        scope: str,
+        workspace: str,
+        resource_id: str | None = None,
+        created_at: float | None = None,
+    ) -> Resource:
         with self._lock:
-            rows = self.conn.execute(
-                "SELECT id FROM resources WHERE kind = ? AND name = ? ORDER BY created_at",
+            previous = self.conn.execute(
+                "SELECT id FROM resources WHERE kind = ? AND name = ?",
                 (kind, name),
-            ).fetchall()
-            if not rows:
-                return self.register_resource(
-                    kind=kind,
-                    name=name,
-                    stack=stack,
-                    generation=generation,
-                    scope=scope,
-                    workspace=workspace,
-                )
+            ).fetchone()
             now = self.clock.now()
+            rid = resource_id or str(uuid.uuid4())
+            created = now if created_at is None else created_at
             self.conn.execute(
-                "UPDATE resources SET stack = ?, generation = ?, scope = ?, workspace = ?, "
-                "last_used = ?, state = 'active' WHERE kind = ? AND name = ?",
-                (stack, generation, scope, workspace, now, kind, name),
+                "INSERT INTO resources"
+                "(id, kind, name, stack, generation, scope, workspace, created_at, "
+                "last_used, state) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active') "
+                "ON CONFLICT(kind, name) DO UPDATE SET stack = excluded.stack, "
+                "generation = excluded.generation, scope = excluded.scope, "
+                "workspace = excluded.workspace, last_used = ?, state = 'active'",
+                (
+                    rid,
+                    kind,
+                    name,
+                    stack,
+                    generation,
+                    scope,
+                    workspace,
+                    created,
+                    created,
+                    now,
+                ),
             )
-            self.log_event("resource.reconciled", f"{kind}:{name}")
-            resource = self.get_resource(str(rows[0]["id"]))
+            current = self.conn.execute(
+                "SELECT id FROM resources WHERE kind = ? AND name = ?", (kind, name)
+            ).fetchone()
+            assert current is not None
+            rid = str(current["id"])
+            self.conn.execute(
+                "INSERT INTO resource_uses"
+                "(resource_id, workspace, stack, generation, last_used, state) "
+                "VALUES (?, ?, ?, ?, ?, 'active') "
+                "ON CONFLICT(resource_id, workspace, stack, generation) "
+                "DO UPDATE SET last_used = excluded.last_used, state = 'active'",
+                (rid, workspace, stack, generation, now),
+            )
+            event = "resource.registered" if previous is None else "resource.reconciled"
+            self.log_event(event, f"{kind}:{name}")
+            resource = self.get_resource(rid)
             assert resource is not None
             return resource
 
     def get_resource(self, resource_id: str) -> Resource | None:
         row = self._exec("SELECT * FROM resources WHERE id = ?", (resource_id,)).fetchone()
         return _resource_from_row(row) if row else None
+
+    def get_resource_by_engine_identity(self, kind: str, name: str) -> Resource | None:
+        row = self._exec(
+            "SELECT * FROM resources WHERE kind = ? AND name = ?", (kind, name)
+        ).fetchone()
+        return _resource_from_row(row) if row else None
+
+    def canonicalize_image_identity(self, tag: str, image_id: str) -> Resource | None:
+        """Use Docker's immutable image ID for both new and adopted image rows.
+
+        Older registries stored either the mutable build tag or Docker's truncated image
+        ID. This small migration preserves their consumer uses and leases while moving
+        both legacy aliases to the ID that `docker image ls` and adoption now expose.
+        """
+        # Preserve the order for predictable migrations and logs: the old mutable tag
+        # first, then Docker's legacy 12-character `image ls` ID.
+        aliases = (tag, image_id.removeprefix("sha256:")[:12])
+        with self._lock:
+            canonical = self.conn.execute(
+                "SELECT * FROM resources WHERE kind = 'image' AND name = ?", (image_id,)
+            ).fetchone()
+            for alias in dict.fromkeys(aliases):
+                if alias == image_id:
+                    continue
+                legacy = self.conn.execute(
+                    "SELECT id FROM resources WHERE kind = 'image' AND name = ?", (alias,)
+                ).fetchone()
+                if legacy is None:
+                    continue
+                if canonical is None:
+                    self.conn.execute(
+                        "UPDATE resources SET name = ? WHERE id = ?",
+                        (image_id, legacy["id"]),
+                    )
+                    canonical = self.conn.execute(
+                        "SELECT * FROM resources WHERE id = ?", (legacy["id"],)
+                    ).fetchone()
+                    assert canonical is not None
+                    continue
+                self._merge_resource_rows(
+                    source_id=str(legacy["id"]), target_id=str(canonical["id"])
+                )
+            return _resource_from_row(canonical) if canonical is not None else None
+
+    def _merge_resource_rows(self, *, source_id: str, target_id: str) -> None:
+        """Move leases and consumer uses into an existing canonical resource row."""
+        source = self.get_resource(source_id)
+        assert source is not None
+        for use in self.conn.execute(
+            "SELECT workspace, stack, generation, last_used, state "
+            "FROM resource_uses WHERE resource_id = ?",
+            (source_id,),
+        ).fetchall():
+            existing = self.conn.execute(
+                "SELECT last_used, state FROM resource_uses "
+                "WHERE resource_id = ? AND workspace = ? AND stack = ? AND generation = ?",
+                (target_id, use["workspace"], use["stack"], use["generation"]),
+            ).fetchone()
+            if existing is None:
+                self.conn.execute(
+                    "INSERT INTO resource_uses"
+                    "(resource_id, workspace, stack, generation, last_used, state) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        target_id,
+                        use["workspace"],
+                        use["stack"],
+                        use["generation"],
+                        use["last_used"],
+                        use["state"],
+                    ),
+                )
+                continue
+            state = (
+                "active"
+                if "active" in {str(existing["state"]), str(use["state"])}
+                else str(existing["state"])
+            )
+            self.conn.execute(
+                "UPDATE resource_uses SET last_used = ?, state = ? "
+                "WHERE resource_id = ? AND workspace = ? AND stack = ? AND generation = ?",
+                (
+                    max(float(existing["last_used"]), float(use["last_used"])),
+                    state,
+                    target_id,
+                    use["workspace"],
+                    use["stack"],
+                    use["generation"],
+                ),
+            )
+        self.conn.execute(
+            "UPDATE leases SET resource_id = ? WHERE resource_id = ?", (target_id, source_id)
+        )
+        self.conn.execute("DELETE FROM resources WHERE id = ?", (source_id,))
+        self.conn.execute(
+            "UPDATE resources SET created_at = MIN(created_at, ?), "
+            "last_used = MAX(last_used, ?) WHERE id = ?",
+            (source.created_at, source.last_used, target_id),
+        )
 
     def list_resources(self, *, state: str | None = None) -> list[Resource]:
         if state is None:
@@ -304,7 +546,81 @@ class Registry:
         )
 
     def set_resource_state(self, resource_id: str, state: str) -> None:
-        self._exec("UPDATE resources SET state = ? WHERE id = ?", (state, resource_id))
+        with self._lock:
+            self.conn.execute("UPDATE resources SET state = ? WHERE id = ?", (state, resource_id))
+            self.conn.execute(
+                "UPDATE resource_uses SET state = ? WHERE resource_id = ?",
+                (state, resource_id),
+            )
+
+    def _all_uses_done(self, resource_id: str) -> bool:
+        uses = self._exec(
+            "SELECT workspace, state FROM resource_uses WHERE resource_id = ?",
+            (resource_id,),
+        ).fetchall()
+        return bool(uses) and all(str(use["state"]) == "done" for use in uses)
+
+    def resource_retention_signals(
+        self, resource_id: str, *, done_workspaces: set[str] | None = None
+    ) -> tuple[bool, bool]:
+        """Return (superseded, done) only when every consumer is inactive.
+
+        A mixed object whose A consumer is done and B consumer is superseded is safe to
+        retire, but uses the conservative superseded warm cap rather than immediate done
+        collection. Any one active/current consumer keeps the shared engine object.
+        """
+        done_workspaces = done_workspaces or set()
+        uses = self._exec(
+            "SELECT workspace, stack, generation, state FROM resource_uses WHERE resource_id = ?",
+            (resource_id,),
+        ).fetchall()
+        if not uses:
+            return False, False
+        any_superseded = False
+        for use in uses:
+            is_done = str(use["state"]) == "done" or str(use["workspace"]) in done_workspaces
+            is_superseded = (
+                self.generation_superseded_at(
+                    str(use["generation"]),
+                    stack=str(use["stack"]),
+                    workspace=str(use["workspace"]),
+                )
+                is not None
+            )
+            if not is_done and not is_superseded:
+                return False, False
+            any_superseded = any_superseded or is_superseded
+        return (True, False) if any_superseded else (False, True)
+
+    def mark_workspace_done(self, workspace: str) -> int:
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT DISTINCT resource_uses.resource_id FROM resource_uses "
+                "JOIN resources ON resources.id = resource_uses.resource_id "
+                "WHERE resource_uses.workspace = ? AND resources.scope != 'machine'",
+                (workspace,),
+            ).fetchall()
+            resource_ids = [str(row["resource_id"]) for row in rows]
+            self.conn.execute(
+                "UPDATE resource_uses SET state = 'done' WHERE workspace = ? "
+                "AND resource_id IN (SELECT id FROM resources WHERE scope != 'machine')",
+                (workspace,),
+            )
+            for resource_id in resource_ids:
+                state = "done" if self._all_uses_done(resource_id) else "active"
+                self.conn.execute(
+                    "UPDATE resources SET state = ? WHERE id = ?", (state, resource_id)
+                )
+            return len(resource_ids)
+
+    def done_workspace_ids(self) -> set[str]:
+        rows = self._exec(
+            "SELECT resource_uses.workspace FROM resource_uses "
+            "JOIN resources ON resources.id = resource_uses.resource_id "
+            "WHERE resources.scope != 'machine' GROUP BY resource_uses.workspace "
+            "HAVING SUM(CASE WHEN resource_uses.state = 'done' THEN 0 ELSE 1 END) = 0"
+        ).fetchall()
+        return {str(row["workspace"]) for row in rows}
 
     def remove_resource(self, resource_id: str) -> None:
         self._exec("DELETE FROM resources WHERE id = ?", (resource_id,))
@@ -322,16 +638,21 @@ class Registry:
     ) -> Lease:
         now = self.clock.now()
         lease_id = str(uuid.uuid4())
-        self._exec(
-            "INSERT INTO leases"
-            "(id, resource_id, pid, proc_start, acquired_at, heartbeat_at, ttl_seconds)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (lease_id, resource_id, pid, proc_start, now, now, ttl_seconds),
-        )
-        self.log_event("lease.acquired", resource_id)
-        lease = self.get_lease(lease_id)
-        assert lease is not None
-        return lease
+        with self._lock:
+            self.conn.execute(
+                "INSERT INTO leases"
+                "(id, resource_id, pid, proc_start, acquired_at, heartbeat_at, ttl_seconds)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (lease_id, resource_id, pid, proc_start, now, now, ttl_seconds),
+            )
+            self.conn.execute(
+                "UPDATE resources SET last_used = ?, state = 'active' WHERE id = ?",
+                (now, resource_id),
+            )
+            self.log_event("lease.acquired", resource_id)
+            lease = self.get_lease(lease_id)
+            assert lease is not None
+            return lease
 
     def get_lease(self, lease_id: str) -> Lease | None:
         row = self._exec("SELECT * FROM leases WHERE id = ?", (lease_id,)).fetchone()
@@ -350,29 +671,36 @@ class Registry:
 
     # -- generations -------------------------------------------------------
 
-    def record_generation(self, digest: str, stack: str) -> None:
+    def record_generation(self, digest: str, stack: str, workspace: str) -> None:
         self._exec(
-            "INSERT OR IGNORE INTO generations(digest, stack, created_at) VALUES (?, ?, ?)",
-            (digest, stack, self.clock.now()),
+            "INSERT INTO generations(workspace, stack, digest, created_at, superseded_at) "
+            "VALUES (?, ?, ?, ?, NULL) ON CONFLICT(workspace, stack, digest) "
+            "DO UPDATE SET superseded_at = NULL",
+            (workspace, stack, digest, self.clock.now()),
         )
 
-    def supersede_generations(self, stack: str, keep_digest: str) -> int:
+    def supersede_generations(self, stack: str, keep_digest: str, workspace: str) -> int:
         cur = self._exec(
             "UPDATE generations SET superseded_at = ?"
-            " WHERE stack = ? AND digest != ? AND superseded_at IS NULL",
-            (self.clock.now(), stack, keep_digest),
+            " WHERE workspace = ? AND stack = ? AND digest != ? AND superseded_at IS NULL",
+            (self.clock.now(), workspace, stack, keep_digest),
         )
         return cur.rowcount
 
-    def generation_recorded(self, digest: str) -> bool:
+    def generation_recorded(self, digest: str, stack: str, workspace: str) -> bool:
         return (
-            self._exec("SELECT 1 FROM generations WHERE digest = ?", (digest,)).fetchone()
+            self._exec(
+                "SELECT 1 FROM generations WHERE workspace = ? AND stack = ? AND digest = ?",
+                (workspace, stack, digest),
+            ).fetchone()
             is not None
         )
 
-    def generation_superseded_at(self, digest: str) -> float | None:
+    def generation_superseded_at(self, digest: str, *, stack: str, workspace: str) -> float | None:
         row = self._exec(
-            "SELECT superseded_at FROM generations WHERE digest = ?", (digest,)
+            "SELECT superseded_at FROM generations "
+            "WHERE workspace = ? AND stack = ? AND digest = ?",
+            (workspace, stack, digest),
         ).fetchone()
         return row["superseded_at"] if row else None
 

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -25,7 +25,9 @@ from bosn.registry import Registry
 _LIST_COMMANDS: dict[str, list[str]] = {
     "container": ["ps", "--all", "--format", "{{json .}}"],
     "volume": ["volume", "ls", "--format", "{{json .}}"],
-    "image": ["images", "--format", "{{json .}}"],
+    # `docker images` shortens `.ID` to 12 characters unless told otherwise.  Adoption,
+    # convergence, execution leases, and GC must all use the same immutable full ID.
+    "image": ["images", "--no-trunc", "--format", "{{json .}}"],
 }
 
 _INSPECT_COMMANDS: dict[str, list[str]] = {

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -172,13 +172,16 @@ def plan(
 
     verdicts: list[Verdict] = []
     for resource in registry.list_resources():
+        superseded, workspace_done = registry.resource_retention_signals(
+            resource.id, done_workspaces=done_workspaces
+        )
         verdicts.append(
             evaluate(
                 registry,
                 resource,
                 now=now,
-                superseded=registry.generation_superseded_at(resource.generation) is not None,
-                workspace_done=resource.workspace in done_workspaces,
+                superseded=superseded,
+                workspace_done=workspace_done,
                 pressure=pressure,
                 alive_probe=alive_probe,
             )

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -48,6 +48,7 @@ class FakeEngine:
         self.image_ids: dict[str, str] = {"alpine": "sha256:alpine-v1"}
         self.image_platforms: dict[str, str] = {"alpine": "linux/amd64"}
         self.container_specs: dict[str, dict[str, object]] = {}
+        self.resource_labels: dict[tuple[str, str], dict[str, str]] = {}
         self.container_serial = 0
 
     def run(self, args: list[str], *, check: bool = False) -> EngineResult:
@@ -57,6 +58,12 @@ class FakeEngine:
         if args[:2] == ["container", "inspect"] and "{{json .}}" in args:
             spec = self.container_specs.get(args[-1])
             return EngineResult(0 if spec else 1, json.dumps(spec) if spec else "", "")
+        if args[:2] == ["volume", "inspect"] and "{{json .Labels}}" in args:
+            raw = self.resource_labels.get(("volume", args[-1]))
+            return EngineResult(0 if raw is not None else 1, json.dumps(raw or {}), "")
+        if args[:2] == ["image", "inspect"] and "{{json .Config.Labels}}" in args:
+            raw = self.resource_labels.get(("image", args[-1]))
+            return EngineResult(0 if raw is not None else 1, json.dumps(raw or {}), "")
         if args[:2] == ["image", "inspect"] and "{{.Id}}" in args:
             requested_platform = (
                 args[args.index("--platform") + 1] if "--platform" in args else None
@@ -80,6 +87,7 @@ class FakeEngine:
                 self.image_platforms.setdefault(args[-1], "linux/amd64")
         if args[:2] == ["volume", "create"]:
             self.existing.add(args[-1])
+            self.resource_labels[("volume", args[-1])] = self._labels_from_args(args)
         if args[:3] == ["container", "rm", "--force"]:
             target = args[-1]
             name = next(
@@ -134,7 +142,18 @@ class FakeEngine:
             self.existing.add(tag)
             self.image_ids[tag] = f"sha256:{hashlib.sha256(tag.encode()).hexdigest()}"
             self.image_platforms[tag] = "linux/amd64"
+            raw = self._labels_from_args(args)
+            self.resource_labels[("image", tag)] = raw
+            self.resource_labels[("image", self.image_ids[tag])] = raw
         return EngineResult(0, "ok", "")
+
+    @staticmethod
+    def _labels_from_args(args: list[str]) -> dict[str, str]:
+        return {
+            args[index + 1].split("=", 1)[0]: args[index + 1].split("=", 1)[1]
+            for index, value in enumerate(args[:-1])
+            if value == "--label"
+        }
 
     def stream(
         self,
@@ -326,12 +345,191 @@ def test_image_backed_stack_runs_the_resolved_declared_image(
 
 def test_the_old_generation_is_marked_superseded(project: Path, registry: Registry) -> None:
     engine = FakeEngine()
-    first = Converger(load(project), registry, engine).converge()  # type: ignore[arg-type]
+    manifest = load(project)
+    workspace = workspace_of(manifest)
+    first = Converger(manifest, registry, engine).converge()  # type: ignore[arg-type]
     (project / "Dockerfile").write_text("FROM debian\n", encoding="utf-8")
     second = Converger(load(project), registry, engine).converge()  # type: ignore[arg-type]
 
-    assert registry.generation_superseded_at(first.digest) is not None
-    assert registry.generation_superseded_at(second.digest) is None
+    assert (
+        registry.generation_superseded_at(first.digest, stack="test", workspace=workspace)
+        is not None
+    )
+    assert (
+        registry.generation_superseded_at(second.digest, stack="test", workspace=workspace) is None
+    )
+
+
+def test_shared_volumes_rebind_to_the_current_generation_and_refresh_liveness(
+    project: Path, tmp_path: Path
+) -> None:
+    from bosn.clock import FakeClock
+
+    clock = FakeClock()
+    engine = FakeEngine()
+    with Registry(tmp_path / "liveness.sqlite3", clock=clock) as registry:
+        first_converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+        first = first_converger.converge()
+        shared = {
+            resource.scope: resource
+            for resource in registry.list_resources()
+            if resource.kind == "volume" and resource.scope in {"stack", "machine"}
+        }
+        clock.advance(3600)
+
+        (project / "Dockerfile").write_text("FROM alpine\nRUN echo changed\n", encoding="utf-8")
+        second = Converger(load(project), registry, engine).converge()  # type: ignore[arg-type]
+
+        assert second.digest != first.digest
+        for scope, previous in shared.items():
+            current = registry.get_resource_by_engine_identity("volume", previous.name)
+            assert current is not None
+            assert current.id == previous.id
+            assert current.scope == scope
+            assert current.generation == second.digest
+            assert current.last_used == clock.now()
+            assert (
+                registry.generation_superseded_at(
+                    current.generation,
+                    stack=current.stack,
+                    workspace=current.workspace,
+                )
+                is None
+            )
+
+
+def test_warm_converge_refreshes_each_reused_owned_dependency(
+    project: Path, tmp_path: Path
+) -> None:
+    from bosn.clock import FakeClock
+
+    clock = FakeClock()
+    engine = FakeEngine()
+    with Registry(tmp_path / "warm.sqlite3", clock=clock) as registry:
+        converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+        first = converger.converge()
+        image_id = engine.image_ids[first.image_tag]
+        identities = [("image", image_id), *(("volume", name) for name in first.volumes)]
+        before = {
+            identity: registry.get_resource_by_engine_identity(*identity) for identity in identities
+        }
+        assert all(resource is not None for resource in before.values())
+        clock.advance(3600)
+
+        second = converger.converge()
+
+        assert second.action == REUSED
+        for identity, previous in before.items():
+            current = registry.get_resource_by_engine_identity(*identity)
+            assert previous is not None and current is not None
+            assert current.id == previous.id
+            assert current.last_used == clock.now()
+
+
+def test_adopted_image_id_is_refreshed_and_leased_by_a_warm_run(
+    project: Path, tmp_path: Path
+) -> None:
+    from bosn.clock import FakeClock
+    from bosn.retention import KEPT_LEASED, Pressure, evaluate
+
+    clock = FakeClock()
+    engine = FakeEngine()
+    with Registry(tmp_path / "adopted-image.sqlite3", clock=clock) as registry:
+        converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+        first = converger.converge()
+        image_id = engine.image_ids[first.image_tag]
+        original = registry.get_resource_by_engine_identity("image", image_id)
+        assert original is not None
+        registry.remove_resource(original.id)
+        adopted = registry.register_resource(
+            kind="image",
+            name=image_id,
+            stack=first.stack,
+            generation=first.digest,
+            scope="spec",
+            workspace=workspace_of(converger.manifest),
+        )
+        registry.set_resource_state(adopted.id, "adopted")
+        clock.advance(3600)
+
+        warm = converger.converge()
+        refreshed = registry.get_resource(adopted.id)
+        assert refreshed is not None
+        assert refreshed.last_used == clock.now()
+        assert refreshed.state == "active"
+        assert registry.get_resource_by_engine_identity("image", first.image_tag) is None
+        _container_id, leases = converger._acquire_execution_container(
+            warm,
+            stack_name=None,
+            workspace=workspace_of(converger.manifest),
+        )
+        try:
+            assert adopted.id in {lease.resource_id for lease in leases}
+            clock.advance(4 * 24 * 3600)
+            verdict = evaluate(
+                registry,
+                refreshed,
+                superseded=True,
+                workspace_done=True,
+                pressure=Pressure(under_pressure=True),
+                alive_probe=lambda _pid, _start: True,
+            )
+            assert not verdict.collect
+            assert verdict.reason == KEPT_LEASED
+        finally:
+            for lease in leases:
+                registry.release_lease(lease.id)
+
+
+@pytest.mark.parametrize("kind", ["image", "volume"])
+def test_owned_reused_resource_without_a_registry_row_is_restored(
+    project: Path, tmp_path: Path, kind: str
+) -> None:
+    engine = FakeEngine()
+    with Registry(tmp_path / "restore-owned.sqlite3") as registry:
+        converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+        first = converger.converge()
+        name = engine.image_ids[first.image_tag] if kind == "image" else first.volumes[0]
+        original = registry.get_resource_by_engine_identity(kind, name)
+        assert original is not None
+        registry.remove_resource(original.id)
+
+        converger.converge()
+
+        restored = registry.get_resource_by_engine_identity(kind, name)
+        assert restored is not None
+        assert restored.id != original.id
+
+
+@pytest.mark.parametrize("collision", ["foreign", "incomplete"])
+def test_reused_volume_collision_is_refused_before_registry_reconciliation(
+    project: Path, tmp_path: Path, collision: str
+) -> None:
+    engine = FakeEngine()
+    with Registry(tmp_path / "foreign-volume.sqlite3") as registry:
+        converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+        first = converger.converge()
+        name = first.volumes[0]
+        original = registry.get_resource_by_engine_identity("volume", name)
+        assert original is not None
+        registry.remove_resource(original.id)
+        if collision == "foreign":
+            engine.resource_labels[("volume", name)] = labels.ResourceLabels(
+                registry="other-registry",
+                kind="volume",
+                stack="test",
+                generation=first.digest,
+                scope="spec",
+                workspace="/other",
+                created="2026-01-01T00:00:00Z",
+            ).to_dict()
+        else:
+            engine.resource_labels[("volume", name)] = {labels.REGISTRY: registry.registry_id}
+
+        with pytest.raises(EngineError, match="refusing to reuse"):
+            converger.converge()
+
+        assert registry.get_resource_by_engine_identity("volume", name) is None
 
 
 def test_every_created_resource_is_registered(converger: Converger, registry: Registry) -> None:
@@ -365,6 +563,12 @@ def _name(scope: str, *, digest: str, workspace: str, family: str | None = "rust
 def test_spec_scoped_volumes_change_with_the_digest() -> None:
     a = _name("spec", digest="sha256:aaa", workspace="/w1")
     b = _name("spec", digest="sha256:bbb", workspace="/w1")
+    assert a != b
+
+
+def test_spec_scoped_volumes_differ_across_workspaces() -> None:
+    a = _name("spec", digest="sha256:aaa", workspace="/w1")
+    b = _name("spec", digest="sha256:aaa", workspace="/w2")
     assert a != b
 
 
@@ -448,6 +652,80 @@ def test_distinct_worktrees_get_distinct_workspace_ids(tmp_path: Path) -> None:
     assert ids[0] != ids[1]
 
 
+def test_one_workspaces_roll_does_not_supersede_another_workspaces_generation(
+    tmp_path: Path,
+) -> None:
+    roots = [tmp_path / "wt-a", tmp_path / "wt-b"]
+    for root in roots:
+        root.mkdir()
+        (root / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+        (root / "bosn.toml").write_text(SAMPLE, encoding="utf-8")
+    engine = FakeEngine()
+    with Registry(tmp_path / "workspace-generations.sqlite3") as registry:
+        manifests = [load(root) for root in roots]
+        shared = [
+            Converger(manifest, registry, engine).converge()  # type: ignore[arg-type]
+            for manifest in manifests
+        ]
+        assert shared[0].digest == shared[1].digest
+
+        (roots[0] / "Dockerfile").write_text("FROM alpine\nRUN echo changed\n", encoding="utf-8")
+        Converger(load(roots[0]), registry, engine).converge()  # type: ignore[arg-type]
+
+        assert (
+            registry.generation_superseded_at(
+                shared[0].digest,
+                stack=shared[0].stack,
+                workspace=workspace_of(manifests[0]),
+            )
+            is not None
+        )
+        assert (
+            registry.generation_superseded_at(
+                shared[1].digest,
+                stack=shared[1].stack,
+                workspace=workspace_of(manifests[1]),
+            )
+            is None
+        )
+
+
+def test_shared_old_resources_stay_current_until_every_workspace_rolls(tmp_path: Path) -> None:
+    from bosn.clock import FakeClock
+    from bosn.retention import plan
+
+    roots = [tmp_path / "consumer-a", tmp_path / "consumer-b"]
+    for root in roots:
+        root.mkdir()
+        (root / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+        (root / "bosn.toml").write_text(SAMPLE, encoding="utf-8")
+    clock = FakeClock()
+    engine = FakeEngine()
+    with Registry(tmp_path / "shared-consumers.sqlite3", clock=clock) as registry:
+        manifests = [load(root) for root in roots]
+        original = [
+            Converger(manifest, registry, engine).converge()  # type: ignore[arg-type]
+            for manifest in manifests
+        ]
+        old_names = {
+            engine.image_ids[original[0].image_tag],
+            original[0].volumes[0],
+        }
+
+        (roots[1] / "Dockerfile").write_text("FROM alpine\nRUN echo b-rolled\n", encoding="utf-8")
+        Converger(load(roots[1]), registry, engine).converge()  # type: ignore[arg-type]
+        clock.advance(2 * 24 * 3600)
+
+        verdicts = {verdict.name: verdict for verdict in plan(registry)}
+        assert all(not verdicts[name].collect for name in old_names)
+
+        (roots[0] / "Dockerfile").write_text("FROM alpine\nRUN echo a-rolled\n", encoding="utf-8")
+        Converger(load(roots[0]), registry, engine).converge()  # type: ignore[arg-type]
+
+        verdicts = {verdict.name: verdict for verdict in plan(registry)}
+        assert all(verdicts[name].collect for name in old_names)
+
+
 def test_a_non_canonical_path_to_the_same_root_is_the_same_workspace(project: Path) -> None:
     """`..` and `.` must not be able to split one worktree into two."""
     from bosn.converge import workspace_of
@@ -518,7 +796,14 @@ def test_a_failed_build_does_not_supersede_the_working_generation(
     with pytest.raises(EngineError):
         Converger(load(project), registry, FailingEngine()).converge()  # type: ignore[arg-type]
 
-    assert registry.generation_superseded_at(good.digest) is None
+    assert (
+        registry.generation_superseded_at(
+            good.digest,
+            stack=good.stack,
+            workspace=workspace_of(load(project)),
+        )
+        is None
+    )
 
 
 def test_a_cancelled_build_reports_cancellation_not_a_generic_failure(
@@ -578,6 +863,53 @@ def test_second_run_reuses_the_same_persistent_container(converger: Converger) -
     assert len(engine.ran("exec")) == 2
     assert {command[-1] for command in engine.ran("start")} == {container_id}
     assert {command[1] for command in engine.ran("exec")} == {container_id}
+
+
+def test_active_execution_leases_image_container_and_all_mounted_volumes(
+    project: Path, tmp_path: Path
+) -> None:
+    from bosn.clock import FakeClock
+    from bosn.retention import KEPT_LEASED, Pressure, evaluate
+
+    clock = FakeClock()
+    engine = FakeEngine()
+    with Registry(tmp_path / "dependencies.sqlite3", clock=clock) as registry:
+        converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+        converged = converger.converge()
+        clock.advance(3600)
+        _container_id, leases = converger._acquire_execution_container(
+            converged,
+            stack_name=None,
+            workspace=workspace_of(converger.manifest),
+        )
+        try:
+            resources = registry.list_resources()
+            assert {lease.resource_id for lease in leases} == {
+                resource.id for resource in resources
+            }
+            assert {resource.kind for resource in resources} == {
+                "container",
+                "image",
+                "volume",
+            }
+            assert len(resources) == 5
+            assert {resource.last_used for resource in resources} == {clock.now()}
+
+            clock.advance(4 * 24 * 3600)
+            for resource in resources:
+                verdict = evaluate(
+                    registry,
+                    resource,
+                    superseded=True,
+                    workspace_done=True,
+                    pressure=Pressure(under_pressure=True),
+                    alive_probe=lambda _pid, _start: True,
+                )
+                assert not verdict.collect
+                assert verdict.reason == KEPT_LEASED
+        finally:
+            for lease in leases:
+                registry.release_lease(lease.id)
 
 
 def test_generation_roll_replaces_the_container_and_reconciles_its_row(

--- a/tests/test_daemon_jobs.py
+++ b/tests/test_daemon_jobs.py
@@ -285,7 +285,14 @@ def test_a_cancelled_build_leaves_no_generation_row(
     ipc.send_request(served.port, {"verb": "cancel", "job": job_id, "auth": served.secret})
     drain(stream)
 
-    assert served.registry.generation_superseded_at(digest) is None
+    assert (
+        served.registry.generation_superseded_at(
+            digest,
+            stack=manifest.stack(None).name,
+            workspace=str(manifest.root),
+        )
+        is None
+    )
     rows = served.registry.conn.execute(
         "SELECT 1 FROM generations WHERE digest = ?", (digest,)
     ).fetchall()

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -243,6 +243,59 @@ def test_lease_acquired_after_planning_is_seen_before_idle_stop(
     assert [cmd for cmd in engine.commands if cmd[:2] == ["container", "stop"]] == []
 
 
+def test_dependency_lease_acquired_after_planning_is_seen_before_removal(
+    registry: Registry, clock: FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import bosn.gc as gc_mod
+
+    resource = add(registry, "active-volume")
+    engine = FakeEngine({"active-volume": label_dict(registry=registry.registry_id, kind="volume")})
+    clock.advance(10 * DAY)
+    original_plan = gc_mod.plan
+
+    def plan_then_lease(*args, **kwargs):
+        verdicts = original_plan(*args, **kwargs)
+        registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+        return verdicts
+
+    monkeypatch.setattr(gc_mod, "plan", plan_then_lease)
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.removed == []
+    assert result.kept == ["active-volume"]
+    assert engine.removals() == []
+
+
+def test_dependency_reused_after_done_planning_is_seen_before_removal(
+    registry: Registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import bosn.gc as gc_mod
+
+    resource = add(registry, "reused-volume")
+    assert mark_done(registry, "/w") == 1
+    engine = FakeEngine({"reused-volume": label_dict(registry=registry.registry_id, kind="volume")})
+    original_plan = gc_mod.plan
+
+    def plan_then_reconcile(*args, **kwargs):
+        verdicts = original_plan(*args, **kwargs)
+        registry.reconcile_resource(
+            kind=resource.kind,
+            name=resource.name,
+            stack=resource.stack,
+            generation=resource.generation,
+            scope=resource.scope,
+            workspace=resource.workspace,
+        )
+        return verdicts
+
+    monkeypatch.setattr(gc_mod, "plan", plan_then_reconcile)
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.removed == []
+    assert result.kept == ["reused-volume"]
+    assert engine.removals() == []
+
+
 def test_idle_stop_serializes_concurrent_lease_acquisition(
     registry: Registry, clock: FakeClock
 ) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,6 +5,7 @@ No Docker needed; these are pure unit tests and run on every platform.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -75,6 +76,97 @@ def test_touch_resource_advances_last_used(registry: Registry, clock: FakeClock)
     assert updated.last_used == resource.created_at + 3600
 
 
+def test_engine_identity_is_unique_and_registration_reconciles_in_place(
+    registry: Registry, clock: FakeClock
+) -> None:
+    first = registry.register_resource(
+        kind="volume",
+        name="shared-cache",
+        stack="one",
+        generation="sha256:old",
+        scope="stack",
+        workspace="/w1",
+    )
+    clock.advance(60)
+
+    second = registry.register_resource(
+        kind="volume",
+        name="shared-cache",
+        stack="two",
+        generation="sha256:new",
+        scope="machine",
+        workspace="/w2",
+    )
+
+    assert second.id == first.id
+    assert second.last_used == clock.now()
+    assert (second.stack, second.generation, second.scope, second.workspace) == (
+        "two",
+        "sha256:new",
+        "machine",
+        "/w2",
+    )
+    assert [(resource.kind, resource.name) for resource in registry.list_resources()] == [
+        ("volume", "shared-cache")
+    ]
+
+
+def test_legacy_image_tag_is_merged_into_its_immutable_identity(registry: Registry) -> None:
+    legacy = registry.register_resource(
+        kind="image",
+        name="bosn/test:tag",
+        stack="test",
+        generation="sha256:g",
+        scope="spec",
+        workspace="/w1",
+    )
+    canonical = registry.register_resource(
+        kind="image",
+        name="sha256:image-id",
+        stack="test",
+        generation="sha256:g",
+        scope="spec",
+        workspace="/w2",
+    )
+    legacy_lease = registry.acquire_lease(legacy.id, pid=1, proc_start=1.0)
+
+    merged = registry.canonicalize_image_identity("bosn/test:tag", "sha256:image-id")
+
+    assert merged is not None
+    assert merged.id == canonical.id
+    assert registry.get_resource(legacy.id) is None
+    moved_lease = registry.get_lease(legacy_lease.id)
+    assert moved_lease is not None
+    assert moved_lease.resource_id == canonical.id
+    assert [(resource.kind, resource.name) for resource in registry.list_resources()] == [
+        ("image", "sha256:image-id")
+    ]
+    uses = registry.conn.execute(
+        "SELECT workspace FROM resource_uses WHERE resource_id = ? ORDER BY workspace",
+        (canonical.id,),
+    ).fetchall()
+    assert [row["workspace"] for row in uses] == ["/w1", "/w2"]
+
+
+def test_legacy_short_image_id_is_merged_into_the_full_identity(registry: Registry) -> None:
+    full_id = "sha256:0123456789ababcdef0123456789abcdef0123456789abcdef0123456789ab"
+    legacy = registry.register_resource(
+        kind="image",
+        name="0123456789ab",
+        stack="test",
+        generation="sha256:g",
+        scope="spec",
+        workspace="/w",
+    )
+
+    merged = registry.canonicalize_image_identity("bosn/test:tag", full_id)
+
+    assert merged is not None
+    assert merged.id == legacy.id
+    assert merged.name == full_id
+    assert registry.get_resource_by_engine_identity("image", "0123456789ab") is None
+
+
 def test_lease_expiry_is_driven_by_the_injected_clock(registry: Registry, clock: FakeClock) -> None:
     resource = registry.register_resource(
         kind="volume", name="v", stack="s", generation="g", scope="spec", workspace="/w"
@@ -115,12 +207,102 @@ def test_removing_a_resource_cascades_to_its_leases(registry: Registry) -> None:
 def test_generations_supersede_all_but_the_current_digest(
     registry: Registry, clock: FakeClock
 ) -> None:
-    registry.record_generation("sha256:old", "test")
+    registry.record_generation("sha256:old", "test", "/w")
     clock.advance(60)
-    registry.record_generation("sha256:new", "test")
-    assert registry.supersede_generations("test", keep_digest="sha256:new") == 1
-    assert registry.generation_superseded_at("sha256:old") == clock.now()
-    assert registry.generation_superseded_at("sha256:new") is None
+    registry.record_generation("sha256:new", "test", "/w")
+    assert registry.supersede_generations("test", keep_digest="sha256:new", workspace="/w") == 1
+    assert (
+        registry.generation_superseded_at("sha256:old", stack="test", workspace="/w") == clock.now()
+    )
+    assert registry.generation_superseded_at("sha256:new", stack="test", workspace="/w") is None
+
+
+def test_generation_supersession_is_scoped_to_one_workspace(
+    registry: Registry, clock: FakeClock
+) -> None:
+    for workspace in ("/w1", "/w2"):
+        registry.record_generation("sha256:shared", "test", workspace)
+    registry.record_generation("sha256:w1-new", "test", "/w1")
+
+    assert registry.supersede_generations("test", keep_digest="sha256:w1-new", workspace="/w1") == 1
+    assert (
+        registry.generation_superseded_at("sha256:shared", stack="test", workspace="/w1")
+        == clock.now()
+    )
+    assert registry.generation_superseded_at("sha256:shared", stack="test", workspace="/w2") is None
+
+
+def test_mixed_done_and_superseded_consumers_make_a_shared_resource_retirable(
+    registry: Registry,
+) -> None:
+    for workspace in ("/w1", "/w2"):
+        registry.record_generation("sha256:old", "test", workspace)
+        registry.register_resource(
+            kind="image",
+            name="sha256:image",
+            stack="test",
+            generation="sha256:old",
+            scope="spec",
+            workspace=workspace,
+        )
+    registry.mark_workspace_done("/w1")
+    registry.record_generation("sha256:new", "test", "/w2")
+    registry.supersede_generations("test", keep_digest="sha256:new", workspace="/w2")
+    image = registry.get_resource_by_engine_identity("image", "sha256:image")
+    assert image is not None
+
+    assert registry.resource_retention_signals(image.id) == (True, False)
+
+
+def test_v1_migration_deduplicates_engine_objects_and_preserves_leases(tmp_path: Path) -> None:
+    path = tmp_path / "v1.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        INSERT INTO meta VALUES ('schema_version', '1');
+        INSERT INTO meta VALUES ('registry_id', 'registry-v1');
+        CREATE TABLE resources (
+            id TEXT PRIMARY KEY, kind TEXT NOT NULL, name TEXT NOT NULL,
+            stack TEXT NOT NULL, generation TEXT NOT NULL, scope TEXT NOT NULL,
+            workspace TEXT NOT NULL, created_at REAL NOT NULL, last_used REAL NOT NULL,
+            state TEXT NOT NULL DEFAULT 'active'
+        );
+        CREATE TABLE leases (
+            id TEXT PRIMARY KEY, resource_id TEXT NOT NULL REFERENCES resources(id)
+                ON DELETE CASCADE,
+            pid INTEGER NOT NULL, proc_start REAL NOT NULL, acquired_at REAL NOT NULL,
+            heartbeat_at REAL NOT NULL, ttl_seconds REAL NOT NULL
+        );
+        CREATE TABLE generations (
+            digest TEXT PRIMARY KEY, stack TEXT NOT NULL, created_at REAL NOT NULL,
+            superseded_at REAL
+        );
+        CREATE TABLE events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, at REAL NOT NULL,
+            kind TEXT NOT NULL, detail TEXT NOT NULL DEFAULT ''
+        );
+        INSERT INTO resources VALUES
+            ('old', 'volume', 'cache', 'test', 'sha256:g', 'stack', '/w', 1, 2, 'active'),
+            ('new', 'volume', 'cache', 'test', 'sha256:g', 'stack', '/w', 3, 4, 'active');
+        INSERT INTO leases VALUES ('lease-old', 'old', 1, 1, 1, 1, 900);
+        INSERT INTO generations VALUES ('sha256:g', 'test', 1, NULL);
+        """
+    )
+    connection.close()
+
+    with Registry(path) as migrated:
+        resources = migrated.list_resources()
+        assert len(resources) == 1
+        assert resources[0].id == "new"
+        assert resources[0].created_at == 1
+        assert migrated.leases_for("new")[0].id == "lease-old"
+        assert migrated.meta("schema_version") == "2"
+        assert migrated.generation_superseded_at("sha256:g", stack="test", workspace="/w") is None
+        index_columns = migrated.conn.execute(
+            "PRAGMA index_info(idx_resources_engine_identity)"
+        ).fetchall()
+        assert [row["name"] for row in index_columns] == ["kind", "name"]
 
 
 def test_events_are_recorded_for_lifecycle_actions(registry: Registry) -> None:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -110,6 +110,18 @@ def test_labels_are_confirmed_by_inspect_when_the_listing_truncates_them() -> No
     assert any("inspect" in cmd for cmd in engine.commands)
 
 
+def test_image_discovery_requests_and_keeps_the_full_immutable_id() -> None:
+    image_id = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    engine = FakeEngine(
+        {"image": [{"ID": image_id, "Labels": json.dumps(label_dict(kind="image"))}]}
+    )
+
+    scan = ResourceScanner(engine).scan(OURS, kinds=["image"])  # type: ignore[arg-type]
+
+    assert [resource.name for resource in scan.owned] == [image_id]
+    assert ["images", "--no-trunc", "--format", "{{json .}}"] in engine.commands
+
+
 @pytest.mark.parametrize(
     "blob",
     ["", "null", "<no value>", "map[]", "not json at all {", "[1,2,3]"],

--- a/tests/test_scenario_docker.py
+++ b/tests/test_scenario_docker.py
@@ -19,7 +19,7 @@ from bosn import labels
 from bosn.clock import FakeClock
 from bosn.converge import Converger
 from bosn.engine import Engine
-from bosn.gc import Collector, done_workspaces, mark_done, status
+from bosn.gc import Collector, mark_done, status
 from bosn.manifest import load
 from bosn.registry import Registry
 from bosn.resources import ResourceScanner
@@ -87,7 +87,11 @@ def registry(tmp_path: Path, clock: FakeClock) -> Iterator[Registry]:
 
 
 def _cleanup(registry: Registry, engine: Engine) -> None:
-    for resource in registry.list_resources():
+    resources = registry.list_resources()
+    for resource in resources:
+        if resource.kind == "container":
+            engine.run(["container", "rm", "--force", resource.name])
+    for resource in resources:
         if resource.kind == "volume":
             engine.run(["volume", "rm", "--force", resource.name])
         elif resource.kind == "image":
@@ -119,21 +123,21 @@ def test_full_lifecycle_run_lease_done_ttl_gc(
         clock.advance(10 * DAY)
 
         collector = Collector(registry, engine)
-        held = collector.collect(dry_run=True, done_workspaces=done_workspaces(registry))
+        held = collector.collect(dry_run=True)
         assert target.name not in held.removed, "a live lease must protect its resource"
 
         # -- release the lease, then mark the workspace done ------------------
         registry.release_lease(lease.id)
         assert mark_done(registry, str(load(project).root)) >= 1
 
-        planned = collector.collect(dry_run=True, done_workspaces=done_workspaces(registry))
+        planned = collector.collect(dry_run=True)
         assert target.name in planned.removed
         assert all(m.name not in planned.removed for m in machine_volumes), (
             "done must never collect machine-scoped caches"
         )
 
         # -- apply: exactly the owned resources go ----------------------------
-        applied = collector.collect(dry_run=False, done_workspaces=done_workspaces(registry))
+        applied = collector.collect(dry_run=False)
         assert target.name in applied.removed
         assert applied.errors == []
 
@@ -174,7 +178,11 @@ def test_a_lost_registry_rebuilds_from_labels(
     converger = Converger(load(project), registry, engine)
     try:
         converger.run(["true"])
-        original = {r.name for r in registry.list_resources() if r.kind == "volume"}
+        original = {
+            (resource.kind, resource.name)
+            for resource in registry.list_resources()
+            if resource.kind in {"container", "volume", "image"}
+        }
         registry_id = registry.registry_id
 
         # wipe every row, keeping the registry id -- the database is "lost"
@@ -182,9 +190,16 @@ def test_a_lost_registry_rebuilds_from_labels(
             registry.remove_resource(resource.id)
         assert registry.list_resources() == []
 
-        scan = ResourceScanner(engine).scan(registry_id, kinds=["volume"])
+        scan = ResourceScanner(engine).scan(registry_id, kinds=["container", "volume", "image"])
         adopted = adopt(registry, scan, clock=clock)
 
-        assert original <= set(adopted), "every owned volume must be rediscovered from labels"
+        assert {name for _kind, name in original} <= set(adopted)
+        assert {resource.kind for resource in registry.list_resources()} == {
+            "container",
+            "image",
+            "volume",
+        }
+        _result, code, output = converger.run(["echo", "adopted-ok"])
+        assert code == 0, output
     finally:
         _cleanup(registry, engine)


### PR DESCRIPTION
Fixes #35.\n\nReconciles reused owned resources, tracks every workspace/generation consumer of shared engine objects, and leases image plus mounted-volume dependencies for live executions.\n\nIt also migrates legacy resource rows safely, canonicalizes Docker image identities, fails closed for foreign collisions, and closes GC reuse races.\n\nValidated with lint, type checks, 299 non-Docker tests, and all Docker integration modules.