### PR TITLE
Route registry mutations through daemon

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -159,23 +159,27 @@ def cmd_doctor(opts: Options) -> int:
     from bosn.registry import Registry, default_db_path
 
     db_path = (opts.state_dir / "registry.sqlite3") if opts.state_dir else default_db_path()
-    with Registry(db_path) as registry:
-        deadline = registry.meta("maintenance.next_deadline")
-        print(f"scheduler manifest installed: {autostart.manifest_installed()}")
-        print(f"scheduler next deadline: {deadline or '-'}")
-        if not info.reachable:
-            print(f"diagnosis:      {info.detail}", file=sys.stderr)
-            return 1
-        from bosn.resources import ResourceScanner
+    if not db_path.exists():
+        deadline = None
+        registry_id = None
+    else:
+        with Registry(db_path, read_only=True) as registry:
+            deadline = registry.meta("maintenance.next_deadline")
+            registry_id = registry.registry_id
+    print(f"scheduler manifest installed: {autostart.manifest_installed()}")
+    print(f"scheduler next deadline: {deadline or '-'}")
+    if not info.reachable:
+        print(f"diagnosis:      {info.detail}", file=sys.stderr)
+        return 1
+    from bosn.resources import ResourceScanner
 
-        scan = ResourceScanner(Engine(opts.engine)).scan(registry.registry_id)
-        if scan.foreign_registries:
-            state = f" --state-dir {opts.state_dir}" if opts.state_dir else ""
-            print(
-                "complete resources from foreign registry ids found; recover with: "
-                f"bosn{state} adopt",
-                file=sys.stderr,
-            )
+    scan = ResourceScanner(Engine(opts.engine)).scan(registry_id or "")
+    if scan.foreign_registries:
+        state = f" --state-dir {opts.state_dir}" if opts.state_dir else ""
+        print(
+            f"complete resources from foreign registry ids found; recover with: bosn{state} adopt",
+            file=sys.stderr,
+        )
     return 0
 
 
@@ -245,7 +249,7 @@ def cmd_jobs(opts: Options) -> int:
     return 0
 
 
-def _open_manifest_and_registry(opts: Options):
+def _open_manifest_and_registry(opts: Options, *, read_only: bool = False):
     from bosn.manifest import ManifestError, find_manifest, load
     from bosn.registry import Registry, default_db_path
 
@@ -257,14 +261,19 @@ def _open_manifest_and_registry(opts: Options):
     manifest = load(manifest_path)
     state_dir = opts.state_dir
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
-    return manifest, Registry(db_path)
+    return manifest, Registry(db_path, read_only=read_only)
 
 
 def cmd_tasks(opts: Options) -> int:
-    from bosn.manifest import ManifestError, generation_digest
+    from bosn.manifest import ManifestError, find_manifest, generation_digest, load
 
     try:
-        manifest, registry = _open_manifest_and_registry(opts)
+        manifest_path = opts.manifest or find_manifest()
+        if manifest_path is None:
+            raise ManifestError(
+                "no bosn.toml found in this directory or any parent; create one or pass --manifest"
+            )
+        manifest = load(manifest_path)
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -291,9 +300,6 @@ def cmd_tasks(opts: Options) -> int:
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    finally:
-        registry.close()
-
     print(json.dumps(payload, indent=2))
     return 0
 
