### PR TITLE
Fix policy propagation and execution deadlines

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -24,6 +24,32 @@ NOT_IMPLEMENTED_EXIT = 3
 # short enough not to look hung.
 DAEMON_STOP_TIMEOUT = 45.0
 
+
+def _policy_flags(opts: Options) -> dict[str, float | None]:
+    """The complete CLI layer of the policy precedence stack."""
+    from bosn.config import policy_keys
+
+    return {key: getattr(opts, key) for key in policy_keys()}
+
+
+_POLICY_FLAG_KEYS = (
+    "container_idle_stop",
+    "container_remove",
+    "warm_volume_ttl",
+    "superseded_cap",
+    "shared_cache_ceiling",
+    "run_max_duration",
+    "idle_retire_seconds",
+    "max_builds",
+    "build_ttl_seconds",
+)
+
+
+def _add_policy_flags(parser: argparse.ArgumentParser, *, default: object) -> None:
+    for key in _POLICY_FLAG_KEYS:
+        parser.add_argument(f"--{key.replace('_', '-')}", type=float, default=default)
+
+
 # verb -> (help text, phase that lands it)
 VERBS: dict[str, tuple[str, str]] = {
     "run": ("run an ad-hoc command in a stack", "implemented"),
@@ -66,9 +92,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--manifest", default=None, help="path to bosn.toml (default: nearest one upward)"
     )
+    # Policy is global because every command must resolve exactly the same snapshot.
+    # The daemon repeats its three operational flags after the verb for spawned argv
+    # compatibility; the remaining flags belong before the verb like --engine.
+    _add_policy_flags(parser, default=None)
     subparsers = parser.add_subparsers(dest="verb", metavar="VERB")
     for verb, (help_text, _) in VERBS.items():
         sub = subparsers.add_parser(verb, help=help_text)
+        _add_policy_flags(sub, default=argparse.SUPPRESS)
         sub.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
         if verb in {"run", "tasks", "shell", "done", "ensure", "adopt"}:
             sub.add_argument("--stack", default=None, help="stack to use (default: the default)")
@@ -95,9 +126,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     daemon_parser = subparsers.add_parser(DAEMON_VERB, help=argparse.SUPPRESS)
     daemon_parser.add_argument("--port", type=int, default=None)
