### PR TITLE
Fix Docker storage accounting

### DIFF
--- a/src/bosn/accounting.py
+++ b/src/bosn/accounting.py
@@ -1,11 +1,14 @@
 """Byte accounting and backing-store pressure probes.
 
-Docker's human-facing size strings are deliberately not parsed: inspect emits byte counts,
-which keeps the supervisor's decisions independent of locale and display rounding.
+The Docker CLI exposes its verbose inventory as JSON but renders sizes with SI suffixes.
+Those values are parsed once per pass; unknown formats remain unknown rather than zero.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,12 +16,8 @@ from pathlib import Path
 from bosn.engine import Engine
 from bosn.registry import Resource
 
-_SIZE_COMMANDS = {
-    "container": ["container", "inspect", "--size", "--format", "{{.SizeRw}}"],
-    "image": ["image", "inspect", "--format", "{{.Size}}"],
-    # Docker has no per-volume inspect size; `system df -v` is the supported source.
-    "volume": ["system", "df", "-v", "--format", "{{json .}}"],
-}
+_INVENTORY_COMMAND = ["system", "df", "-v", "--format", "{{json .}}"]
+_SIZE = re.compile(r"^([0-9]+(?:\.[0-9]+)?)\s*([kmgtpe]?b)$", re.I)
 
 
 @dataclass(frozen=True)
@@ -28,39 +27,106 @@ class StorageProbe:
     vhdx_slack_bytes: int | None = None
 
 
-def resource_bytes(engine: Engine, resource: Resource) -> int | None:
-    """Return a resource's managed bytes, or None when the engine cannot attribute it."""
-    args = _SIZE_COMMANDS.get(resource.kind)
-    if args is None:
+def _bytes(value: object) -> int | None:
+    """Parse Docker's JSON size field; absent/unrecognised remains explicitly unknown."""
+    if isinstance(value, int):
+        return max(0, value)
+    match = _SIZE.match(str(value).strip())
+    if not match:
         return None
-    result = engine.run([*args, resource.name])
-    if not result.ok:
-        return None
-    if resource.kind != "volume":
-        try:
-            return max(0, int(result.stdout.strip()))
-        except ValueError:
-            return None
-    # `docker system df -v` describes local volumes in a table.  Docker does not expose a
-    # stable machine-readable per-volume size, so only accept an exact byte field when an
-    # engine implementation provides one; otherwise report the attribution as unavailable.
-    import json
+    units = {"b": 0, "kb": 1, "mb": 2, "gb": 3, "tb": 4, "pb": 5, "eb": 6}
+    return int(float(match.group(1)) * 1000 ** units[match.group(2).lower()])
 
-    for line in result.stdout.splitlines():
+
+@dataclass(frozen=True)
+class StorageInventory:
+    """One `system df -v` snapshot, avoiding per-resource commands and layer double counting."""
+
+    sizes: dict[tuple[str, str], int]
+
+    @classmethod
+    def collect(cls, engine: Engine) -> StorageInventory:
         try:
-            row = json.loads(line)
+            result = engine.run(_INVENTORY_COMMAND)
+        except KeyboardInterrupt:
+            raise
+        except Exception:  # noqa: BLE001 - status must still expose unknown measurements offline
+            return cls({})
+        if not result.ok:
+            return cls({})
+        sizes: dict[tuple[str, str], int] = {}
+        try:
+            rows = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
         except json.JSONDecodeError:
-            continue
-        if str(row.get("Name", "")) == resource.name:
-            for key in ("SizeBytes", "Size"):
-                try:
-                    return max(0, int(row[key]))
-                except (KeyError, TypeError, ValueError):
-                    pass
-    return None
+            return cls({})
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            for kind, key, field in (
+                ("volume", "Volumes", "Size"),
+                ("container", "Containers", "Size"),
+            ):
+                for item in row.get(key, []):
+                    if isinstance(item, dict) and (size := _bytes(item.get(field))) is not None:
+                        sizes[(kind, str(item.get("Name") or item.get("ID") or ""))] = size
+            # UniqueSize is the only image attribution that cannot charge a shared layer twice.
+            for item in row.get("Images", []):
+                if isinstance(item, dict) and (size := _bytes(item.get("UniqueSize"))) is not None:
+                    sizes[("image", str(item.get("ID", "")))] = size
+        return cls(sizes)
 
 
-def probe(path: Path) -> StorageProbe:
-    """Probe the filesystem carrying bosn state; VHDX slack remains a distinct field."""
+def resource_bytes(
+    engine: Engine, resource: Resource, inventory: StorageInventory | None = None
+) -> int | None:
+    """Return a resource's managed bytes, or None when the engine cannot attribute it."""
+    inventory = inventory or StorageInventory.collect(engine)
+    return inventory.sizes.get((resource.kind, resource.name))
+
+
+def engine_storage_path(engine: Engine, fallback: Path) -> Path:
+    """Find the host path which actually holds engine data, never assuming registry storage."""
+    try:
+        root = engine.run(["info", "--format", "{{.DockerRootDir}}"]).stdout.strip()
+    except KeyboardInterrupt:
+        raise
+    except Exception:  # noqa: BLE001 - an unavailable engine leaves the value explicitly fallback
+        root = ""
+    candidate = Path(root)
+    if root and candidate.exists():
+        return candidate
+    if os.name == "nt":
+        settings = Path(os.environ.get("APPDATA", "")) / "Docker" / "settings-store.json"
+        try:
+            raw = json.loads(settings.read_text(encoding="utf-8"))
+            for key in ("CustomWslDistroDir", "DataFolder"):
+                value = raw.get(key)
+                if value and (vhdx := desktop_vhdx(Path(str(value)))) is not None:
+                    return vhdx
+        except (OSError, json.JSONDecodeError):
+            pass
+    return fallback
+
+
+def desktop_vhdx(directory: Path) -> Path | None:
+    """Return Docker Desktop's allocated data disk below a configured host directory."""
+    if not directory.is_dir():
+        return None
+    candidates = [path for path in directory.rglob("*.vhdx") if path.is_file()]
+    if not candidates:
+        return None
+    # Docker's data disk is normally docker_data.vhdx; prefer it, otherwise use the largest
+    # virtual disk rather than accidentally accounting a small ancillary disk.
+    return max(
+        candidates, key=lambda path: (path.name.lower() == "docker_data.vhdx", path.stat().st_size)
+    )
+
+
+def probe(engine: Engine, fallback: Path) -> StorageProbe:
+    """Probe engine storage (or a documented fallback when the engine cannot reveal it)."""
+    path = engine_storage_path(engine, fallback)
     usage = shutil.disk_usage(path)
-    return StorageProbe(free_bytes=usage.free, total_bytes=usage.total)
+    # Docker Desktop does not expose a reliable guest-used / host-allocated pair through the
+    # CLI.  In particular, host-volume capacity minus the VHDX's logical length is *not* VHDX
+    # slack. Keep it unknown rather than emitting a dangerous false compaction recommendation.
+    return StorageProbe(free_bytes=usage.free, total_bytes=usage.total, vhdx_slack_bytes=None)

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from bosn import labels
-from bosn.accounting import probe, resource_bytes
+from bosn.accounting import StorageInventory, probe, resource_bytes
 from bosn.config import Config
 from bosn.engine import Engine
 from bosn.registry import Registry