@@ -393,9 +399,9 @@ def cmd_run(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
     from bosn.config import load as load_config
-    from bosn.converge import Converger, workspace_of
+    from bosn.converge import workspace_of
     from bosn.engine import EngineError
-    from bosn.manifest import ManifestError
+    from bosn.manifest import ManifestError, find_manifest, load
 
     command = opts.command
     if not command and not opts.task:
@@ -403,7 +409,10 @@ def cmd_run(opts: Options) -> int:
         return 2
 
     try:
-        manifest, registry = _open_manifest_and_registry(opts)
+        manifest_path = opts.manifest or find_manifest()
+        if manifest_path is None:
+            raise ManifestError("no bosn.toml found; create one or pass --manifest")
+        manifest = load(manifest_path)
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -418,15 +427,25 @@ def cmd_run(opts: Options) -> int:
             stack_name = opts.stack
 
         converged = _converge_via_daemon(opts, manifest, stack_name)
-        converger = Converger(
-            manifest,
-            registry,
-            Engine(opts.engine),
-            run_max_duration=config.get("run_max_duration"),
+        acquired = daemon_mod.request(
+            "execution-acquire",
+            opts.state_dir,
+            manifest=str(manifest.path),
+            result=converged.to_dict(),
+            stack=stack_name,
+            workspace=workspace_of(manifest),
+            engine=opts.engine,
         )
-        _result, code, output = converger.run_converged(
-            converged, command, stack_name=stack_name, workspace=workspace_of(manifest)
-        )
+        if not acquired.get("ok"):
+            raise EngineError(str(acquired.get("error") or "execution acquire failed"))
+        try:
+            result = Engine(opts.engine).run(
+                ["exec", str(acquired["container"]), *command],
+                timeout=config.get("run_max_duration"),
+            )
+        finally:
+            daemon_mod.request("execution-release", opts.state_dir, session=acquired["session"])
+        code, output = result.returncode, result.stdout or result.stderr
     except JobFailed as exc:
         print(str(exc), file=sys.stderr)
         return exc.exit_code
@@ -436,9 +455,6 @@ def cmd_run(opts: Options) -> int:
     except (ManifestError, EngineError, ConfigError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    finally:
-        registry.close()
-
     if output:
         print(output)
     return code
@@ -496,8 +512,11 @@ def cmd_status(opts: Options) -> int:
 
     state_dir = opts.state_dir
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
+    if not db_path.exists():
+        print(json.dumps({"registered": 0, "storage": "not initialized"}, indent=2))
+        return 0
     try:
-        with Registry(db_path) as registry:
+        with Registry(db_path, read_only=True) as registry:
             print(
                 json.dumps(
                     status(
@@ -513,115 +532,133 @@ def cmd_status(opts: Options) -> int:
 
 
 def cmd_gc(opts: Options) -> int:
+    from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
     from bosn.config import load as load_config
-    from bosn.gc import Collector
-    from bosn.registry import Registry, default_db_path
 
-    state_dir = opts.state_dir
-    db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
     try:
-        with Registry(db_path) as registry:
-            collector = Collector(
-                registry, Engine(opts.engine), config=load_config(flags=_policy_flags(opts))
-            )
-            result = collector.collect(dry_run=opts.dry_run)
+        flags = _policy_flags(opts)
+        load_config(flags=flags)
+        reply = daemon_mod.request(
+            "gc", opts.state_dir, engine=opts.engine, dry_run=opts.dry_run, policy_flags=flags
+        )
     except ConfigError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-
-    print(json.dumps({**result.summary(), "dry_run": result.dry_run}, indent=2))
-    for name in result.would_stop:
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        return 1
+    if not reply.get("ok"):
+        print(str(reply.get("error") or "gc failed"), file=sys.stderr)
+        return 1
+    print(json.dumps({**reply["result"], "dry_run": opts.dry_run}, indent=2))
+    for name in reply.get("would_stop", []):
         print(f"would stop {name}")
-    for name in result.stopped:
+    for name in reply.get("stopped", []):
         print(f"stopped {name}")
-    for name in result.removed:
-        print(("would remove " if result.dry_run else "removed ") + name)
-    for message in result.errors:
+    for name in reply.get("removed", []):
+        print(("would remove " if opts.dry_run else "removed ") + name)
+    for message in reply.get("errors", []):
         print(f"error: {message}", file=sys.stderr)
-    for advisory in result.advisories:
+    for advisory in reply.get("advisories", []):
         print(f"advisory: {advisory}", file=sys.stderr)
-    return 1 if result.errors else 0
+    return 1 if reply.get("errors") else 0
 
 
 def cmd_done(opts: Options) -> int:
+    from bosn import daemon as daemon_mod
     from bosn.converge import workspace_of
-    from bosn.gc import mark_done
-    from bosn.manifest import ManifestError
+    from bosn.manifest import ManifestError, find_manifest, load
 
     try:
-        manifest, registry = _open_manifest_and_registry(opts)
+        manifest_path = opts.manifest or find_manifest()
+        if manifest_path is None:
+            raise ManifestError("no bosn.toml found; create one or pass --manifest")
+        manifest = load(manifest_path)
+        reply = daemon_mod.request("done", opts.state_dir, workspace=workspace_of(manifest))
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    try:
-        # The canonical workspace id, matching what converge registered resources under.
-        # A raw manifest.root would miss them whenever the two spellings differ.
-        marked = mark_done(registry, workspace_of(manifest))
-    finally:
-        registry.close()
-    print(f"marked {marked} resource(s) in {manifest.root} as done")
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        return 1
+    if not reply.get("ok"):
+        print(str(reply.get("error") or "done failed"), file=sys.stderr)
+        return 1
+    print(f"marked {reply['marked']} resource(s) in {manifest.root} as done")
     return 0
 
 
 def cmd_adopt(opts: Options) -> int:
     """The sole ownership-transfer/recovery entry point for complete label contracts."""
-    from bosn.registry import Registry, default_db_path
-    from bosn.resources import ResourceScanner, adopt
+    from bosn import daemon as daemon_mod
 
-    state_dir = opts.state_dir
-    db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
-    with Registry(db_path) as registry:
-        # Scan with an impossible id so every complete contract is classified as foreign.
-        scan = ResourceScanner(Engine(opts.engine)).scan("", kinds=["container", "volume", "image"])
-        registries = scan.foreign_registries
-        if not registries:
-            print("no complete labeled resources found")
-            return 0
-        if len(registries) != 1:
-            print("adopt refused: multiple foreign registry ids found", file=sys.stderr)
-            return 1
-        old_id = next(iter(registries))
-        registry.set_meta("registry_id", old_id)
-        owned = ResourceScanner(Engine(opts.engine)).scan(old_id)
-        names = adopt(registry, owned)
-    print(json.dumps({"adopted": names, "registry_id": old_id}, indent=2))
+    try:
+        reply = daemon_mod.request("adopt", opts.state_dir, engine=opts.engine)
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        return 1
+    if not reply.get("ok"):
+        print(str(reply.get("error") or "adopt failed"), file=sys.stderr)
+        return 1
+    if not reply.get("adopted"):
+        print("no complete labeled resources found")
+        return 0
+    print(json.dumps({"adopted": reply["adopted"], "registry_id": reply["registry_id"]}, indent=2))
     return 0
 
 
 def cmd_shell(opts: Options) -> int:
     from bosn import daemon as daemon_mod
-    from bosn.converge import Converger, workspace_of
+    from bosn.converge import workspace_of
     from bosn.engine import EngineError
-    from bosn.manifest import ManifestError
+    from bosn.manifest import ManifestError, find_manifest, load
 
     try:
-        manifest, registry = _open_manifest_and_registry(opts)
+        manifest_path = opts.manifest or find_manifest()
+        if manifest_path is None:
+            raise ManifestError("no bosn.toml found; create one or pass --manifest")
+        manifest = load(manifest_path)
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
     try:
         converged = _converge_via_daemon(opts, manifest, opts.stack)
-        return Converger(manifest, registry, Engine(opts.engine)).shell_converged(
-            converged, stack_name=opts.stack, workspace=workspace_of(manifest)
+        acquired = daemon_mod.request(
+            "execution-acquire",
+            opts.state_dir,
+            manifest=str(manifest.path),
+            result=converged.to_dict(),
+            stack=opts.stack,
+            workspace=workspace_of(manifest),
+            engine=opts.engine,
         )
+        if not acquired.get("ok"):
+            raise EngineError(str(acquired.get("error") or "execution acquire failed"))
+        try:
+            return Engine(opts.engine).interactive(
+                ["exec", "-it", str(acquired["container"]), "sh"]
+            )
+        finally:
+            daemon_mod.request("execution-release", opts.state_dir, session=acquired["session"])
     except JobFailed as exc:
         print(str(exc), file=sys.stderr)
         return exc.exit_code
     except (daemon_mod.DaemonError, ipc.TransportError, EngineError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    finally:
-        registry.close()
 
 
 def cmd_ensure(opts: Options) -> int:
     """Build/register the requested generation without starting a command."""
     from bosn import daemon as daemon_mod
-    from bosn.manifest import ManifestError
+    from bosn.manifest import ManifestError, find_manifest, load
 
     try:
-        manifest, registry = _open_manifest_and_registry(opts)
+        manifest_path = opts.manifest or find_manifest()
+        if manifest_path is None:
+            raise ManifestError("no bosn.toml found; create one or pass --manifest")
+        manifest = load(manifest_path)
     except ManifestError as exc:
         print(
             json.dumps({"ok": False, "error": str(exc), "next": "create-or-pass-manifest"}),
@@ -636,8 +673,6 @@ def cmd_ensure(opts: Options) -> int:
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         print(json.dumps({"ok": False, "error": str(exc), "next": "start-daemon"}), file=sys.stderr)
         return 1
-    finally:
-        registry.close()
     print(json.dumps({"ok": True, "stack": result.stack, "digest": result.digest}))
     return 0
 

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 from collections.abc import Generator, Iterator
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -179,10 +180,22 @@ class _Handler(socketserver.StreamRequestHandler):
                 self.connection, {"ok": False, "error": "unauthenticated IPC request"}
             )
             return
-        if str(request.get("version") or __version__) != __version__ and verb in {
+        mutating_verbs = {
+            "converge",
             "cancel",
-            "shutdown",
-        }:
+            "gc",
+            "done",
+            "adopt",
+            "compose-adopt",
+            "execution-acquire",
+            "execution-release",
+        }
+        if (
+            verb != "shutdown"
+            and verb in mutating_verbs
+            and "version" in request
+            and str(request.get("version") or "") != __version__
+        ):
             ipc.send_response(
                 self.connection,
                 {
@@ -287,6 +300,9 @@ class Daemon:
         self._server: _Server | None = None
         self._stop = threading.Event()
         self._watchdog_thread: threading.Thread | None = None
+        self._execution_sessions: dict[str, tuple[str, ...]] = {}
+        self._execution_lock = threading.RLock()
+        self._stopping = False
         self.secret = secrets.token_urlsafe(32)
         self.registry = Registry(self.state_dir / "registry.sqlite3", clock=self.clock)
         stored_deadline = self.registry.meta("maintenance.next_deadline")
@@ -331,7 +347,9 @@ class Daemon:
         what keeps this from becoming a way to pin the daemon forever -- a build that never
         reports is eventually cancelled, and then this goes back to being about idleness.
         """
-        if self.jobs.active_count() > 0:
+        with self._execution_lock:
+            sessions_active = bool(self._execution_sessions)
+        if self.jobs.active_count() > 0 or sessions_active:
             return False
         return self.idle_seconds() >= self.idle_retire_seconds
 
@@ -376,9 +394,11 @@ class Daemon:
                 self.registry.log_event("job.expired", f"{job.id} {job.stack}")
             self.run_maintenance_if_due()
             if self.should_retire():
-                self.registry.log_event("daemon.idle_retired", f"idle={self.idle_seconds():.0f}s")
-                self.request_stop()
-                return
+                if self.request_stop():
+                    self.registry.log_event(
+                        "daemon.idle_retired", f"idle={self.idle_seconds():.0f}s"
+                    )
+                    return
 
     def _write_heartbeat(self) -> None:
         heartbeat_file(self.state_dir).touch()
@@ -443,16 +463,21 @@ class Daemon:
         self._next_maintenance_at = deadline
         self.registry.set_meta("maintenance.next_deadline", f"{deadline:.6f}")
 
-    def request_stop(self) -> None:
+    def request_stop(self) -> bool:
+        with self._execution_lock:
+            if self._execution_sessions:
+                return False
+            self._stopping = True
         self._stop.set()
         if self._server is not None:
             threading.Thread(target=self._server.shutdown, daemon=True).start()
+        return True
 
     def shutdown(self) -> None:
         self._stop.set()
         watchdog = self._watchdog_thread
         if watchdog is not None and watchdog is not threading.current_thread():
-            watchdog.join(timeout=2)
+            watchdog.join()
         # Cancel in-flight builds and wait for them *before* closing the registry they
         # write to. Each one tells its attached clients why it stopped rather than dying
         # silently.
@@ -485,6 +510,12 @@ class Daemon:
             "status": self._verb_status,
             "jobs": self._verb_jobs,
             "cancel": self._verb_cancel,
+            "gc": self._verb_gc,
+            "done": self._verb_done,
+            "adopt": self._verb_adopt,
+            "compose-adopt": self._verb_compose_adopt,
+            "execution-acquire": self._verb_execution_acquire,
+            "execution-release": self._verb_execution_release,
             "shutdown": self._verb_shutdown,
         }.get(verb)
         if handler is None:
@@ -529,6 +560,100 @@ class Daemon:
             return {"ok": False, "error": str(exc)}
         self.registry.log_event("job.cancelled", job.id)
         return {"ok": True, "job": job.id, "state": job.state}
+
+    def _verb_gc(self, request: dict[str, Any]) -> dict[str, Any]:
+        from bosn.config import load as load_config
+        from bosn.engine import Engine
+        from bosn.gc import Collector
+
+        flags = request.get("policy_flags")
+        config = load_config(flags=flags if isinstance(flags, dict) else None)
+        result = Collector(
+            self.registry, Engine(str(request.get("engine") or self.engine_binary)), config=config
+        ).collect(dry_run=bool(request.get("dry_run", True)))
+        return {
+            "ok": True,
+            "result": result.summary(),
+            "removed": result.removed,
+            "stopped": result.stopped,
+            "would_stop": result.would_stop,
+            "errors": result.errors,
+            "advisories": result.advisories,
+        }
+
+    def _verb_done(self, request: dict[str, Any]) -> dict[str, Any]:
+        from bosn.gc import mark_done
+
+        workspace = str(request.get("workspace") or "")
+        if not workspace:
+            return {"ok": False, "error": "done requires a workspace"}
+        return {"ok": True, "marked": mark_done(self.registry, workspace)}
+
+    def _verb_adopt(self, request: dict[str, Any]) -> dict[str, Any]:
+        from bosn.engine import Engine
+        from bosn.resources import ResourceScanner, adopt
+
+        engine = Engine(str(request.get("engine") or self.engine_binary))
+        scan = ResourceScanner(engine).scan("", kinds=["container", "volume", "image"])
+        registries = scan.foreign_registries
+        if not registries:
+            return {"ok": True, "adopted": [], "registry_id": None}
+        if len(registries) != 1:
+            return {"ok": False, "error": "adopt refused: multiple foreign registry ids found"}
+        registry_id = next(iter(registries))
+        self.registry.set_meta("registry_id", registry_id)
+        names = adopt(self.registry, ResourceScanner(engine).scan(registry_id))
+        return {"ok": True, "adopted": names, "registry_id": registry_id}
+
+    def _verb_compose_adopt(self, _request: dict[str, Any]) -> dict[str, Any]:
+        from bosn.resources import ResourceScanner, adopt
+
+        scan = ResourceScanner().scan(self.registry.registry_id)
+        return {"ok": True, "adopted": adopt(self.registry, scan)}
+
+    def _verb_execution_acquire(self, request: dict[str, Any]) -> dict[str, Any]:
+        from bosn.converge import Converger, ConvergeResult
+        from bosn.engine import Engine
+        from bosn.manifest import load
+
+        manifest = load(Path(str(request.get("manifest") or "")))
+        converged = ConvergeResult.from_dict(dict(request.get("result") or {}))
+        workspace = str(request.get("workspace") or "")
+        if not workspace:
+            return {"ok": False, "error": "execution-acquire requires workspace"}
+        session = str(uuid.uuid4())
+        with self._execution_lock:
+            if self._stopping:
+                return {"ok": False, "error": "daemon is stopping; retry after it restarts"}
+            # Reserve before engine/registry work so shutdown sees this as active immediately.
+            self._execution_sessions[session] = ()
+        try:
+            name, leases = Converger(
+                manifest, self.registry, Engine(str(request.get("engine") or self.engine_binary))
+            )._acquire_execution_container(
+                converged, stack_name=request.get("stack") or None, workspace=workspace
+            )
+        except KeyboardInterrupt:
+            with self._execution_lock:
+                self._execution_sessions.pop(session, None)
+            raise
+        except Exception:
+            with self._execution_lock:
+                self._execution_sessions.pop(session, None)
+            raise
+        with self._execution_lock:
+            self._execution_sessions[session] = tuple(lease.id for lease in leases)
+        return {"ok": True, "container": name, "session": session}
+
+    def _verb_execution_release(self, request: dict[str, Any]) -> dict[str, Any]:
+        session = str(request.get("session") or "")
+        with self._execution_lock:
+            leases = self._execution_sessions.pop(session, None)
+        if leases is None:
+            return {"ok": False, "error": "unknown execution session"}
+        for lease_id in leases:
+            self.registry.release_lease(lease_id)
+        return {"ok": True}
 
     def _verb_converge(self, request: dict[str, Any]) -> Iterator[dict[str, Any]]:
         """Submit a converge under the coalescing policy, then stream the job it landed on.
@@ -623,7 +748,11 @@ class Daemon:
         return BuildOutcome(returncode=0, result=result.to_dict())
 
     def _verb_shutdown(self, _request: dict[str, Any]) -> dict[str, Any]:
-        self.request_stop()
+        if not self.request_stop():
+            return {
+                "ok": False,
+                "error": "daemon has active execution session(s); wait for run or shell to exit",
+            }
         return {"ok": True, "stopping": True}
 
 

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -11,9 +11,8 @@ import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 
-from bosn import __version__, labels
-from bosn.registry import Registry, default_db_path
-from bosn.resources import ResourceScanner, adopt
+from bosn import __version__, daemon, labels
+from bosn.registry import Registry
 
 
 class DockerFrontDoorError(ValueError):
@@ -67,7 +66,9 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _compose_overlay(registry: Registry, compose: Path) -> Path:
+def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
+    if isinstance(registry_id, Registry):
+        registry_id = registry_id.registry_id
     """Generate an ephemeral Compose overlay that labels every service container."""
     names = re.findall(r"^  ([A-Za-z0-9_-]+):\s*$", compose.read_text(encoding="utf-8"), re.M)
     if not names:
@@ -77,7 +78,7 @@ def _compose_overlay(registry: Registry, compose: Path) -> Path:
     lines = ["services:"]
     for name in names:
         contract = labels.ResourceLabels(
-            registry=registry.registry_id,
+            registry=registry_id,
             kind="container",
             stack=name,
             generation="compose",
@@ -100,18 +101,21 @@ def _compose_overlay(registry: Registry, compose: Path) -> Path:
 def _run_compose(command: str, compose: Path, args: list[str]) -> int:
     if args:
         raise DockerFrontDoorError(f"unsupported compose flag or argument {args[0]!r}")
-    with Registry(default_db_path()) as registry:
-        overlay = _compose_overlay(registry, compose)
-        try:
-            completed = subprocess.run(
-                ["docker", "compose", "-f", str(compose), "-f", str(overlay), command], check=False
-            )
-            if command == "up" and completed.returncode == 0:
-                scan = ResourceScanner().scan(registry.registry_id)
-                adopt(registry, scan)
-            return completed.returncode
-        finally:
-            overlay.unlink(missing_ok=True)
+    reply = daemon.request("status")
+    if not reply.get("ok"):
+        raise DockerFrontDoorError(str(reply.get("error") or "cannot reach bosn daemon"))
+    overlay = _compose_overlay(str(reply["registry_id"]), compose)
+    try:
+        completed = subprocess.run(
+            ["docker", "compose", "-f", str(compose), "-f", str(overlay), command], check=False
+        )
+        if command == "up" and completed.returncode == 0:
+            adopted = daemon.request("compose-adopt")
+            if not adopted.get("ok"):
+                raise DockerFrontDoorError(str(adopted.get("error") or "compose adoption failed"))
+        return completed.returncode
+    finally:
+        overlay.unlink(missing_ok=True)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -151,10 +151,21 @@ class Registry:
         # The daemon serves requests on a thread pool while owning one connection, so the
         # connection must outlive its creating thread; a lock keeps it single-writer.
         self._lock = threading.RLock()
-        self.conn = sqlite3.connect(str(self.path), isolation_level=None, check_same_thread=False)
+        if read_only:
+            # URI mode=ro refuses a missing database and prevents SQLite from creating WAL,
+            # schema, or migration state behind a supposedly read-only CLI command.
+            uri = f"file:{self.path.as_posix()}?mode=ro"
+            self.conn = sqlite3.connect(
+                uri, uri=True, isolation_level=None, check_same_thread=False
+            )
+        else:
+            self.conn = sqlite3.connect(
+                str(self.path), isolation_level=None, check_same_thread=False
+            )
         self.conn.row_factory = sqlite3.Row
         with self._lock:
-            self.conn.execute("PRAGMA journal_mode=WAL")
+            if not read_only:
+                self.conn.execute("PRAGMA journal_mode=WAL")
             self.conn.execute("PRAGMA foreign_keys=ON")
             self.conn.execute("PRAGMA busy_timeout=5000")
             if not read_only:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -195,6 +195,18 @@ def test_idle_retirement_stops_an_unused_daemon(tmp_path: Path) -> None:
     assert not daemon_mod.is_serving(tmp_path)
 
 
+def test_active_execution_session_pins_daemon_and_refuses_shutdown(tmp_path: Path) -> None:
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0)
+    try:
+        daemon._execution_sessions["session"] = ("lease",)
+        assert not daemon.should_retire()
+        reply = daemon._verb_shutdown({})
+        assert reply["ok"] is False
+        assert "active execution" in reply["error"]
+    finally:
+        daemon.registry.close()
+
+
 # -- unattended maintenance ------------------------------------------------
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -329,3 +329,10 @@ def test_a_second_reader_sees_writes_and_is_not_blocked(tmp_path: Path) -> None:
                 kind="volume", name="v2", stack="s", generation="g", scope="spec", workspace="/w"
             )
             assert len(reader.list_resources()) == 2
+
+
+def test_read_only_registry_refuses_missing_database_without_creating_it(tmp_path: Path) -> None:
+    path = tmp_path / "missing.sqlite3"
+    with pytest.raises(sqlite3.OperationalError):
+        Registry(path, read_only=True)
+    assert not path.exists()


### PR DESCRIPTION
Closes #40\n\n- route GC, done, adoption, compose reconciliation, and execution leases through authenticated daemon verbs\n- use true SQLite read-only access for reporting/discovery paths\n- centrally version-gate mutations and preserve a version-tolerant shutdown remedy\n- synchronize execution sessions with shutdown and idle retirement