-    daemon_parser.add_argument("--idle-retire-seconds", type=float, default=None)
-    daemon_parser.add_argument("--max-builds", type=int, default=None)
-    daemon_parser.add_argument("--build-ttl-seconds", type=float, default=None)
+    _add_policy_flags(daemon_parser, default=argparse.SUPPRESS)
     daemon_parser.add_argument("--stop", action="store_true", help="stop a running daemon")
     autostart = daemon_parser.add_mutually_exclusive_group()
     autostart.add_argument(
@@ -179,13 +208,7 @@ def cmd_daemon(opts: Options) -> int:
         return 0
 
     try:
-        config = load_config(
-            flags={
-                "idle_retire_seconds": opts.idle_retire_seconds,
-                "max_builds": opts.max_builds,
-                "build_ttl_seconds": opts.build_ttl_seconds,
-            }
-        )
+        config = load_config(flags=_policy_flags(opts))
         daemon = daemon_mod.Daemon(
             state_dir=state_dir,
             port=opts.port,
@@ -193,6 +216,7 @@ def cmd_daemon(opts: Options) -> int:
             max_builds=int(config.get("max_builds")),
             build_ttl_seconds=config.get("build_ttl_seconds"),
             engine_binary=opts.engine,
+            config=config,
         )
         return daemon.serve_forever()
     except ConfigError as exc:
@@ -359,6 +383,8 @@ def _converge_via_daemon(opts: Options, manifest, stack_name: str | None):
 
 def cmd_run(opts: Options) -> int:
     from bosn import daemon as daemon_mod
+    from bosn.config import ConfigError
+    from bosn.config import load as load_config
     from bosn.converge import Converger, workspace_of
     from bosn.engine import EngineError
     from bosn.manifest import ManifestError
@@ -375,6 +401,7 @@ def cmd_run(opts: Options) -> int:
         return 1
 
     try:
+        config = load_config(flags=_policy_flags(opts))
         if opts.task:
             task = manifest.task(opts.task)
             command = ["sh", "-c", task.cmd]
@@ -383,7 +410,12 @@ def cmd_run(opts: Options) -> int:
             stack_name = opts.stack
 
         converged = _converge_via_daemon(opts, manifest, stack_name)
-        converger = Converger(manifest, registry, Engine(opts.engine))
+        converger = Converger(
+            manifest,
+            registry,
+            Engine(opts.engine),
+            run_max_duration=config.get("run_max_duration"),
+        )
         _result, code, output = converger.run_converged(
             converged, command, stack_name=stack_name, workspace=workspace_of(manifest)
         )
@@ -393,7 +425,7 @@ def cmd_run(opts: Options) -> int:
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:  # fail closed, stay visible
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
         return 1
-    except (ManifestError, EngineError) as exc:
+    except (ManifestError, EngineError, ConfigError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
     finally:
@@ -450,6 +482,7 @@ def cmd_cancel(opts: Options) -> int:
 
 def cmd_status(opts: Options) -> int:
     from bosn.config import ConfigError
+    from bosn.config import load as load_config
     from bosn.gc import status
     from bosn.registry import Registry, default_db_path
 
@@ -457,7 +490,14 @@ def cmd_status(opts: Options) -> int:
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
     try:
         with Registry(db_path) as registry:
-            print(json.dumps(status(registry, Engine(opts.engine)), indent=2))
+            print(
+                json.dumps(
+                    status(
+                        registry, Engine(opts.engine), config=load_config(flags=_policy_flags(opts))
+                    ),
+                    indent=2,
+                )
+            )
         return 0
     except ConfigError as exc:
         print(str(exc), file=sys.stderr)
@@ -465,14 +505,22 @@ def cmd_status(opts: Options) -> int:
 
 
 def cmd_gc(opts: Options) -> int:
+    from bosn.config import ConfigError
+    from bosn.config import load as load_config
     from bosn.gc import Collector
     from bosn.registry import Registry, default_db_path
 
     state_dir = opts.state_dir
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
-    with Registry(db_path) as registry:
-        collector = Collector(registry, Engine(opts.engine))
-        result = collector.collect(dry_run=opts.dry_run)
+    try:
+        with Registry(db_path) as registry:
+            collector = Collector(
+                registry, Engine(opts.engine), config=load_config(flags=_policy_flags(opts))
+            )
+            result = collector.collect(dry_run=opts.dry_run)
+    except ConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
     print(json.dumps({**result.summary(), "dry_run": result.dry_run}, indent=2))
     for name in result.would_stop:

--- a/src/bosn/config.py
+++ b/src/bosn/config.py
@@ -33,6 +33,11 @@ _DEFAULTS = {
 _ENV = {key: f"BOSN_{key.upper()}" for key in _DEFAULTS}
 
 
+def policy_keys() -> tuple[str, ...]:
+    """Documented policy keys, in stable CLI/report order."""
+    return tuple(_DEFAULTS)
+
+
 def default_path() -> Path:
     explicit = os.environ.get("BOSN_CONFIG")
     if explicit:

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -28,7 +28,6 @@ REUSED = "reused"
 REGISTERED = "registered"
 ROLLED = "rolled"
 CONTAINER_HEARTBEAT_TIMEOUT_SECONDS = 600
-RUN_MAX_DURATION_SECONDS = 8 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -273,6 +272,7 @@ class Converger:
         *,
         progress: Callable[[str], None] | None = None,
         cancelled: threading.Event | None = None,
+        run_max_duration: float | None = None,
     ) -> None:
         self.manifest = manifest
         self.registry = registry
@@ -281,6 +281,7 @@ class Converger:
         # the build stops when the job is cancelled.
         self.progress = progress
         self.cancelled = cancelled
+        self.run_max_duration = run_max_duration
 
     def converge(
         self, stack_name: str | None = None, *, workspace: str | None = None
@@ -566,13 +567,13 @@ class Converger:
             for mount in expected_mounts.values():
                 suffix = ":ro" if not mount["rw"] else ""
                 args += ["--volume", f"{mount['source']}:{mount['destination']}{suffix}"]
-            # PID 1 exits when the daemon heartbeat goes stale or a run is orphaned for
-            # too long.  `--rm` above then removes the stopped container automatically.
+            # PID 1 exits only when the daemon heartbeat goes stale. Execution deadlines
+            # belong to the individual `docker exec`, not the container's creation time:
+            # a warm container may correctly serve many later sessions.
             watchdog = (
-                "started=$(date +%s); while :; do now=$(date +%s); "
+                "while :; do now=$(date +%s); "
                 "beat=$(stat -c %Y /bosn-daemon/heartbeat 2>/dev/null || echo 0); "
                 f"[ $((now-beat)) -gt {CONTAINER_HEARTBEAT_TIMEOUT_SECONDS} ] && exit 0; "
-                f"[ $((now-started)) -gt {RUN_MAX_DURATION_SECONDS} ] && exit 0; "
                 "sleep 30; done"
             )
             args += [converged.image_tag, "sh", "-c", watchdog]
@@ -934,7 +935,7 @@ class Converger:
         )
         args = ["exec", name, *command]
         try:
-            result = self.engine.run(args)
+            result = self.engine.run(args, timeout=self.run_max_duration)
         finally:
             for lease in leases:
                 self.registry.release_lease(lease.id)

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from bosn import __version__, ipc
 from bosn.clock import Clock, SystemClock
+from bosn.config import Config
 from bosn.jobs import BuildOutcome, Job, JobError, JobManager
 from bosn.registry import Registry, default_state_dir
 
@@ -269,8 +270,10 @@ class Daemon:
         engine_binary: str = "docker",
         maintenance_interval_seconds: float = DEFAULT_MAINTENANCE_INTERVAL_SECONDS,
         clock: Clock | None = None,
+        config: Config | None = None,
     ) -> None:
         self.engine_binary = engine_binary
+        self.config = config
         self.clock = clock or SystemClock()
         self.state_dir = state_dir or default_state_dir()
         self.bind_port = port_for(self.state_dir) if port is None else port
@@ -415,7 +418,7 @@ class Daemon:
 
         self.registry.log_event("maintenance.gc.started")
         try:
-            result = Collector(self.registry, engine).collect(dry_run=False)
+            result = Collector(self.registry, engine, config=self.config).collect(dry_run=False)
         except KeyboardInterrupt:
             raise
         except Exception as exc:  # noqa: BLE001 - never claim a failed GC succeeded
@@ -490,6 +493,7 @@ class Daemon:
             "uptime_seconds": time.time() - self.started_at,
             "idle_seconds": self.idle_seconds(),
             "resources": len(self.registry.list_resources()),
+            "config": self.config.report() if self.config is not None else None,
         }
 
     def _verb_jobs(self, request: dict[str, Any]) -> dict[str, Any]:

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -56,15 +56,20 @@ class Engine:
         """True when the engine binary is on PATH. Does not prove the daemon is up."""
         return shutil.which(self.binary) is not None
 
