### PR TITLE
Make build TTL progress-aware

### DIFF
--- a/src/bosn/jobs.py
+++ b/src/bosn/jobs.py
@@ -133,6 +133,7 @@ class Job:
         self.state = state
         self.created_at = now
         self.started_at: float | None = None
+        self.last_progress_at: float | None = None
         self.ended_at: float | None = None
         self.returncode: int | None = None
         self.error: str | None = None
@@ -187,6 +188,10 @@ class Job:
             if self.state in TERMINAL_STATES:
                 watcher.put(self.summary(final=True))
             else:
+                if self.cancelled.is_set():
+                    watcher.put(
+                        {"event": "cancelling", "job": self.id, "reason": self.error or "cancelled"}
+                    )
                 self._watchers.append(watcher)
         return watcher
 
@@ -237,6 +242,10 @@ class Job:
         return True
 
     def log(self, line: str, stream: str = "stdout") -> None:
+        # Builder output is the liveness signal. Watcher heartbeats deliberately never
+        # call this: a disconnected or chatty client must not keep a wedged build alive.
+        with self._lock:
+            self.last_progress_at = time.time()
         self.emit({"event": "log", "stream": stream, "line": line})
 
     def summary(self, *, final: bool = False) -> dict[str, Any]:
@@ -402,6 +411,7 @@ class JobManager:
                 continue
             job.state = RUNNING
             job.started_at = time.time()
+            job.last_progress_at = job.started_at
             self._running += 1
             job.emit(job.summary())
             thread = threading.Thread(target=self._run, args=(job,), daemon=True)
@@ -516,33 +526,35 @@ class JobManager:
         return job
 
     def reap_expired(self, now: float | None = None) -> list[Job]:
-        """Cancel builds that have outlived their TTL.
+        """Cancel builds whose builder has stopped making progress for the TTL.
 
         Without this a builder that hangs forever pins the daemon forever: running jobs
         block idle retirement, so a job that never reports is also a daemon that never
         retires and resources that never get collected.
         """
         now = now if now is not None else time.time()
-        candidates: list[Job] = []
+        reaped: list[Job] = []
+        notifications: list[tuple[Job, dict[str, Any]]] = []
         with self._lock:
             for job in list(self._jobs.values()):
-                if job.state != RUNNING or job.started_at is None:
-                    continue
-                # Already reaped: a cancelled build stays RUNNING until its builder tears
-                # down, which can take tens of seconds. Without this the watchdog reaps it
-                # again on every 0.5s tick and writes an event row each time.
-                if job.cancelled.is_set():
-                    continue
-                if now - job.started_at > self.ttl_seconds:
-                    candidates.append(job)
-
-        reaped: list[Job] = []
-        for job in candidates:
-            try:
-                self.cancel(job.id, reason=f"exceeded the {self.ttl_seconds:.0f}s build TTL")
-            except JobError:
-                continue  # it finished on its own between the scan and the cancel
-            reaped.append(job)
+                # `log()` holds this same job lock while it refreshes progress, so the
+                # decision cannot race a new builder line between stale inspection and
+                # cancellation.
+                with job._lock:
+                    if job.state != RUNNING or job.started_at is None or job.cancelled.is_set():
+                        continue
+                    progress_at = job.last_progress_at or job.started_at
+                    if now - progress_at <= self.ttl_seconds:
+                        continue
+                    reason = f"no builder progress for {self.ttl_seconds:.0f}s (build TTL)"
+                    job.error = reason
+                    job.cancelled.set()
+                    notifications.append(
+                        (job, {"event": "cancelling", "job": job.id, "reason": reason})
+                    )
+                    reaped.append(job)
+        for job, event in notifications:
+            job.emit(event)
         return reaped
 
     # -- observation -------------------------------------------------------

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -339,6 +339,46 @@ def test_a_hung_build_is_reaped_by_its_ttl(builder: SlowBuilder) -> None:
         manager.shutdown(timeout=5)
 
 
+def test_builder_progress_keeps_a_long_build_alive(builder: SlowBuilder) -> None:
+    manager = JobManager(builder, max_builds=2, ttl_seconds=1)
+    try:
+        job = manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:progress").job
+        assert wait_until(lambda: job.state == RUNNING)
+        assert job.started_at is not None
+        # It has run longer than the inactivity window, but the builder just emitted output.
+        job.started_at = time.time() - 2
+        job.log("still building")
+        assert manager.reap_expired(now=time.time()) == []
+        assert job.state == RUNNING
+    finally:
+        builder.release.set()
+        manager.shutdown(timeout=5)
+
+
+def test_watcher_activity_does_not_refresh_builder_progress(builder: SlowBuilder) -> None:
+    manager = JobManager(builder, max_builds=2, ttl_seconds=1)
+    try:
+        job = manager.submit(workspace=WORKSPACE, stack=STACK, digest="sha256:silent").job
+        assert wait_until(lambda: job.state == RUNNING)
+        assert job.started_at is not None
+        watcher = job.watch()
+        assert manager.reap_expired(now=job.started_at + 2) == [job]
+        assert job.error is not None and "no builder progress" in job.error
+        events = [watcher.get(timeout=1) for _ in range(2)]  # initial log + cancellation
+        assert any(
+            event["event"] == "cancelling" and "no builder progress" in event["reason"]
+            for event in events
+        )
+        late = job.watch()
+        replay = []
+        while not late.empty():
+            replay.append(late.get_nowait())
+        assert any(event["event"] == "cancelling" for event in replay)
+    finally:
+        builder.release.set()
+        manager.shutdown(timeout=5)
+
+
 def test_a_healthy_build_is_not_reaped(manager: JobManager, builder: SlowBuilder) -> None:
     job = submit(manager, "sha256:fine").job
     assert wait_until(lambda: job.state == RUNNING)


### PR DESCRIPTION
Fixes #44.\n\nTracks builder progress separately from watcher activity, expires only stalled builds, makes the expiry decision atomic with output, and exposes the inactivity reason to current and late watchers.\n\nValidated with lint, types, 306 non-Docker tests, and review.