@@ -199,13 +199,14 @@ def status(
 
     config = config or load_config()
     scan = ResourceScanner(engine).scan(registry.registry_id)
+    inventory = StorageInventory.collect(engine)
 
     attributed: dict[tuple[str, str, str], dict[str, int]] = defaultdict(
         lambda: {"count": 0, "bytes": 0, "unmeasured": 0}
     )
     measured: dict[str, int | None] = {}
     for resource in registry.list_resources():
-        size = resource_bytes(engine, resource)
+        size = resource_bytes(engine, resource, inventory)
         measured[resource.id] = size
         bucket = attributed[(resource.workspace, resource.stack, resource.kind)]
         bucket["count"] += 1
@@ -214,7 +215,7 @@ def status(
         else:
             bucket["bytes"] += size
     managed_bytes = sum(size for size in measured.values() if size is not None)
-    storage = probe(registry.path.parent)
+    storage = probe(engine, registry.path.parent)
     pressure = Pressure.assess(
         resource_count=len(measured), managed_bytes=managed_bytes, free_bytes=storage.free_bytes
     )
@@ -238,7 +239,15 @@ def status(
         "by_reason": by_reason,
         "engine": scan.counts(),
         "foreign_registries": sorted(scan.foreign_registries),
-        "foreign_registry_totals": {"count": len(scan.foreign), "bytes": None},
+        "foreign_registry_totals": {
+            "count": len(scan.foreign),
+            "bytes": sum(
+                inventory.sizes.get((resource.kind, resource.name), 0) for resource in scan.foreign
+            ),
+            "unmeasured": sum(
+                (resource.kind, resource.name) not in inventory.sizes for resource in scan.foreign
+            ),
+        },
         "managed_bytes": managed_bytes,
         "managed_reclaimable_bytes": reclaimable,
         "pressure": {

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -1,0 +1,82 @@
+"""Engine storage inventory is queried once and preserves Docker's ownership boundaries."""
+
+from __future__ import annotations
+
+import json
+
+from bosn.accounting import StorageInventory, desktop_vhdx, engine_storage_path
+from bosn.engine import EngineResult
+
+
+class Engine:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(self, args: list[str]) -> EngineResult:
+        self.calls.append(args)
+        return EngineResult(
+            0,
+            json.dumps(
+                {
+                    "Volumes": [{"Name": "work", "Size": "12.5MB"}],
+                    "Images": [
+                        {
+                            "ID": "sha256:a",
+                            "Size": "100MB",
+                            "SharedSize": "90MB",
+                            "UniqueSize": "10MB",
+                        },
+                        {
+                            "ID": "sha256:b",
+                            "Size": "100MB",
+                            "SharedSize": "90MB",
+                            "UniqueSize": "10MB",
+                        },
+                    ],
+                    "Containers": [{"ID": "c", "Size": "4kB"}],
+                }
+            ),
+            "",
+        )
+
+
+class RootEngine:
+    def __init__(self, root: str) -> None:
+        self.root = root
+
+    def run(self, args: list[str]) -> EngineResult:
+        assert args == ["info", "--format", "{{.DockerRootDir}}"]
+        return EngineResult(0, self.root, "")
+
+
+def test_system_df_inventory_attributes_volume_without_a_positional_argument() -> None:
+    engine = Engine()
+    inventory = StorageInventory.collect(engine)  # type: ignore[arg-type]
+
+    assert engine.calls == [["system", "df", "-v", "--format", "{{json .}}"]]
+    assert inventory.sizes[("volume", "work")] == 12_500_000
+    assert (
+        inventory.sizes[("image", "sha256:a")] + inventory.sizes[("image", "sha256:b")]
+        == 20_000_000
+    )
+    assert inventory.sizes[("container", "c")] == 4_000
+
+
+def test_engine_storage_path_prefers_the_engine_root_over_registry_state(tmp_path) -> None:
+    root = tmp_path / "engine-data"
+    root.mkdir()
+    state = tmp_path / "state"
+    state.mkdir()
+
+    assert engine_storage_path(RootEngine(str(root)), state) == root  # type: ignore[arg-type]
+
+
+def test_desktop_vhdx_finds_docker_data_disk_in_configured_directory(tmp_path) -> None:
+    data = tmp_path / "disk"
+    data.mkdir()
+    small = data / "ancillary.vhdx"
+    small.write_bytes(b"x")
+    docker_data = data / "docker_data.vhdx"
+    docker_data.write_bytes(b"xx")
+
+    assert desktop_vhdx(tmp_path) == docker_data

--- a/tests/test_accounting_docker.py
+++ b/tests/test_accounting_docker.py
@@ -1,0 +1,21 @@
+"""Real Docker coverage for #37 inventory accounting."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from bosn.accounting import StorageInventory
+from bosn.engine import Engine
+
+
+@pytest.mark.docker
+def test_system_df_attributes_a_real_named_volume(engine: Engine) -> None:
+    name = f"bosn-accounting-{uuid.uuid4().hex[:12]}"
+    engine.run(["volume", "create", name], check=True)
+    try:
+        inventory = StorageInventory.collect(engine)
+        assert inventory.sizes.get(("volume", name)) is not None
+    finally:
+        engine.run(["volume", "rm", "--force", name])


### PR DESCRIPTION
Closes #37\n\n- collect one verbose Docker storage inventory per status pass\n- attribute named volumes and unique image layers without invalid positional commands or shared-layer double counting\n- report foreign totals and engine-backed free space, preserving unknown VHDX slack explicitly\n- add focused real-Docker volume coverage