-    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+    def run(
+        self, args: list[str], *, check: bool = False, timeout: float | None = None
+    ) -> EngineResult:
         if not self.available():
             raise EngineError(f"{self.binary!r} is not on PATH")
-        completed = rp.subprocess_run(
-            [self.binary, *args],
-            cwd=None,
-            check=False,
-            timeout=self.timeout,
-        )
+        effective_timeout = self.timeout if timeout is None else max(1, int(timeout))
+        try:
+            completed = rp.subprocess_run(
+                [self.binary, *args], cwd=None, check=False, timeout=effective_timeout
+            )
+        except RuntimeError as exc:
+            raise EngineError(
+                f"{self.binary} {' '.join(args)} exceeded its {effective_timeout}-second deadline"
+            ) from exc
         result = EngineResult(
             returncode=completed.returncode,
             stdout=(completed.stdout or "").strip(),

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from bosn import labels
 from bosn.accounting import probe, resource_bytes
+from bosn.config import Config
 from bosn.engine import Engine
 from bosn.registry import Registry
 from bosn.resources import ResourceScanner
@@ -64,10 +65,13 @@ class GCResult:
 
 
 class Collector:
-    def __init__(self, registry: Registry, engine: Engine | None = None) -> None:
+    def __init__(
+        self, registry: Registry, engine: Engine | None = None, *, config: Config | None = None
+    ) -> None:
         self.registry = registry
         self.engine = engine or Engine()
         self.scanner = ResourceScanner(self.engine)
+        self.config = config
 
     def _ownership_proven(self, kind: str, name: str) -> bool:
         """Re-confirm from the engine's labels before deleting anything.
@@ -84,13 +88,15 @@ class Collector:
         dry_run: bool = True,
         pressure: Pressure | None = None,
     ) -> GCResult:
-        verdicts: list[Verdict] = plan(self.registry, pressure=pressure)
+        verdicts: list[Verdict] = plan(self.registry, pressure=pressure, config=self.config)
         result = GCResult(dry_run=dry_run)
 
         for verdict in verdicts:
             if not verdict.collect:
                 result.kept.append(verdict.name)
-                if not container_should_stop(verdict.resource, self.registry.clock.now()):
+                if not container_should_stop(
+                    verdict.resource, self.registry.clock.now(), config=self.config
+                ):
                     continue
                 # The planning snapshot is not a mutation boundary: another client may
                 # acquire a lease while the rest of the plan is evaluated. Serialize all
@@ -109,12 +115,15 @@ class Collector:
                         superseded=superseded,
                         workspace_done=workspace_done,
                         pressure=pressure,
+                        config=self.config,
                     )
                     protected = current.reason in {KEPT_LEASED, KEPT_QUIET_PERIOD}
                     if (
                         current.collect
                         or protected
-                        or not container_should_stop(resource, self.registry.clock.now())
+                        or not container_should_stop(
+                            resource, self.registry.clock.now(), config=self.config
+                        )
                     ):
                         continue
                     if not self._ownership_proven(resource.kind, resource.name):
@@ -149,6 +158,7 @@ class Collector:
                     superseded=superseded,
                     workspace_done=workspace_done,
                     pressure=pressure,
+                    config=self.config,
                 )
                 if not current.collect:
                     result.kept.append(resource.name)
@@ -180,12 +190,14 @@ class Collector:
         return result
 
 
-def status(registry: Registry, engine: Engine | None = None) -> dict:
+def status(
+    registry: Registry, engine: Engine | None = None, *, config: Config | None = None
+) -> dict:
     """Tiers, leases, and foreign registries. Read-only: works with the daemon dead."""
     engine = engine or Engine()
     from bosn.config import load as load_config
 
-    config = load_config()
+    config = config or load_config()
     scan = ResourceScanner(engine).scan(registry.registry_id)
 
     attributed: dict[tuple[str, str, str], dict[str, int]] = defaultdict(
@@ -206,7 +218,7 @@ def status(registry: Registry, engine: Engine | None = None) -> dict:
     pressure = Pressure.assess(
         resource_count=len(measured), managed_bytes=managed_bytes, free_bytes=storage.free_bytes
     )
-    verdicts = plan(registry, pressure=pressure)
+    verdicts = plan(registry, pressure=pressure, config=config)
     reclaimable = sum(measured[v.resource.id] or 0 for v in collectable(verdicts))
     advisory = (
         "Backing-store slack exceeds managed reclaimable bytes; compact the Docker VHDX manually."

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -44,6 +44,14 @@ class Options:
     stop: bool = False
     autostart: bool | None = None
 
+    # policy overrides (file < environment < CLI flag)
+    container_idle_stop: float | None = None
+    container_remove: float | None = None
+    warm_volume_ttl: float | None = None
+    superseded_cap: float | None = None
+    shared_cache_ceiling: float | None = None
+    run_max_duration: float | None = None
+
     extras: tuple[str, ...] = field(default=())
 
     @property
@@ -65,6 +73,19 @@ def _as_path(value: object) -> Path | None:
 
 def _as_str(value: object) -> str | None:
     return None if value is None else str(value)
+
+
+def _float_or_none(value: object) -> float | None:
+    return None if value is None else float(str(value))
+
+
+def _int_or_none(value: object) -> int | None:
+    if value is None:
+        return None
+    number = float(str(value))
+    if not number.is_integer():
+        raise ValueError(f"expected an integer, got {value!r}")
+    return int(number)
 
 
 def from_namespace(ns: argparse.Namespace) -> Options:
@@ -107,8 +128,14 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         dry_run=bool(get("dry_run", True)),
         port=None if port is None else int(str(port)),
         idle_retire_seconds=None if idle is None else float(str(idle)),
-        max_builds=None if max_builds is None else int(str(max_builds)),
+        max_builds=_int_or_none(max_builds),
         build_ttl_seconds=None if build_ttl is None else float(str(build_ttl)),
         stop=bool(get("stop", False)),
         autostart=autostart,
+        container_idle_stop=_float_or_none(get("container_idle_stop")),
+        container_remove=_float_or_none(get("container_remove")),
+        warm_volume_ttl=_float_or_none(get("warm_volume_ttl")),
+        superseded_cap=_float_or_none(get("superseded_cap")),
+        shared_cache_ceiling=_float_or_none(get("shared_cache_ceiling")),
+        run_max_duration=_float_or_none(get("run_max_duration")),
     )

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from bosn.config import Config
 from bosn.registry import Lease, Registry, Resource
 from bosn.resources import (
     QUIET_PERIOD_SECONDS,
@@ -92,20 +93,19 @@ class Pressure:
         )
 
 
-def container_should_stop(resource: Resource, now: float) -> bool:
+def container_should_stop(resource: Resource, now: float, *, config: Config | None = None) -> bool:
     from bosn.config import load
 
-    return resource.kind == "container" and (now - resource.last_used) >= load().get(
+    config = config or load()
+    return resource.kind == "container" and (now - resource.last_used) >= config.get(
         "container_idle_stop"
     )
 
 
-def _ttl_for(resource: Resource) -> float:
-    from bosn.config import load
-
+def _ttl_for(resource: Resource, *, config: Config) -> float:
     if resource.kind == "container":
-        return load().get("container_remove")
-    return load().get("warm_volume_ttl")
+        return config.get("container_remove")
+    return config.get("warm_volume_ttl")
 
 
 def evaluate(
@@ -116,11 +116,16 @@ def evaluate(
     superseded: bool = False,
     workspace_done: bool = False,
     pressure: Pressure | None = None,
+    config: Config | None = None,
     alive_probe=process_alive,
 ) -> Verdict:
     """Decide a single resource's fate. Never mutates anything."""
     now = registry.clock.now() if now is None else now
     pressure = pressure or Pressure()
+    if config is None:
+        from bosn.config import load
+
+        config = load()
 
     leases: list[Lease] = registry.leases_for(resource.id)
     if any(not lease_is_expired(lease, now, alive_probe=alive_probe) for lease in leases):
@@ -134,9 +139,7 @@ def evaluate(
         return Verdict(resource, False, KEPT_QUIET_PERIOD)
 
     if superseded:
-        from bosn.config import load
-
-        if age >= load().get("superseded_cap"):
+        if age >= config.get("superseded_cap"):
             return Verdict(resource, True, COLLECT_SUPERSEDED)
         return Verdict(resource, False, KEPT_WARM)
 
@@ -152,7 +155,7 @@ def evaluate(
         # Machine-shared caches age only under pressure.
         return Verdict(resource, False, KEPT_MACHINE_SCOPE)
 
-    if age >= _ttl_for(resource):
+    if age >= _ttl_for(resource, config=config):
         return Verdict(resource, True, COLLECT_IDLE)
 
     return Verdict(resource, False, KEPT_WARM)
@@ -164,6 +167,7 @@ def plan(
     now: float | None = None,
     done_workspaces: set[str] | None = None,
     pressure: Pressure | None = None,
+    config: Config | None = None,
     alive_probe=process_alive,
 ) -> list[Verdict]:
     """Evaluate every registered resource. Pure: the registry is not modified."""
@@ -183,6 +187,7 @@ def plan(
                 superseded=superseded,
                 workspace_done=workspace_done,
                 pressure=pressure,
+                config=config,
                 alive_probe=alive_probe,
             )
         )

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -79,6 +79,12 @@ def test_doctor_reports_unreachable_engine_without_crashing(capsys) -> None:
     assert "not on PATH" in captured.err
 
 
+def test_gc_reports_invalid_policy_without_a_traceback(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setenv("BOSN_WARM_VOLUME_TTL", "not-a-number")
+    assert cli.main(["--state-dir", str(tmp_path), "gc"]) == 1
+    assert "warm_volume_ttl" in capsys.readouterr().err
+
+
 def test_stopping_a_daemon_that_was_not_running_says_so(tmp_path, capsys) -> None:
     assert cli.main(["--state-dir", str(tmp_path), "__daemon", "--stop"]) == 0
     assert "no daemon was running" in capsys.readouterr().out

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -44,6 +44,7 @@ class FakeEngine:
 
     def __init__(self) -> None:
         self.commands: list[list[str]] = []
+        self.timeouts: list[float | None] = []
         self.existing: set[str] = set()
         self.image_ids: dict[str, str] = {"alpine": "sha256:alpine-v1"}
         self.image_platforms: dict[str, str] = {"alpine": "linux/amd64"}
@@ -51,8 +52,11 @@ class FakeEngine:
         self.resource_labels: dict[tuple[str, str], dict[str, str]] = {}
         self.container_serial = 0
 
-    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+    def run(
+        self, args: list[str], *, check: bool = False, timeout: float | None = None
+    ) -> EngineResult:
         self.commands.append(list(args))
+        self.timeouts.append(timeout)
         if args[:2] == ["version", "--format"]:
             return EngineResult(0, "linux/amd64", "")
         if args[:2] == ["container", "inspect"] and "{{json .}}" in args:
@@ -1014,8 +1018,10 @@ def test_failed_new_container_is_removed_by_immutable_id(
             super().__init__()
             self.created_id = ""
 
-        def run(self, args: list[str], *, check: bool = False) -> EngineResult:
-            result = super().run(args, check=check)
+        def run(
+            self, args: list[str], *, check: bool = False, timeout: float | None = None
+        ) -> EngineResult:
+            result = super().run(args, check=check, timeout=timeout)
             if args[0] == "create":
                 self.created_id = result.stdout
                 if failure == "validation":
@@ -1047,8 +1053,10 @@ def test_new_container_is_removed_if_lease_acquisition_fails(
             super().__init__()
             self.created_id = ""
 
-        def run(self, args: list[str], *, check: bool = False) -> EngineResult:
-            result = super().run(args, check=check)
+        def run(
+            self, args: list[str], *, check: bool = False, timeout: float | None = None
+        ) -> EngineResult:
+            result = super().run(args, check=check, timeout=timeout)
             if args[0] == "create":
                 self.created_id = result.stdout
             return result
@@ -1196,4 +1204,14 @@ def test_persistent_container_has_daemon_loss_and_run_duration_watchdogs(
     create = engine.ran("create")[0]
     assert "--rm" in create
     assert any("daemon.heartbeat:/bosn-daemon/heartbeat:ro" in arg for arg in create)
-    assert any("stat -c %Y" in arg and "started" in arg for arg in create)
+    assert any("stat -c %Y" in arg for arg in create)
+    assert "started=$(date +%s)" not in create[-1]
+
+
+def test_execution_uses_configured_deadline_not_engine_control_timeout(
+    converger: Converger,
+) -> None:
+    converger.run_max_duration = 123.0
+    converger.run(["true"])
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+    assert engine.timeouts[-1] == 123.0

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -213,7 +213,7 @@ def test_maintenance_catches_up_then_runs_on_the_injected_clock(
             return EngineInfo(binary="docker", reachable=True)
 
     class RecordingCollector:
-        def __init__(self, _registry, _engine) -> None:
+        def __init__(self, _registry, _engine, *, config=None) -> None:
             pass
 
         def collect(self, **_kwargs):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -82,6 +82,49 @@ def test_daemon_numeric_flags_are_typed() -> None:
     assert isinstance(parsed.idle_retire_seconds, float)
 
 
+def test_all_documented_policy_flags_are_typed() -> None:
+    parsed = opts(
+        [
+            "--container-idle-stop",
+            "1",
+            "--container-remove",
+            "2",
+            "--warm-volume-ttl",
+            "3",
+            "--superseded-cap",
+            "4",
+            "--shared-cache-ceiling",
+            "5",
+            "--run-max-duration",
+            "6",
+            "--idle-retire-seconds",
+            "7",
+            "--max-builds",
+            "8",
+            "--build-ttl-seconds",
+            "9",
+            "status",
+        ]
+    )
+    assert [
+        parsed.container_idle_stop,
+        parsed.container_remove,
+        parsed.warm_volume_ttl,
+        parsed.superseded_cap,
+        parsed.shared_cache_ceiling,
+        parsed.run_max_duration,
+        parsed.idle_retire_seconds,
+        parsed.max_builds,
+        parsed.build_ttl_seconds,
+    ] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8, 9.0]
+
+
+def test_policy_flags_work_before_or_after_the_verb() -> None:
+    assert opts(["--run-max-duration", "12", "run"]).run_max_duration == 12
+    assert opts(["run", "--run-max-duration", "12", "--", "true"]).run_max_duration == 12
+    assert opts(["--idle-retire-seconds", "12", "__daemon"]).idle_retire_seconds == 12
+
+
 def test_gc_apply_flips_dry_run() -> None:
     assert opts(["gc"]).dry_run is True
     assert opts(["gc", "--apply"]).dry_run is False

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -8,6 +8,7 @@ import pytest
 
 from bosn import retention
 from bosn.clock import FakeClock
+from bosn.config import load as load_config
 from bosn.registry import Registry
 from bosn.retention import (
     COLLECT_DONE,
@@ -90,6 +91,14 @@ def test_containers_idle_stop_at_one_hour(registry: Registry, clock: FakeClock) 
     assert not retention.container_should_stop(resource, clock.now())
     clock.advance(HOUR + 1)
     assert retention.container_should_stop(resource, clock.now())
+
+
+def test_explicit_policy_snapshot_controls_retention(registry: Registry, clock: FakeClock) -> None:
+    resource = make(registry, kind="container")
+    clock.advance(2)
+    config = load_config(flags={"container_idle_stop": 1, "container_remove": 1})
+    assert retention.container_should_stop(resource, clock.now(), config=config)
+    assert evaluate(registry, resource, config=config, alive_probe=DEAD).collect
 
 
 def test_containers_are_removed_at_one_day(registry: Registry, clock: FakeClock) -> None:


### PR DESCRIPTION
Fixes #43.\n\nThreads one resolved policy snapshot through CLI, daemon maintenance, retention, GC, and status. Separates configured docker-exec deadlines from short engine control-plane timeouts, reports deadline expiry cleanly, and prevents persistent containers expiring based on creation age.\n\nValidated with lint, type checks, and 304 non-Docker tests.