### PR TITLE
Add recurring maintenance scheduler

### DIFF
--- a/src/bosn/autostart.py
+++ b/src/bosn/autostart.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 NAME = "bosn-daemon"
+MAINTENANCE_INTERVAL_SECONDS = 300
 
 
 def command() -> list[str]:
@@ -33,7 +34,12 @@ def enable(*, platform: str | None = None, home: Path | None = None) -> Path:
     if platform.startswith("win"):
         target.mkdir(parents=True, exist_ok=True)
         launcher = target / "bosn-daemon.cmd"
-        launcher.write_text(f"@echo off\r\n{invocation}\r\n", encoding="utf-8")
+        launcher.write_text(
+            "@echo off\r\n:loop\r\n"
+            f"{invocation}\r\ntimeout /t {MAINTENANCE_INTERVAL_SECONDS} /nobreak >nul\r\n"
+            "goto loop\r\n",
+            encoding="utf-8",
+        )
         return launcher
     target.parent.mkdir(parents=True, exist_ok=True)
     if platform == "darwin":
@@ -42,17 +48,27 @@ def enable(*, platform: str | None = None, home: Path | None = None) -> Path:
             '<plist version="1.0"><dict><key>Label</key>'
             "<string>io.github.zackees.bosn</string><key>ProgramArguments</key><array>"
             f"{''.join(f'<string>{part}</string>' for part in command())}"
-            "</array><key>RunAtLoad</key><true/></dict></plist>\n",
+            "</array><key>RunAtLoad</key><true/><key>StartInterval</key>"
+            f"<integer>{MAINTENANCE_INTERVAL_SECONDS}</integer></dict></plist>\n",
             encoding="utf-8",
         )
         return target
     target.write_text(
         "[Unit]\nDescription=bosn container lifecycle supervisor\n\n"
-        "[Service]\nType=simple\nExecStart=" + invocation + "\nRestart=on-failure\n\n"
-        "[Install]\nWantedBy=default.target\n",
+        + "[Service]\nType=simple\nExecStart="
+        + invocation
+        + "\n",
         encoding="utf-8",
     )
