### PR TITLE
Render build cancellation status

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -318,6 +318,8 @@ def _drive_job(events, *, quiet: bool = False) -> dict:
                 print(note, file=sys.stderr)
         elif kind == "attached" and not quiet:
             print(f"attached to {event.get('job')} ({event.get('state')})", file=sys.stderr)
+        elif kind == "cancelling":
+            print(f"build cancelling: {event.get('reason')}", file=sys.stderr)
         if event.get("final"):
             final = event
     if not final:


### PR DESCRIPTION
Follow-up to #44. Renders the already-emitted progress-TTL cancellation event in CLI job streams so users receive the immediate inactivity reason.