-    subprocess.run(["systemctl", "--user", "enable", "--now", target.name], check=False)
+    timer = target.with_name("bosn-daemon.timer")
+    timer.write_text(
+        "[Unit]\nDescription=run bosn maintenance regularly\n\n[Timer]\n"
+        "OnBootSec=1min\nOnUnitInactiveSec="
+        + str(MAINTENANCE_INTERVAL_SECONDS)
+        + "s\nPersistent=true\n\n[Install]\nWantedBy=timers.target\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["systemctl", "--user", "enable", "--now", timer.name], check=False)
     return target
 
 
@@ -63,6 +79,28 @@ def disable(*, platform: str | None = None, home: Path | None = None) -> Path:
     if platform.startswith("win"):
         target = target / "bosn-daemon.cmd"
     elif platform != "darwin":
-        subprocess.run(["systemctl", "--user", "disable", "--now", target.name], check=False)
+        timer = target.with_name("bosn-daemon.timer")
+        subprocess.run(["systemctl", "--user", "disable", "--now", timer.name], check=False)
+        timer.unlink(missing_ok=True)
     target.unlink(missing_ok=True)
     return target
+
+
+def manifest_installed(*, platform: str | None = None, home: Path | None = None) -> bool:
+    """Whether the recurring scheduler's launcher files are installed.
+
+    This intentionally does not claim the operating-system scheduler is currently
+    enabled: a user can disable a systemd timer after its unit files are written.
+    """
+    platform = platform or sys.platform
+    target = path(platform=platform, home=home)
+    if platform.startswith("win"):
+        return (target / "bosn-daemon.cmd").exists()
+    if platform == "darwin":
+        return target.exists()
+    return target.exists() and target.with_name("bosn-daemon.timer").exists()
+
+
+def enabled(*, platform: str | None = None, home: Path | None = None) -> bool:
+    """Backward-compatible alias for :func:`manifest_installed`."""
+    return manifest_installed(platform=platform, home=home)

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -149,19 +149,25 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def cmd_doctor(opts: Options) -> int:
+    from bosn import autostart
+
     info = Engine(opts.engine).info()
     print(f"engine binary:  {info.binary}")
     print(f"client version: {info.client_version or '-'}")
     print(f"server version: {info.server_version or '-'}")
     print(f"reachable:      {'yes' if info.reachable else 'no'}")
-    if not info.reachable:
-        print(f"diagnosis:      {info.detail}", file=sys.stderr)
-        return 1
     from bosn.registry import Registry, default_db_path
-    from bosn.resources import ResourceScanner
 
     db_path = (opts.state_dir / "registry.sqlite3") if opts.state_dir else default_db_path()
     with Registry(db_path) as registry:
+        deadline = registry.meta("maintenance.next_deadline")
+        print(f"scheduler manifest installed: {autostart.manifest_installed()}")
+        print(f"scheduler next deadline: {deadline or '-'}")
+        if not info.reachable:
+            print(f"diagnosis:      {info.detail}", file=sys.stderr)
+            return 1
+        from bosn.resources import ResourceScanner
+
         scan = ResourceScanner(Engine(opts.engine)).scan(registry.registry_id)
         if scan.foreign_registries:
             state = f" --state-dir {opts.state_dir}" if opts.state_dir else ""

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import errno
 import hashlib
 import json
+import math
 import os
 import secrets
 import socket
@@ -282,12 +283,21 @@ class Daemon:
         self.last_activity = self.started_at
         self.heartbeat_at = self.started_at
         self.maintenance_interval_seconds = maintenance_interval_seconds
-        self._next_maintenance_at = self.started_at  # catch up immediately after downtime
         self._maintenance_backoff_seconds = MAINTENANCE_BACKOFF_INITIAL_SECONDS
         self._server: _Server | None = None
         self._stop = threading.Event()
+        self._watchdog_thread: threading.Thread | None = None
         self.secret = secrets.token_urlsafe(32)
         self.registry = Registry(self.state_dir / "registry.sqlite3", clock=self.clock)
+        stored_deadline = self.registry.meta("maintenance.next_deadline")
+        try:
+            deadline = float(stored_deadline) if stored_deadline else self.started_at
+            if not math.isfinite(deadline):
+                raise ValueError("deadline must be finite")
+            self._next_maintenance_at = deadline
+        except (TypeError, ValueError):
+            self._next_maintenance_at = self.started_at
+            self.registry.log_event("maintenance.deadline.recovered", stored_deadline or "")
         self.jobs = JobManager(
             self._build,
             max_builds=max_builds,
@@ -351,7 +361,8 @@ class Daemon:
             pass
         self.registry.log_event("daemon.started", f"pid={os.getpid()} port={self.port}")
 
-        threading.Thread(target=self._idle_watchdog, daemon=True).start()
+        self._watchdog_thread = threading.Thread(target=self._idle_watchdog, daemon=True)
+        self._watchdog_thread.start()
         try:
             self._server.serve_forever(poll_interval=0.2)
         finally:
@@ -399,7 +410,7 @@ class Daemon:
             raise
         except Exception as exc:  # noqa: BLE001 - a scheduler failure must be visible
             self.registry.log_event("maintenance.reap.error", f"{type(exc).__name__}: {exc}")
-            self._next_maintenance_at = self.clock.now() + self.maintenance_interval_seconds
+            self._set_next_maintenance(self.clock.now() + self.maintenance_interval_seconds)
             return
 
         engine = Engine(self.engine_binary)
@@ -410,7 +421,7 @@ class Daemon:
                 "maintenance.engine_down",
                 f"retry_in={self._maintenance_backoff_seconds:g}s {detail}",
             )
-            self._next_maintenance_at = self.clock.now() + self._maintenance_backoff_seconds
+            self._set_next_maintenance(self.clock.now() + self._maintenance_backoff_seconds)
             self._maintenance_backoff_seconds = min(
                 self._maintenance_backoff_seconds * 2, MAINTENANCE_BACKOFF_MAX_SECONDS
             )
@@ -426,7 +437,11 @@ class Daemon:
         else:
             self.registry.log_event("maintenance.gc.finished", json.dumps(result.summary()))
         self._maintenance_backoff_seconds = MAINTENANCE_BACKOFF_INITIAL_SECONDS
-        self._next_maintenance_at = self.clock.now() + self.maintenance_interval_seconds
+        self._set_next_maintenance(self.clock.now() + self.maintenance_interval_seconds)
+
+    def _set_next_maintenance(self, deadline: float) -> None:
+        self._next_maintenance_at = deadline
+        self.registry.set_meta("maintenance.next_deadline", f"{deadline:.6f}")
 
     def request_stop(self) -> None:
         self._stop.set()
@@ -435,6 +450,9 @@ class Daemon:
 
     def shutdown(self) -> None:
         self._stop.set()
+        watchdog = self._watchdog_thread
+        if watchdog is not None and watchdog is not threading.current_thread():
+            watchdog.join(timeout=2)
         # Cancel in-flight builds and wait for them *before* closing the registry they
         # write to. Each one tells its attached clients why it stopped rather than dying
         # silently.

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -17,5 +17,15 @@ def test_per_user_login_launcher_can_be_enabled_and_removed(
     assert installed.exists()
     text = installed.read_text(encoding="utf-8")
     assert "bosn" in text
+    if platform == "win32":
+        assert "timeout /t" in text and "goto loop" in text
+    elif platform == "darwin":
+        assert "StartInterval" in text
+    else:
+        timer = installed.with_name("bosn-daemon.timer")
+        assert timer.exists() and "Persistent=true" in timer.read_text(encoding="utf-8")
+        assert "Type=simple" in text
     assert autostart.disable(platform=platform, home=tmp_path) == installed
     assert not installed.exists()
+    if platform == "linux":
+        assert not installed.with_name("bosn-daemon.timer").exists()

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -71,11 +71,17 @@ def test_unknown_verb_is_rejected() -> None:
     assert exc.value.code != 0
 
 
-def test_doctor_reports_unreachable_engine_without_crashing(capsys) -> None:
-    code = cli.main(["--engine", "definitely-not-an-engine-binary", "doctor"])
+def test_doctor_reports_unreachable_engine_and_scheduler_state_without_crashing(
+    tmp_path, capsys
+) -> None:
+    code = cli.main(
+        ["--state-dir", str(tmp_path), "--engine", "definitely-not-an-engine-binary", "doctor"]
+    )
     assert code == 1
     captured = capsys.readouterr()
     assert "reachable:      no" in captured.out
+    assert "scheduler manifest installed:" in captured.out
+    assert "scheduler next deadline: -" in captured.out
     assert "not on PATH" in captured.err
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -277,6 +277,69 @@ def test_maintenance_engine_down_is_visible_and_uses_exponential_backoff(
         daemon.registry.close()
 
 
+def test_maintenance_deadline_persists_across_scheduler_wake(monkeypatch, tmp_path: Path) -> None:
+    clock = FakeClock()
+    calls: list[str] = []
+
+    class Engine:
+        def __init__(self, *_args):
+            pass
+
+        def info(self):
+            return EngineInfo(binary="docker", reachable=True)
+
+    class Collector:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def collect(self, **_kwargs):
+            calls.append("gc")
+            return type("Result", (), {"summary": lambda self: {}})()
+
+    import bosn.engine
+    import bosn.gc
+
+    monkeypatch.setattr(bosn.engine, "Engine", Engine)
+    monkeypatch.setattr(bosn.gc, "Collector", Collector)
+    first = Daemon(
+        state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60, idle_retire_seconds=1
+    )
+    assert first.run_maintenance_if_due()
+    assert first.registry.meta("maintenance.next_deadline") == f"{clock.now() + 60:.6f}"
+    thread = threading.Thread(target=first.serve_forever, daemon=True)
+    thread.start()
+    assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
+    clock.advance(1)
+    thread.join(timeout=15)
+    assert not thread.is_alive(), "the first daemon must retire before the scheduler wakes it"
+    assert not daemon_mod.is_serving(tmp_path)
+    clock.advance(120)
+    wake = Daemon(state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60)
+    try:
+        assert wake._next_maintenance_at == clock.now() - 61
+        assert wake.run_maintenance_if_due(), "a missed deadline catches up on scheduler wake"
+        assert calls == ["gc", "gc"]
+    finally:
+        wake.registry.close()
+
+
+def test_malformed_persisted_maintenance_deadline_recovers(tmp_path: Path) -> None:
+    clock = FakeClock()
+    registry_path = tmp_path / "registry.sqlite3"
+    from bosn.registry import Registry
+
+    with Registry(registry_path, clock=clock) as registry:
+        registry.set_meta("maintenance.next_deadline", "not-a-timestamp")
+    daemon = Daemon(state_dir=tmp_path, clock=clock)
+    try:
+        assert daemon._next_maintenance_at == clock.now()
+        assert any(
+            event["kind"] == "maintenance.deadline.recovered" for event in daemon.registry.events()
+        )
+    finally:
+        daemon.registry.close()
+
+
 # -- client behavior -------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #39\n\n- persist maintenance deadlines across daemon lifetimes\n- install recurring platform launchers and expose scheduler manifest/deadline in doctor\n- cover idle retirement, missed-deadline wake, and malformed persisted state