### PR TITLE
fix: make adoption recovery scoped and reconcile startup state

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ needed, first copy `registry.sqlite3` (including its `-wal` and `-shm` siblings)
 the copy as input to `sqlite3 copy.sqlite3 ".recover"`. Adopted resources receive a
 24-hour quiet period before normal age-based retention resumes.
 
+To transfer a resource between live registries, select it explicitly with
+`bosn adopt --transfer volume:<name>`. Docker labels are immutable, so bosn requires that
+the volume have no attached containers, copies its contents to a temporary staging volume,
+recreates the selected name with the current labels, copies the data back, and preserves the
+staging volume if a copy/recreate step fails. Images and containers are refused rather than
+silently recreating an unknown runtime contract.
+
 Enable the per-user login launcher once with `bosn __daemon --autostart`; it writes a
 Startup launcher on Windows, a LaunchAgent on macOS, or a user systemd unit on Linux.
 Disable and remove it with `bosn __daemon --no-autostart`. Each scheduled pass reaps

--- a/README.md
+++ b/README.md
@@ -248,10 +248,13 @@ reports each effective value and its origin.
 ## Registry recovery
 
 Run `bosn doctor` after an unclean shutdown. If it finds complete labels from a prior
-registry it prints `bosn adopt`, the only ownership-transfer command. SQLite diagnosis is
+registry it prints a source-specific `bosn adopt --from-registry <uuid>` command. This is
+lost-database recovery only: it restores that identity into an empty registry and never
+replaces the identity of a registry that already has rows. SQLite diagnosis is
 non-destructive: run `sqlite3 registry.sqlite3 "PRAGMA integrity_check"`; if recovery is
-needed, copy the database first and use SQLite's `.recover` output to build a replacement.
-Adopted resources receive a 24-hour quiet period before normal age-based retention resumes.
+needed, first copy `registry.sqlite3` (including its `-wal` and `-shm` siblings), then use
+the copy as input to `sqlite3 copy.sqlite3 ".recover"`. Adopted resources receive a
+24-hour quiet period before normal age-based retention resumes.
 
 Enable the per-user login launcher once with `bosn __daemon --autostart`; it writes a
 Startup launcher on Windows, a LaunchAgent on macOS, or a user systemd unit on Linux.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,19 @@ recreates the selected name with the current labels, copies the data back, and p
 staging volume if a copy/recreate step fails. Images and containers are refused rather than
 silently recreating an unknown runtime contract.
 
+To adopt resources from a documented pre-bosn producer, run
+`bosn adopt --legacy <family> --yes`, where `<family>` is `clud`, `soldr`, or `zccache` — the
+only families bosn recognizes; any other name is refused with the list of known families.
+Selection is by each family's own `.managed=true` label under its documented namespace
+(`com.clud.docker-build`, `io.soldr.perf-local`, `io.zccache.perf-local`) — never by matching
+a resource's name. Only volumes are adopted this way (relabeled in place by the same staged
+copy/recreate used by `--transfer`); a legacy container or image with the managed label is
+reported as skipped rather than rebuilt. A resource whose producer schema is unrecognized
+(soldr's `.schema`) or whose required workspace label is absent is refused rather than
+migrated on a guess. Without `--yes`, the command only reports what it would adopt and
+changes nothing; adopted resources get the same adoption-time aging and 24-hour quiet period
+as any other recovered resource.
+
 Enable the per-user login launcher once with `bosn __daemon --autostart`; it writes a
 Startup launcher on Windows, a LaunchAgent on macOS, or a user systemd unit on Linux.
 Disable and remove it with `bosn __daemon --no-autostart`. Each scheduled pass reaps

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -159,6 +159,23 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
                 metavar="KIND:NAME",
                 help="explicitly transfer one detached volume by staged copy and recreation",
             )
+            sub.add_argument(
+                "--legacy",
+                dest="legacy",
+                default=None,
+                metavar="FAMILY",
+                help=(
+                    "adopt resources from a documented pre-bosn producer contract "
+                    "(clud, soldr, zccache); unknown names remain manual"
+                ),
+            )
+            sub.add_argument(
+                "--yes",
+                dest="yes",
+                action="store_true",
+                default=False,
+                help="apply the adoption; without it, only report what would be adopted",
+            )
         if verb == "gc":
             group = sub.add_mutually_exclusive_group()
             group.add_argument(
@@ -223,6 +240,21 @@ def cmd_doctor(opts: Options) -> int:
     print(f"scheduler manifest installed: {autostart.manifest_installed()}")
     print(f"scheduler next deadline: {deadline or '-'}")
     print(f"registry integrity: {integrity}")
+    if db_path.exists() and integrity != "ok":
+        backup = db_path.with_suffix(".backup.sqlite3")
+        recovered = db_path.with_suffix(".recovered.sql")
+        print(
+            "registry integrity check failed; back up before attempting recovery, "
+            "then recover into a new file -- never overwrite the original:",
+            file=sys.stderr,
+        )
+        print(f"  sqlite3 {db_path} \"VACUUM INTO '{backup}'\"", file=sys.stderr)
+        print(f"  sqlite3 {db_path} .recover > {recovered}", file=sys.stderr)
+        print(
+            "inspect the recovered SQL before replacing anything; the original "
+            f"{db_path} is left untouched by these commands",
+            file=sys.stderr,
+        )
     if not info.reachable:
         print(f"diagnosis:      {info.detail}", file=sys.stderr)
         return 1
@@ -724,9 +756,138 @@ def cmd_done(opts: Options) -> int:
     return 0
 
 
+def cmd_adopt_legacy(opts: Options) -> int:
+    """``adopt --legacy <family>``: documented pre-bosn producer contracts, no name guessing.
+
+    Unlike lost-registry recovery and explicit ``--transfer``, this path never mutates the
+    registry directly from the CLI (writes to it always go through the daemon -- see
+    ``bosn/daemon.py``'s ``compose-adopt`` verb). It only recreates qualifying volumes with
+    bosn's label contract via the engine, then asks the daemon to register whatever now
+    carries our identity -- the same idempotent step ``bosn/docker_cli.py`` already runs
+    after ``docker compose up``.
+    """
+    from bosn import daemon as daemon_mod
+    from bosn import legacy
+    from bosn.engine import Engine
+    from bosn.resources import ResourceScanner
+
+    try:
+        family = legacy.resolve_family(str(opts.legacy))
+    except legacy.UnknownLegacyFamilyError as exc:
+        return _error(
+            code="adopt.unknown_legacy_family",
+            message=str(exc),
+            next_step=f"choose one of: {', '.join(legacy.known_families())}",
+            as_json=opts.json,
+        )
+
+    try:
+        status = daemon_mod.request("status", opts.state_dir)
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        return _error(
+            code="daemon.unreachable",
+            message=f"cannot reach the bosn daemon: {exc}",
+            next_step="start or restart the daemon, then retry",
+            as_json=opts.json,
+        )
+    if not status.get("ok"):
+        return _error(
+            code="adopt.failed",
+            message=str(status.get("error") or "could not read current registry identity"),
+            next_step="run `bosn doctor` and retry",
+            as_json=opts.json,
+        )
+    registry_id = str(status["registry_id"])
+
+    import time
+
+    engine = Engine(opts.engine)
+    plan = legacy.plan_adoption(
+        ResourceScanner(engine), family, registry_id=registry_id, now=time.time()
+    )
+    eligible_names = [entry.resource.name for entry in plan.eligible]
+    skipped_names = [resource.name for resource in plan.skipped_immutable]
+    refused_report = [
+        {"name": resource.name, "reason": reason} for resource, reason in plan.refused
+    ]
+
+    if not opts.yes:
+        report = {
+            "ok": False,
+            "code": "adopt.confirmation_required",
+            "message": (
+                f"--legacy {family.name} would adopt {len(eligible_names)} volume(s); "
+                "no changes applied without --yes"
+            ),
+            "next": "re-run the same command with --yes to apply",
+            "family": family.name,
+            "would_adopt": eligible_names,
+            "skipped_immutable": skipped_names,
+            "refused": refused_report,
+            "applied": False,
+        }
+        if opts.json:
+            print(json.dumps(report))
+        else:
+            print(report["message"], file=sys.stderr)
+            for name in eligible_names:
+                print(f"  would adopt: {name}", file=sys.stderr)
+            for name in skipped_names:
+                print(f"  skipped (not a volume, cannot relabel): {name}", file=sys.stderr)
+            for item in refused_report:
+                print(f"  refused: {item['name']}: {item['reason']}", file=sys.stderr)
+        return 1
+
+    from bosn.resources import TransferError
+
+    try:
+        legacy.apply_plan(engine, plan)
+    except TransferError as exc:
+        return _error(
+            code="adopt.legacy_relabel_failed",
+            message=str(exc),
+            next_step="resolve the reported engine error and retry",
+            as_json=opts.json,
+        )
+
+    try:
+        registered = daemon_mod.request("compose-adopt", opts.state_dir)
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        return _error(
+            code="daemon.unreachable",
+            message=(
+                f"relabeled {len(eligible_names)} volume(s) but could not reach the daemon "
+                f"to register them: {exc}"
+            ),
+            next_step="run `bosn adopt --from-registry` or restart the daemon and retry",
+            as_json=opts.json,
+        )
+    if not registered.get("ok"):
+        return _error(
+            code="adopt.failed",
+            message=str(registered.get("error") or "registration after relabel failed"),
+            next_step="run `bosn doctor` and retry",
+            as_json=opts.json,
+        )
+
+    result = {
+        "adopted": eligible_names,
+        "skipped_immutable": skipped_names,
+        "refused": refused_report,
+        "family": family.name,
+        "registry_id": registry_id,
+        "applied": True,
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
 def cmd_adopt(opts: Options) -> int:
     """The sole ownership-transfer/recovery entry point for complete label contracts."""
     from bosn import daemon as daemon_mod
+
+    if opts.legacy:
+        return cmd_adopt_legacy(opts)
 
     try:
         reply = daemon_mod.request(
@@ -737,11 +898,19 @@ def cmd_adopt(opts: Options) -> int:
             transfer=list(opts.transfer),
         )
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
-        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
-        return 1
+        return _error(
+            code="daemon.unreachable",
+            message=f"cannot reach the bosn daemon: {exc}",
+            next_step="start or restart the daemon, then retry",
+            as_json=opts.json,
+        )
     if not reply.get("ok"):
-        print(str(reply.get("error") or "adopt failed"), file=sys.stderr)
-        return 1
+        return _error(
+            code="adopt.failed",
+            message=str(reply.get("error") or "adopt failed"),
+            next_step="run `bosn doctor` and retry",
+            as_json=opts.json,
+        )
     adopted = list(reply.get("adopted") or [])
     transferred = list(reply.get("transferred") or [])
     if not adopted and not transferred:
@@ -884,7 +1053,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     }
     handler = handlers.get(opts.verb)
     if handler is not None:
-        if opts.json and opts.verb not in {"tasks", "gc"}:
+        if opts.json and opts.verb not in {"tasks", "gc", "adopt"}:
             # Older human-oriented verbs already return useful exit codes and write
             # diagnostics to stderr.  Adapt that boundary once so JSON callers never
             # need to parse prose while those commands are migrated individually.

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -233,10 +233,19 @@ def cmd_doctor(opts: Options) -> int:
         registry_id = None
         integrity = "not initialized"
     else:
-        with Registry(db_path, read_only=True) as registry:
-            deadline = registry.meta("maintenance.next_deadline")
-            registry_id = registry.registry_id
-            integrity = registry.integrity_check()
+        # A corrupt registry must still produce a diagnosis, never a traceback: doctor is
+        # the tool the user reaches for precisely when the database is damaged, and the
+        # recovery guidance below is printed from `integrity`. Opening, reading meta, and
+        # reading the registry id can each fail on damage severe enough to stop the pager.
+        try:
+            with Registry(db_path, read_only=True) as registry:
+                deadline = registry.meta("maintenance.next_deadline")
+                registry_id = registry.registry_id
+                integrity = registry.integrity_check()
+        except sqlite3.DatabaseError as exc:
+            deadline = None
+            registry_id = None
+            integrity = f"unreadable: {exc}"
     print(f"scheduler manifest installed: {autostart.manifest_installed()}")
     print(f"scheduler next deadline: {deadline or '-'}")
     print(f"registry integrity: {integrity}")

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -145,6 +145,13 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
             sub.add_argument("--task", default=None, help="run a manifest task by name")
             sub.add_argument("--manifest", default=None, dest="sub_manifest")
         sub.add_argument("--json", action="store_true", default=argparse.SUPPRESS)
+        if verb == "adopt":
+            sub.add_argument(
+                "--from-registry",
+                dest="source_registry",
+                default=None,
+                help="recover this lost registry identity (required when several are found)",
+            )
         if verb == "gc":
             group = sub.add_mutually_exclusive_group()
             group.add_argument(
@@ -214,8 +221,13 @@ def cmd_doctor(opts: Options) -> int:
     scan = ResourceScanner(Engine(opts.engine)).scan(registry_id or "")
     if scan.foreign_registries:
         state = f" --state-dir {opts.state_dir}" if opts.state_dir else ""
+        commands = "; ".join(
+            f"bosn{state} adopt --from-registry {candidate}"
+            for candidate in sorted(scan.foreign_registries)
+        )
         print(
-            f"complete resources from foreign registry ids found; recover with: bosn{state} adopt",
+            "complete resources from foreign registry ids found; "
+            f"choose recovery source: {commands}",
             file=sys.stderr,
         )
     return 0
@@ -707,7 +719,9 @@ def cmd_adopt(opts: Options) -> int:
     from bosn import daemon as daemon_mod
 
     try:
-        reply = daemon_mod.request("adopt", opts.state_dir, engine=opts.engine)
+        reply = daemon_mod.request(
+            "adopt", opts.state_dir, engine=opts.engine, source_registry=opts.source_registry
+        )
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
         return 1

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -207,12 +207,15 @@ def cmd_doctor(opts: Options) -> int:
     if not db_path.exists():
         deadline = None
         registry_id = None
+        integrity = "not initialized"
     else:
         with Registry(db_path, read_only=True) as registry:
             deadline = registry.meta("maintenance.next_deadline")
             registry_id = registry.registry_id
+            integrity = registry.integrity_check()
     print(f"scheduler manifest installed: {autostart.manifest_installed()}")
     print(f"scheduler next deadline: {deadline or '-'}")
+    print(f"registry integrity: {integrity}")
     if not info.reachable:
         print(f"diagnosis:      {info.detail}", file=sys.stderr)
         return 1

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -742,10 +742,21 @@ def cmd_adopt(opts: Options) -> int:
     if not reply.get("ok"):
         print(str(reply.get("error") or "adopt failed"), file=sys.stderr)
         return 1
-    if not reply.get("adopted"):
+    adopted = list(reply.get("adopted") or [])
+    transferred = list(reply.get("transferred") or [])
+    if not adopted and not transferred:
         print("no complete labeled resources found")
         return 0
-    print(json.dumps({"adopted": reply["adopted"], "registry_id": reply["registry_id"]}, indent=2))
+    print(
+        json.dumps(
+            {
+                "adopted": adopted,
+                "transferred": transferred,
+                "registry_id": reply.get("registry_id"),
+            },
+            indent=2,
+        )
+    )
     return 0
 
 

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -152,6 +152,13 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
                 default=None,
                 help="recover this lost registry identity (required when several are found)",
             )
+            sub.add_argument(
+                "--transfer",
+                action="append",
+                default=[],
+                metavar="KIND:NAME",
+                help="explicitly transfer one detached volume by staged copy and recreation",
+            )
         if verb == "gc":
             group = sub.add_mutually_exclusive_group()
             group.add_argument(
@@ -723,7 +730,11 @@ def cmd_adopt(opts: Options) -> int:
 
     try:
         reply = daemon_mod.request(
-            "adopt", opts.state_dir, engine=opts.engine, source_registry=opts.source_registry
+            "adopt",
+            opts.state_dir,
+            engine=opts.engine,
+            source_registry=opts.source_registry,
+            transfer=list(opts.transfer),
         )
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -323,6 +323,32 @@ class Daemon:
             on_settled=self.note_activity,
         )
 
+    def _reconcile_startup_resources(self) -> None:
+        """Repair create-before-registry crashes without making engine absence fatal."""
+        from bosn.engine import Engine, EngineError
+        from bosn.resources import ResourceScanner, reconcile_owned
+
+        try:
+            engine = Engine(self.engine_binary)
+            # Maintenance tests provide a minimal reachability probe.  Those test
+            # doubles intentionally are not a resource-listing engine.
+            if not callable(getattr(engine, "run", None)):
+                return
+            prior_resources = self.registry.list_resources()
+            scan = ResourceScanner(engine).scan(self.registry.registry_id)
+            if self._stop.is_set():
+                return
+            repaired = reconcile_owned(self.registry, scan, prior_resources=prior_resources)
+        except EngineError as exc:
+            self.registry.log_event("recovery.scan.unavailable", str(exc))
+            return
+        except Exception as exc:  # background recovery must never take down IPC
+            if not self._stop.is_set():
+                self.registry.log_event("recovery.scan.failed", str(exc))
+            return
+        if repaired:
+            self.registry.log_event("recovery.startup", ",".join(repaired))
+
     # -- lifecycle ---------------------------------------------------------
 
     @property
@@ -378,6 +404,10 @@ class Daemon:
         except OSError:
             pass
         self.registry.log_event("daemon.started", f"pid={os.getpid()} port={self.port}")
+
+        # Docker can be unavailable or taking a long time to wake.  Recovery must not
+        # postpone serving IPC; this daemon-owned worker is cancelled by normal shutdown.
+        threading.Thread(target=self._reconcile_startup_resources, daemon=True).start()
 
         self._watchdog_thread = threading.Thread(target=self._idle_watchdog, daemon=True)
         self._watchdog_thread.start()
@@ -610,9 +640,26 @@ class Daemon:
         registries = scan.foreign_registries
         if not registries:
             return {"ok": True, "adopted": [], "registry_id": None}
-        if len(registries) != 1:
-            return {"ok": False, "error": "adopt refused: multiple foreign registry ids found"}
-        registry_id = next(iter(registries))
+        selected = str(request.get("source_registry") or "")
+        if selected:
+            if selected not in registries:
+                return {"ok": False, "error": f"adopt source registry not found: {selected}"}
+            registry_id = selected
+        elif len(registries) == 1:
+            registry_id = next(iter(registries))
+        else:
+            commands = "; ".join(
+                f"bosn adopt --from-registry {candidate}" for candidate in sorted(registries)
+            )
+            return {"ok": False, "error": f"choose a source registry: {commands}"}
+        if self.registry.list_resources() and registry_id != self.registry.registry_id:
+            return {
+                "ok": False,
+                "error": (
+                    "adopt recovery requires an empty registry; current identity is preserved. "
+                    "Use an explicit ownership-transfer workflow instead."
+                ),
+            }
         self.registry.set_meta("registry_id", registry_id)
         names = adopt(self.registry, ResourceScanner(engine).scan(registry_id))
         return {"ok": True, "adopted": names, "registry_id": registry_id}

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -326,7 +326,7 @@ class Daemon:
     def _reconcile_startup_resources(self) -> None:
         """Repair create-before-registry crashes without making engine absence fatal."""
         from bosn.engine import Engine, EngineError
-        from bosn.resources import ResourceScanner, reconcile_owned
+        from bosn.resources import ResourceScanner, recompute_manifest_generations, reconcile_owned
 
         try:
             engine = Engine(self.engine_binary)
@@ -339,6 +339,7 @@ class Daemon:
             if self._stop.is_set():
                 return
             repaired = reconcile_owned(self.registry, scan, prior_resources=prior_resources)
+            recompute_manifest_generations(self.registry, scan)
         except EngineError as exc:
             self.registry.log_event("recovery.scan.unavailable", str(exc))
             return
@@ -424,13 +425,13 @@ class Daemon:
             self._write_heartbeat()
             for job in self.jobs.reap_expired():
                 self.registry.log_event("job.expired", f"{job.id} {job.stack}")
-            self.run_maintenance_if_due()
             if self.should_retire():
                 if self.request_stop():
                     self.registry.log_event(
                         "daemon.idle_retired", f"idle={self.idle_seconds():.0f}s"
                     )
                     return
+            self.run_maintenance_if_due()
 
     def _write_heartbeat(self) -> None:
         heartbeat_file(self.state_dir).touch()
@@ -639,6 +640,7 @@ class Daemon:
             ResourceScanner,
             TransferError,
             adopt,
+            recompute_manifest_generations,
             reconcile_owned,
             transfer_volume,
         )
@@ -704,7 +706,9 @@ class Daemon:
                 ),
             }
         self.registry.set_meta("registry_id", registry_id)
-        names = adopt(self.registry, ResourceScanner(engine).scan(registry_id))
+        recovered = ResourceScanner(engine).scan(registry_id)
+        names = adopt(self.registry, recovered)
+        recompute_manifest_generations(self.registry, recovered)
         return {"ok": True, "adopted": names, "registry_id": registry_id}
 
     def _verb_compose_adopt(self, _request: dict[str, Any]) -> dict[str, Any]:

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -342,6 +342,8 @@ class Daemon:
         except EngineError as exc:
             self.registry.log_event("recovery.scan.unavailable", str(exc))
             return
+        except KeyboardInterrupt:
+            raise
         except Exception as exc:  # background recovery must never take down IPC
             if not self._stop.is_set():
                 self.registry.log_event("recovery.scan.failed", str(exc))
@@ -633,9 +635,50 @@ class Daemon:
 
     def _verb_adopt(self, request: dict[str, Any]) -> dict[str, Any]:
         from bosn.engine import Engine
-        from bosn.resources import ResourceScanner, adopt
+        from bosn.resources import (
+            ResourceScanner,
+            TransferError,
+            adopt,
+            reconcile_owned,
+            transfer_volume,
+        )
 
         engine = Engine(str(request.get("engine") or self.engine_binary))
+        selectors = [str(item) for item in request.get("transfer", [])]
+        if selectors:
+            transferred: list[str] = []
+            for selector in selectors:
+                kind, separator, name = selector.partition(":")
+                if separator != ":" or not kind or not name:
+                    return {"ok": False, "error": f"invalid transfer selector: {selector}"}
+                if kind != "volume":
+                    return {
+                        "ok": False,
+                        "error": (
+                            f"{kind} labels are immutable and cannot be safely recreated; "
+                            "only detached volumes support transfer"
+                        ),
+                    }
+                candidates = ResourceScanner(engine).discover(kind)
+                resource = next((item for item in candidates if item.name == name), None)
+                if resource is None or not resource.complete:
+                    return {"ok": False, "error": f"no complete labeled volume named {name}"}
+                if resource.owned_by(self.registry.registry_id):
+                    return {
+                        "ok": False,
+                        "error": f"volume already belongs to this registry: {name}",
+                    }
+                try:
+                    transferred.append(transfer_volume(self.registry, engine, resource))
+                except TransferError as exc:
+                    return {"ok": False, "error": str(exc), "transferred": transferred}
+            scan = ResourceScanner(engine).scan(self.registry.registry_id, kinds=["volume"])
+            reconcile_owned(self.registry, scan)
+            return {
+                "ok": True,
+                "transferred": transferred,
+                "registry_id": self.registry.registry_id,
+            }
         scan = ResourceScanner(engine).scan("", kinds=["container", "volume", "image"])
         registries = scan.foreign_registries
         if not registries:

--- a/src/bosn/legacy.py
+++ b/src/bosn/legacy.py
@@ -205,6 +205,14 @@ SOLDR = LegacyFamily(
     # label outright would reject every soldr volume that exists, i.e. refuse the very
     # contract this family is here to handle. A *present* but unrecognized value still
     # refuses -- that is the signal of a real producer schema change.
+    #
+    # A schema-1 volume cannot slip through that relaxation, because no such labeled
+    # volume exists: soldr commit 1f7066d5 ("give each checkout root its own perf_local
+    # runner and volumes", #1835) is the same commit that bumped RUNNER_SCHEMA to "2",
+    # and `git show 1f7066d5^:ci/perf_local.py` creates volumes as a bare
+    # `docker volume create <name>` with no --label arguments at all. Volume labels and
+    # schema 2 arrived together, so anything carrying .managed=true is post-bump by
+    # construction; the two populations are disjoint by label presence, not by version.
     recognized_schema_versions=frozenset({"2"}),
 )
 

--- a/src/bosn/legacy.py
+++ b/src/bosn/legacy.py
@@ -1,0 +1,307 @@
+"""Legacy-producer adoption: ``bosn adopt --legacy <family>``.
+
+Issue #1's design promised that "legacy `com.clud.docker-build.*`, `io.soldr.perf-local.*`,
+and `io.zccache.perf-local.*` resources migrate through the same `adopt` machinery. Unknown
+names remain manual." Issue #18 restated it as "`adopt --legacy` for resources from clud
+docker-build / soldr / zccache predating bosn," and #41's acceptance criterion is that this
+path "handles documented clud/soldr/zccache contracts without guessing from names."
+
+That last clause is the whole point of this module. ``labels.py`` already says it for bosn's
+own contract: "Name prefixes are never ownership proof." The same rule applies to a legacy
+producer's resources: a volume named ``clud-docker-build-soldr-...`` is not evidence of
+anything. What counts as evidence is carrying that producer's own ``.managed=true`` label
+under its own namespace -- the same proof standard bosn holds itself to. So selection here is
+strictly: (1) the caller names a known family, (2) a resource qualifies only if it carries
+that family's managed label. Substring/prefix matching on names never enters the decision.
+
+Ground truth for the label keys below was read directly from the producer source on this
+machine, not inferred or guessed:
+
+- **clud** (`com.clud.docker-build`) --
+  ``clud/crates/clud-bin/assets/tools/docker/docker_build_soldr.py``. ``LABEL_NS =
+  "com.clud.docker-build"``. Every managed object gets ``.managed=true``, ``.stack``,
+  ``.project-key``, ``.project-root``; cache volumes additionally get ``.role`` (the
+  per-mount purpose, e.g. ``target``/``cargo-home``/``rustup-home``/``cargo-chef``) via
+  ``.cache-role``, applied through ``--label {LABEL_NS}.cache-role={role}`` at volume
+  creation. There is no schema/version label -- clud has never needed to change this
+  contract's shape.
+- **soldr** (`io.soldr.perf-local`) -- ``soldr/ci/perf_local.py``. ``LABEL_PREFIX =
+  "io.soldr.perf-local"``, ``RUNNER_SCHEMA = "2"`` ("Bumped from '1': schema 1 runners are
+  the pre-per-root shared containers" -- a real breaking change in what the labels mean).
+  The *runner container* gets ``.managed``, ``.schema``, ``.image-id``, ``.source-root``,
+  ``.ptrace``, ``.dockerfile-sha256``. Its *volumes* (target/cargo-home/soldr-home) get only
+  ``.managed`` and ``.source-root`` -- notably **not** ``.schema``. Since volumes are the only
+  kind adopted here, ``.schema`` is validated when present and not required; see ``SOLDR``.
+- **zccache** (`io.zccache.perf-local`) -- named in the design, but a repo search
+  (`dev/zccache`) found no producer that emits this namespace: only vendored dependencies
+  and build artifacts, no source that writes ``io.zccache.perf-local.*`` labels. The family
+  is implemented from the documented namespace and the ``.managed=true`` convention the other
+  two families share, per the design text quoted above. Nothing beyond that is fabricated:
+  the workspace-bearing label this family requires (``.workspace``) is a documented
+  assumption, called out where it is used, and a resource missing it is refused rather than
+  guessed at.
+
+Mapping onto bosn's contract (``labels.py``: registry, kind, stack, generation, scope,
+workspace, created) is per-family and deliberately conservative about two fields that have no
+legacy source at all:
+
+- ``generation`` -- a legacy *volume's* labels never carry a content digest (soldr's
+  ``.dockerfile-sha256`` lives on its container, which cannot be relabeled -- see below --
+  and clud/zccache have no digest concept at all). Guessing one would let a stale legacy
+  cache masquerade as current. Every adopted resource instead gets
+  ``LEGACY_GENERATION_SENTINEL``, a value no real ``generation_digest()`` output can ever
+  equal, so the first ordinary converge treats it as superseded rather than reusable --
+  fail toward "rebuild once," never toward silently trusting unknown content.
+- ``created`` -- none of the three producers stamp a creation label. The adopted-resource
+  registry row already gets its ``created_at`` from adoption time (see
+  ``resources.adopt``, which passes ``now`` regardless of the label), so the label value
+  written back onto the object only needs to be a well-formed timestamp for humans reading
+  `docker inspect`; it is set to the adoption instant for the same reason.
+
+Only **volumes** are ever adopted. Docker labels are immutable, so relabeling a container or
+image means destroying and rebuilding it under this module -- unlike a volume, there is no
+safe staged-copy equivalent, and doing so would silently discard a running legacy build
+environment. Containers and images carrying a known family's managed label are reported as
+skipped, exactly like the existing ``--transfer`` path already refuses non-volume kinds
+(see ``resources.transfer_volume``).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+
+from bosn import labels
+from bosn.engine import Engine
+from bosn.resources import DiscoveredResource, ResourceScanner
+
+# No legacy producer's volume-level labels carry a content digest (see module docstring).
+# The sentinel is deliberately not a valid `generation_digest()` output (those are always
+# `sha256:<hex>`), so an adopted resource is guaranteed to be superseded by the first real
+# converge rather than mistaken for a fresh generation.
+LEGACY_GENERATION_SENTINEL = "legacy:no-generation-source"
+
+
+class LegacyAdoptionError(ValueError):
+    """A legacy resource cannot be safely mapped onto the bosn label contract."""
+
+
+class UnknownLegacyFamilyError(ValueError):
+    """``--legacy <family>`` did not name one of the documented families."""
+
+
+def _now_iso(now: float) -> str:
+    return dt.datetime.fromtimestamp(now, dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class LegacyFamily:
+    """One versioned, documented legacy producer contract.
+
+    ``version`` is *our* migration-rule version for this family, bumped whenever the
+    mapping below changes in a way that could alter which resources qualify or how they
+    map. ``schema_label``/``recognized_schema_versions`` are separate: they validate the
+    *producer's own* schema label where one exists (currently only soldr's ``.schema``).
+    """
+
+    name: str
+    namespace: str
+    version: str
+    workspace_label: str
+    stack_label: str | None
+    stack_sentinel: str
+    schema_label: str | None = None
+    recognized_schema_versions: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def managed_label(self) -> str:
+        return f"{self.namespace}.managed"
+
+    def qualifies(self, raw: dict[str, str]) -> bool:
+        """Ownership proof for this family: exactly its own managed label, nothing else.
+
+        Never inspects ``name`` -- a resource named as if it belonged to this family but
+        missing the label is invisible here, by design (the anti-name-guessing rule).
+        """
+        return raw.get(self.managed_label) == "true"
+
+    def map_labels(
+        self, raw: dict[str, str], *, registry_id: str, now: float
+    ) -> labels.ResourceLabels:
+        """Map one qualifying resource's raw labels onto the full bosn contract.
+
+        Raises :class:`LegacyAdoptionError` rather than substituting a guess whenever a
+        required field is absent or a producer schema version is unrecognized.
+        """
+        if not self.qualifies(raw):
+            raise LegacyAdoptionError(
+                f"resource does not carry the {self.name} managed label {self.managed_label!r}"
+            )
+        if self.schema_label is not None:
+            schema_value = raw.get(self.schema_label)
+            # Validated only when the producer actually stamped it. soldr writes .schema
+            # onto its runner *container* but not onto its volumes (verified in
+            # soldr/ci/perf_local.py: `docker volume create` passes only .managed and
+            # .source-root), and volumes are the only kind this path can relabel. Requiring
+            # a label the producer never writes would make every soldr adoption fail closed
+            # -- a feature that refuses its own documented contract 100% of the time. An
+            # absent label is therefore "no version claim", and the family's required
+            # fields below carry the safety; a *present* but unrecognized value still
+            # refuses, which is the case that signals a real producer schema change.
+            if schema_value is not None and schema_value not in self.recognized_schema_versions:
+                raise LegacyAdoptionError(
+                    f"{self.name} resource has unrecognized schema "
+                    f"{schema_value!r} for label {self.schema_label!r}; expected one of "
+                    f"{sorted(self.recognized_schema_versions)} -- refusing to migrate "
+                    "blindly across a producer schema change"
+                )
+        workspace = raw.get(self.workspace_label)
+        if not workspace:
+            raise LegacyAdoptionError(
+                f"{self.name} resource is missing its workspace label "
+                f"{self.workspace_label!r}; cannot adopt without a workspace"
+            )
+        stack = (raw.get(self.stack_label) if self.stack_label else None) or self.stack_sentinel
+        return labels.ResourceLabels(
+            registry=registry_id,
+            kind="volume",
+            stack=stack,
+            generation=LEGACY_GENERATION_SENTINEL,
+            # Legacy caches are keyed to one project/checkout directory (clud's
+            # project-root, soldr's source-root), not shared machine-wide -- "stack"
+            # is the closest of bosn's three SCOPES to what these actually are.
+            scope="stack",
+            workspace=workspace,
+            created=_now_iso(now),
+        )
+
+
+CLUD = LegacyFamily(
+    name="clud",
+    namespace="com.clud.docker-build",
+    version="1",
+    workspace_label="com.clud.docker-build.project-root",
+    stack_label="com.clud.docker-build.stack",
+    stack_sentinel="clud-docker-build",  # unused: clud always sets .stack directly.
+)
+
+SOLDR = LegacyFamily(
+    name="soldr",
+    namespace="io.soldr.perf-local",
+    version="1",
+    workspace_label="io.soldr.perf-local.source-root",
+    stack_label=None,  # soldr has no stack concept of its own.
+    stack_sentinel="soldr-perf-local",
+    schema_label="io.soldr.perf-local.schema",
+    # Only RUNNER_SCHEMA "2" (current, as of this module's writing) is recognized. "1"
+    # is documented in the producer as "the pre-per-root shared containers" -- a real
+    # structural change in what .source-root means -- so it is deliberately excluded
+    # rather than assumed compatible.
+    #
+    # soldr's *volumes* (the only object this module ever relabels) never carry .schema --
+    # only the runner *container* does, and containers are never adopted (see module
+    # docstring). So an absent .schema is normal here and is treated as "no version
+    # claim": the volume still has to satisfy .managed and .source-root. Requiring the
+    # label outright would reject every soldr volume that exists, i.e. refuse the very
+    # contract this family is here to handle. A *present* but unrecognized value still
+    # refuses -- that is the signal of a real producer schema change.
+    recognized_schema_versions=frozenset({"2"}),
+)
+
+ZCCACHE = LegacyFamily(
+    name="zccache",
+    namespace="io.zccache.perf-local",
+    version="1",
+    # No producer was found (see module docstring); `.workspace` is the one convention
+    # assumed beyond `.managed`, mirroring bosn's own field name since there is no real
+    # producer to read a workspace-bearing key from. A resource missing it fails closed.
+    workspace_label="io.zccache.perf-local.workspace",
+    stack_label=None,
+    stack_sentinel="zccache-perf-local",
+)
+
+FAMILIES: dict[str, LegacyFamily] = {family.name: family for family in (CLUD, SOLDR, ZCCACHE)}
+
+
+@dataclass(frozen=True)
+class LegacyPlanEntry:
+    resource: DiscoveredResource
+    new_labels: labels.ResourceLabels
+
+
+@dataclass(frozen=True)
+class LegacyAdoptionPlan:
+    family: LegacyFamily
+    eligible: tuple[LegacyPlanEntry, ...] = ()
+    # Managed-labeled but not a volume: containers/images cannot be safely relabeled.
+    skipped_immutable: tuple[DiscoveredResource, ...] = ()
+    # Managed-labeled volumes that failed schema/required-field validation.
+    refused: tuple[tuple[DiscoveredResource, str], ...] = ()
+
+    def is_empty(self) -> bool:
+        return not (self.eligible or self.skipped_immutable or self.refused)
+
+
+def known_families() -> list[str]:
+    return sorted(FAMILIES)
+
+
+def resolve_family(name: str) -> LegacyFamily:
+    family = FAMILIES.get(name)
+    if family is None:
+        raise UnknownLegacyFamilyError(
+            f"unknown --legacy family {name!r}; known families: {', '.join(known_families())}"
+        )
+    return family
+
+
+def plan_adoption(
+    scanner: ResourceScanner, family: LegacyFamily, *, registry_id: str, now: float
+) -> LegacyAdoptionPlan:
+    """Scan every kind for this family's managed resources and classify each one.
+
+    Only membership in ``family`` gates inclusion here (via ``qualifies``, label-only).
+    Every resource this returns already carries the family's managed label; nothing is
+    matched, included, or excluded by name.
+    """
+    eligible: list[LegacyPlanEntry] = []
+    skipped_immutable: list[DiscoveredResource] = []
+    refused: list[tuple[DiscoveredResource, str]] = []
+    for kind in ("volume", "container", "image"):
+        for resource in scanner.discover(kind):
+            if not family.qualifies(resource.raw_labels):
+                continue
+            if resource.kind != "volume":
+                skipped_immutable.append(resource)
+                continue
+            try:
+                new_labels = family.map_labels(
+                    resource.raw_labels, registry_id=registry_id, now=now
+                )
+            except LegacyAdoptionError as exc:
+                refused.append((resource, str(exc)))
+                continue
+            eligible.append(LegacyPlanEntry(resource=resource, new_labels=new_labels))
+    return LegacyAdoptionPlan(
+        family=family,
+        eligible=tuple(eligible),
+        skipped_immutable=tuple(skipped_immutable),
+        refused=tuple(refused),
+    )
+
+
+def apply_plan(engine: Engine, plan: LegacyAdoptionPlan) -> list[str]:
+    """Relabel every eligible volume in place. Registration is a separate, later step.
+
+    Relabeling only changes engine-side ownership proof; it deliberately does not touch
+    the registry database (writes to it always go through the daemon -- see
+    ``resources.adopt`` / the daemon's ``compose-adopt`` verb, which the caller runs next
+    so the newly-owned volumes get adoption-time aging and the quiet period like any
+    other adopted resource).
+    """
+    from bosn.resources import recreate_volume_with_labels
+
+    adopted: list[str] = []
+    for entry in plan.eligible:
+        adopted.append(recreate_volume_with_labels(engine, entry.resource, entry.new_labels))
+    return adopted

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -32,6 +32,7 @@ class Options:
     stack: str | None = None
     task: str | None = None
     source_registry: str | None = None
+    transfer: tuple[str, ...] = ()
     args: tuple[str, ...] = ()
     json: bool = False
 
@@ -127,6 +128,7 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         stack=_as_str(get("stack")),
         task=_as_str(get("task")),
         source_registry=_as_str(get("source_registry")),
+        transfer=get_list("transfer"),
         args=get_list("args"),
         json=bool(get("json", False)),
         dry_run=bool(get("dry_run", True)),

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -31,6 +31,7 @@ class Options:
     # stack-facing verbs
     stack: str | None = None
     task: str | None = None
+    source_registry: str | None = None
     args: tuple[str, ...] = ()
     json: bool = False
 
@@ -125,6 +126,7 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         manifest=_as_path(manifest),
         stack=_as_str(get("stack")),
         task=_as_str(get("task")),
+        source_registry=_as_str(get("source_registry")),
         args=get_list("args"),
         json=bool(get("json", False)),
         dry_run=bool(get("dry_run", True)),

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -33,6 +33,8 @@ class Options:
     task: str | None = None
     source_registry: str | None = None
     transfer: tuple[str, ...] = ()
+    legacy: str | None = None
+    yes: bool = False
     args: tuple[str, ...] = ()
     json: bool = False
 
@@ -129,6 +131,8 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         task=_as_str(get("task")),
         source_registry=_as_str(get("source_registry")),
         transfer=get_list("transfer"),
+        legacy=_as_str(get("legacy")),
+        yes=bool(get("yes", False)),
         args=get_list("args"),
         json=bool(get("json", False)),
         dry_run=bool(get("dry_run", True)),

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -408,6 +408,11 @@ class Registry:
     def journal_mode(self) -> str:
         return str(self._exec("PRAGMA journal_mode").fetchone()[0]).lower()
 
+    def integrity_check(self) -> str:
+        """Return SQLite's read-only integrity diagnosis without altering the database."""
+        row = self._exec("PRAGMA integrity_check").fetchone()
+        return str(row[0]) if row is not None else "no result"
+
     # -- resources ---------------------------------------------------------
 
     def register_resource(

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -409,8 +409,19 @@ class Registry:
         return str(self._exec("PRAGMA journal_mode").fetchone()[0]).lower()
 
     def integrity_check(self) -> str:
-        """Return SQLite's read-only integrity diagnosis without altering the database."""
-        row = self._exec("PRAGMA integrity_check").fetchone()
+        """Return SQLite's read-only integrity diagnosis without altering the database.
+
+        Damage bad enough to stop the pager makes the PRAGMA itself raise rather than
+        report -- reproducibly so on Linux, where a page-header hit that Windows happened
+        to survive raises "database disk image is malformed". Reporting that as a string
+        is the whole point: `doctor` prints recovery guidance from this value, so raising
+        here would crash the diagnostic in exactly the corrupt-database case it exists to
+        diagnose. Never returns "ok" for a database it could not read.
+        """
+        try:
+            row = self._exec("PRAGMA integrity_check").fetchone()
+        except sqlite3.DatabaseError as exc:
+            return f"unreadable: {exc}"
         return str(row[0]) if row is not None else "no result"
 
     # -- resources ---------------------------------------------------------

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -522,6 +522,45 @@ def reconcile_owned(
     return reconciled
 
 
+def recompute_manifest_generations(registry: Registry, scan: ScanResult) -> int:
+    """Record the current local-content generation for recoverable workspaces.
+
+    Label values describe the generation at creation time.  When the workspace still
+    exists, recovery must also restore the current manifest generation so old labeled
+    resources become superseded after an edit made while SQLite was unavailable.
+    External-image stacks record their content closure but defer supersession to normal
+    daemon convergence: pulling or building during recovery would evade job cancellation.
+    """
+    from bosn.manifest import ManifestError, dockerfile_external_images, generation_digest, load
+
+    refreshed = 0
+    seen: set[tuple[str, str]] = set()
+    for resource in scan.owned:
+        parsed = resource.parsed()
+        key = (parsed.workspace, parsed.stack)
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            manifest = load(Path(parsed.workspace))
+            stack = manifest.stack(parsed.stack)
+        except (ManifestError, OSError):
+            continue
+        has_external_identity = bool(
+            stack.image or dockerfile_external_images(manifest.root, stack)
+        )
+        digest = generation_digest(manifest, stack)
+        registry.record_generation(digest, parsed.stack, parsed.workspace)
+        # A base-image identity is resolved only inside a managed build job.  Recording
+        # the local content closure is still useful after recovery, but treating it as
+        # the final identity would incorrectly retire a resource built from the same
+        # Dockerfile with a resolved external image digest.
+        if not has_external_identity:
+            registry.supersede_generations(parsed.stack, digest, parsed.workspace)
+        refreshed += 1
+    return refreshed
+
+
 def within_quiet_period(adopted_at: float, now: float) -> bool:
     """Adopted resources are protected from age-out for the quiet period."""
     return (now - adopted_at) < QUIET_PERIOD_SECONDS

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from bosn import labels
 from bosn.clock import Clock, SystemClock
 from bosn.engine import Engine
-from bosn.registry import Registry
+from bosn.registry import Registry, Resource
 
 # Docker CLI list commands per resource kind, formatted as one JSON object per line.
 _LIST_COMMANDS: dict[str, list[str]] = {
@@ -68,6 +68,7 @@ class ScanResult:
     owned: list[DiscoveredResource] = field(default_factory=list)
     foreign: list[DiscoveredResource] = field(default_factory=list)
     unlabeled: list[DiscoveredResource] = field(default_factory=list)
+    scanned_kinds: set[str] = field(default_factory=set)
 
     @property
     def foreign_registries(self) -> set[str]:
@@ -116,13 +117,13 @@ class ResourceScanner:
     def __init__(self, engine: Engine | None = None) -> None:
         self.engine = engine or Engine()
 
-    def discover(self, kind: str) -> list[DiscoveredResource]:
+    def _discover(self, kind: str) -> tuple[list[DiscoveredResource], bool]:
         args = _LIST_COMMANDS.get(kind)
         if args is None:
             raise ValueError(f"cannot enumerate unknown kind {kind!r}")
         result = self.engine.run(args)
         if not result.ok:
-            return []
+            return [], False
 
         discovered: list[DiscoveredResource] = []
         for line in result.stdout.splitlines():
@@ -144,6 +145,11 @@ class ResourceScanner:
                 # before concluding a resource is unlabeled.
                 raw = self.inspect_labels(kind, name) or raw
             discovered.append(DiscoveredResource(kind=kind, name=name, raw_labels=raw))
+        return discovered, True
+
+    def discover(self, kind: str) -> list[DiscoveredResource]:
+        """List one kind; callers needing safety metadata should use :meth:`scan`."""
+        discovered, _success = self._discover(kind)
         return discovered
 
     def inspect_labels(self, kind: str, name: str) -> dict[str, str]:
@@ -158,7 +164,10 @@ class ResourceScanner:
     def scan(self, registry_id: str, kinds: list[str] | None = None) -> ScanResult:
         scan = ScanResult()
         for kind in kinds or list(_LIST_COMMANDS):
-            for resource in self.discover(kind):
+            discovered, success = self._discover(kind)
+            if success:
+                scan.scanned_kinds.add(kind)
+            for resource in discovered:
                 if not resource.complete:
                     scan.unlabeled.append(resource)
                 elif resource.owned_by(registry_id):
@@ -396,6 +405,44 @@ def adopt(
         registry.log_event("resource.adopted", f"{resource.kind}:{resource.name}")
         adopted.append(resource.name)
     return adopted
+
+
+def reconcile_owned(
+    registry: Registry, scan: ScanResult, *, prior_resources: list[Resource] | None = None
+) -> list[str]:
+    """Make registry state agree with complete resources carrying our identity.
+
+    This is deliberately additive: a failed or unavailable engine listing must never
+    turn an empty scan into permission to forget registry rows.  Engine deletion is
+    already idempotently handled by collection; startup reconciliation repairs the
+    other crash boundary, where Docker accepted a create but the process died before
+    SQLite recorded it.
+    """
+    reconciled: list[str] = []
+    for resource in scan.owned:
+        parsed = resource.parsed()
+        existing = registry.get_resource_by_engine_identity(resource.kind, resource.name)
+        registered = registry.reconcile_resource(
+            kind=resource.kind,
+            name=resource.name,
+            stack=parsed.stack,
+            generation=parsed.generation,
+            scope=parsed.scope,
+            workspace=parsed.workspace,
+        )
+        registry.record_generation(parsed.generation, parsed.stack, parsed.workspace)
+        if existing is None:
+            registry.set_resource_state(registered.id, "adopted")
+            registry.log_event("resource.recovered", f"{resource.kind}:{resource.name}")
+            reconciled.append(resource.name)
+    discovered = {(resource.kind, resource.name) for resource in scan.owned}
+    # Only rows observed before the scan are candidates.  A concurrent converge may
+    # create a new engine object after listing completes; deleting that fresh row from a
+    # stale scan would reintroduce the crash boundary this function repairs.
+    for resource in prior_resources or []:
+        if resource.kind in scan.scanned_kinds and (resource.kind, resource.name) not in discovered:
+            registry.remove_resource(resource.id)
+    return reconciled
 
 
 def within_quiet_period(adopted_at: float, now: float) -> bool:

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -18,6 +18,7 @@ import json
 import os
 import subprocess
 import sys
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -365,6 +366,82 @@ def prune_dead_leases(registry: Registry, *, alive_probe=process_alive) -> list[
 # -- adoption --------------------------------------------------------------
 
 QUIET_PERIOD_SECONDS = 24 * 3600
+TRANSFER_IMAGE = "alpine:3.20"
+
+
+class TransferError(RuntimeError):
+    """An explicit ownership transfer cannot be performed safely."""
+
+
+def transfer_volume(registry: Registry, engine: Engine, resource: DiscoveredResource) -> str:
+    """Recreate one detached foreign volume with the current ownership labels.
+
+    Docker labels are immutable.  The staging volume retains a recoverable copy until the
+    replacement is verified, so a failed selected transfer never silently destroys data.
+    """
+    if resource.kind != "volume" or not resource.complete:
+        raise TransferError("only a complete labeled volume can be transferred")
+    attached = engine.run(["ps", "--all", "--filter", f"volume={resource.name}", "--quiet"])
+    if not attached.ok:
+        raise TransferError(f"could not check volume attachments for {resource.name}")
+    if attached.stdout.strip():
+        raise TransferError(f"volume {resource.name} is attached; stop its containers first")
+    parsed = resource.parsed()
+    new_labels = labels.ResourceLabels(
+        registry=registry.registry_id,
+        kind=parsed.kind,
+        stack=parsed.stack,
+        generation=parsed.generation,
+        scope=parsed.scope,
+        workspace=parsed.workspace,
+        created=parsed.created,
+    )
+    staging = f"bosn-transfer-{uuid.uuid4().hex}"
+    created_staging = engine.run(["volume", "create", staging])
+    if not created_staging.ok:
+        raise TransferError(f"could not create transfer staging volume for {resource.name}")
+    copy_to_staging = engine.run(
+        [
+            "run",
+            "--rm",
+            "-v",
+            f"{resource.name}:/from:ro",
+            "-v",
+            f"{staging}:/to",
+            TRANSFER_IMAGE,
+            "sh",
+            "-c",
+            "cp -a /from/. /to/",
+        ]
+    )
+    if not copy_to_staging.ok:
+        raise TransferError(f"copy to staging failed; preserved staging volume {staging}")
+    removed = engine.run(["volume", "rm", resource.name])
+    if not removed.ok:
+        raise TransferError(f"could not remove old volume; preserved staging volume {staging}")
+    create = engine.run(["volume", "create", *new_labels.to_docker_args(), resource.name])
+    if not create.ok:
+        raise TransferError(f"could not recreate volume; preserved staging volume {staging}")
+    copy_back = engine.run(
+        [
+            "run",
+            "--rm",
+            "-v",
+            f"{staging}:/from:ro",
+            "-v",
+            f"{resource.name}:/to",
+            TRANSFER_IMAGE,
+            "sh",
+            "-c",
+            "cp -a /from/. /to/",
+        ]
+    )
+    if not copy_back.ok:
+        raise TransferError(
+            f"copy into recreated volume failed; preserved staging volume {staging}"
+        )
+    engine.run(["volume", "rm", staging])
+    return resource.name
 
 
 def adopt(

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -530,6 +530,18 @@ def reconcile_owned(
     for resource in scan.owned:
         parsed = resource.parsed()
         existing = registry.get_resource_by_engine_identity(resource.kind, resource.name)
+        if existing is not None:
+            # Observing a resource is not using it. `reconcile_resource` is an
+            # "I am using this now" mutation (last_used = now, state = 'active'), and the
+            # daemon idle-retires and restarts constantly, so calling it for rows that
+            # already exist would: revert `bosn done` back to active (done workspaces
+            # never collect again), reset last_used so idle/superseded age never
+            # accumulates across a restart (age-based GC becomes inert and the disk grows
+            # without bound -- the exact failure this project exists to prevent), and flip
+            # 'adopted' to 'active', stripping the 24h quiet period so pressure can evict
+            # data that recovery just restored. Reconciliation repairs the missing-row
+            # crash boundary only; it must leave lifecycle state alone.
+            continue
         registered = registry.reconcile_resource(
             kind=resource.kind,
             name=resource.name,
@@ -539,10 +551,9 @@ def reconcile_owned(
             workspace=parsed.workspace,
         )
         registry.record_generation(parsed.generation, parsed.stack, parsed.workspace)
-        if existing is None:
-            registry.set_resource_state(registered.id, "adopted")
-            registry.log_event("resource.recovered", f"{resource.kind}:{resource.name}")
-            reconciled.append(resource.name)
+        registry.set_resource_state(registered.id, "adopted")
+        registry.log_event("resource.recovered", f"{resource.kind}:{resource.name}")
+        reconciled.append(resource.name)
     discovered = {(resource.kind, resource.name) for resource in scan.owned}
     # Only rows observed before the scan are candidates.  A concurrent converge may
     # create a new engine object after listing completes; deleting that fresh row from a

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -376,16 +376,13 @@ class TransferError(RuntimeError):
 def transfer_volume(registry: Registry, engine: Engine, resource: DiscoveredResource) -> str:
     """Recreate one detached foreign volume with the current ownership labels.
 
-    Docker labels are immutable.  The staging volume retains a recoverable copy until the
-    replacement is verified, so a failed selected transfer never silently destroys data.
+    Thin wrapper over :func:`recreate_volume_with_labels`: this call site is explicit
+    ownership transfer, so the new label set is the old one with only ``registry``
+    swapped for ours -- everything else about the resource (stack, generation, scope,
+    workspace, created) is preserved exactly.
     """
     if resource.kind != "volume" or not resource.complete:
         raise TransferError("only a complete labeled volume can be transferred")
-    attached = engine.run(["ps", "--all", "--filter", f"volume={resource.name}", "--quiet"])
-    if not attached.ok:
-        raise TransferError(f"could not check volume attachments for {resource.name}")
-    if attached.stdout.strip():
-        raise TransferError(f"volume {resource.name} is attached; stop its containers first")
     parsed = resource.parsed()
     new_labels = labels.ResourceLabels(
         registry=registry.registry_id,
@@ -396,6 +393,40 @@ def transfer_volume(registry: Registry, engine: Engine, resource: DiscoveredReso
         workspace=parsed.workspace,
         created=parsed.created,
     )
+    return recreate_volume_with_labels(engine, resource, new_labels)
+
+
+def volume_is_attached(engine: Engine, name: str) -> bool:
+    """True when a container references this volume (list is not empty on success).
+
+    Shared by explicit ownership transfer and legacy-family adoption: both recreate a
+    volume in place, which is only safe once nothing has it mounted.
+    """
+    attached = engine.run(["ps", "--all", "--filter", f"volume={name}", "--quiet"])
+    if not attached.ok:
+        raise TransferError(f"could not check volume attachments for {name}")
+    return bool(attached.stdout.strip())
+
+
+def recreate_volume_with_labels(
+    engine: Engine, resource: DiscoveredResource, new_labels: labels.ResourceLabels
+) -> str:
+    """Recreate one detached volume carrying ``new_labels``, staging its data first.
+
+    Docker labels are immutable, so "relabeling" a volume means: copy its data into a
+    scratch volume, remove the original, recreate it under the same name with the new
+    label set, and copy the data back. The staging volume retains a recoverable copy
+    until the replacement is verified, so a failed relabel never silently destroys data.
+
+    This is the mechanical core shared by explicit ``--transfer`` (adopt.py's foreign-id
+    recovery) and legacy-family adoption (``legacy.py``): both need "same object, new
+    ownership labels" and neither can get there by writing a database row, because the
+    labels the engine reports come from the object itself, not from bosn's registry.
+    """
+    if resource.kind != "volume":
+        raise TransferError("only a volume can be relabeled by staged recreation")
+    if volume_is_attached(engine, resource.name):
+        raise TransferError(f"volume {resource.name} is attached; stop its containers first")
     staging = f"bosn-transfer-{uuid.uuid4().hex}"
     created_staging = engine.run(["volume", "create", staging])
     if not created_staging.ok:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -456,6 +456,55 @@ def test_malformed_persisted_maintenance_deadline_recovers(tmp_path: Path) -> No
         daemon.registry.close()
 
 
+def test_adopt_with_multiple_foreign_registries_prints_selectable_commands(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Ambiguity must produce exact `--from-registry <id>` commands, not a blanket refusal."""
+    from bosn import labels
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    first, second = "lost-registry-1", "lost-registry-2"
+
+    def _raw(registry: str) -> dict[str, str]:
+        return labels.ResourceLabels(
+            registry=registry,
+            kind="volume",
+            stack="dev",
+            generation="digest",
+            scope="spec",
+            workspace="workspace",
+            created="2026-01-01T00:00:00Z",
+        ).to_dict()
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            foreign = [
+                DiscoveredResource("volume", "cache-1", _raw(first)),
+                DiscoveredResource("volume", "cache-2", _raw(second)),
+            ]
+            return ScanResult(foreign=foreign)
+
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        original = daemon.registry.registry_id
+        reply = daemon._verb_adopt({"engine": "docker"})
+        assert not reply["ok"]
+        error = str(reply["error"])
+        # Exact, selectable commands for each candidate -- never a blanket refusal.
+        assert f"bosn adopt --from-registry {first}" in error
+        assert f"bosn adopt --from-registry {second}" in error
+        assert "refused" not in error
+        assert daemon.registry.registry_id == original
+    finally:
+        daemon.registry.close()
+
+
 def test_adopt_preserves_a_nonempty_registry_identity(monkeypatch, tmp_path: Path) -> None:
     """Recovery of a lost database must never strand rows in an existing one."""
     from bosn import labels
@@ -534,6 +583,159 @@ def test_adopt_recovers_the_selected_lost_identity(monkeypatch, tmp_path: Path) 
         assert reply["ok"]
         assert daemon.registry.registry_id == lost
         assert daemon.registry.get_resource_by_engine_identity("volume", "cache") is not None
+    finally:
+        daemon.registry.close()
+
+
+# -- startup reconciliation -------------------------------------------------
+#
+# gc.Collector.collect() has exactly one persistent removal boundary: it calls the
+# engine to remove a resource, and only on success does it call registry.remove_resource
+# (src/bosn/gc.py, the final loop). A crash between those two calls leaves a stale
+# registry row for an engine object that no longer exists -- the "remove-before-registry"
+# case below. The container-stop step earlier in collect() only issues `container stop`
+# and a log_event; it never deletes a registry row, so it is not a removal boundary.
+#
+# The complementary creation boundary lives in converge.py: engine.run(["...", "create",
+# ...]) followed by self._register(...) -> registry.register_resource(...). A crash
+# between those two calls leaves a complete labeled engine object with no registry row --
+# the "create-before-registry" case below.
+#
+# Both boundaries are repaired by Daemon._reconcile_startup_resources via
+# resources.reconcile_owned. These tests exercise that daemon method directly (not just
+# the underlying resources.reconcile_owned unit), to prove the daemon wires scanning,
+# prior-resource capture, and event logging together correctly.
+
+
+class _StubEngine:
+    """Only needs to look like an Engine to the reachability check in the daemon."""
+
+    def run(self, args, *, check: bool = False):  # pragma: no cover - not exercised
+        raise AssertionError("the stubbed ResourceScanner should intercept all calls")
+
+
+def test_startup_reconciliation_repairs_create_before_registry_crash(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Daemon startup must recover a labeled engine object with no registry row."""
+    from bosn import labels
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    raw = labels.ResourceLabels(
+        registry="placeholder",
+        kind="volume",
+        stack="dev",
+        generation="digest",
+        scope="spec",
+        workspace="workspace",
+        created="2026-01-01T00:00:00Z",
+    ).to_dict()
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            raw["bosn.registry"] = registry_id
+            resource = DiscoveredResource("volume", "created-first", raw)
+            return ScanResult(owned=[resource], scanned_kinds={"volume"})
+
+    import bosn.engine
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    monkeypatch.setattr(bosn.engine, "Engine", lambda *a, **k: _StubEngine())
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        daemon._reconcile_startup_resources()
+        recovered = daemon.registry.get_resource_by_engine_identity("volume", "created-first")
+        assert recovered is not None
+        assert recovered.state == "adopted"
+        assert any(event["kind"] == "recovery.startup" for event in daemon.registry.events())
+    finally:
+        daemon.registry.close()
+
+
+def test_startup_reconciliation_repairs_remove_before_registry_crash(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Daemon startup must drop a registry row whose engine object is already gone."""
+    from bosn.resources import ScanResult
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            return ScanResult(scanned_kinds={"volume"})
+
+    import bosn.engine
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    monkeypatch.setattr(bosn.engine, "Engine", lambda *a, **k: _StubEngine())
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        stale = daemon.registry.register_resource(
+            kind="volume",
+            name="removed-first",
+            stack="dev",
+            generation="digest",
+            scope="spec",
+            workspace="workspace",
+        )
+        daemon._reconcile_startup_resources()
+        assert daemon.registry.get_resource(stale.id) is None
+    finally:
+        daemon.registry.close()
+
+
+def test_startup_reconciliation_is_idempotent(monkeypatch, tmp_path: Path) -> None:
+    """Mirrors the prune_dead_leases idempotency test: a second pass repairs nothing."""
+    from bosn import labels
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    raw = labels.ResourceLabels(
+        registry="placeholder",
+        kind="volume",
+        stack="dev",
+        generation="digest",
+        scope="spec",
+        workspace="workspace",
+        created="2026-01-01T00:00:00Z",
+    ).to_dict()
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            raw["bosn.registry"] = registry_id
+            resource = DiscoveredResource("volume", "created-first", raw)
+            return ScanResult(owned=[resource], scanned_kinds={"volume"})
+
+    import bosn.engine
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    monkeypatch.setattr(bosn.engine, "Engine", lambda *a, **k: _StubEngine())
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        daemon._reconcile_startup_resources()
+        after_first = daemon.registry.list_resources()
+        repairs_after_first = sum(
+            1 for event in daemon.registry.events() if event["kind"] == "recovery.startup"
+        )
+        assert repairs_after_first == 1
+
+        daemon._reconcile_startup_resources()
+        after_second = daemon.registry.list_resources()
+        repairs_after_second = sum(
+            1 for event in daemon.registry.events() if event["kind"] == "recovery.startup"
+        )
+
+        assert [r.id for r in after_second] == [r.id for r in after_first]
+        assert repairs_after_second == repairs_after_first, "second pass must log no repair"
     finally:
         daemon.registry.close()
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -456,6 +456,88 @@ def test_malformed_persisted_maintenance_deadline_recovers(tmp_path: Path) -> No
         daemon.registry.close()
 
 
+def test_adopt_preserves_a_nonempty_registry_identity(monkeypatch, tmp_path: Path) -> None:
+    """Recovery of a lost database must never strand rows in an existing one."""
+    from bosn import labels
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    lost = "lost-registry"
+    raw = labels.ResourceLabels(
+        registry=lost,
+        kind="volume",
+        stack="dev",
+        generation="digest",
+        scope="spec",
+        workspace="workspace",
+        created="2026-01-01T00:00:00Z",
+    ).to_dict()
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            resource = DiscoveredResource("volume", "cache", raw)
+            return ScanResult(owned=[resource] if registry_id == lost else [], foreign=[resource])
+
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        original = daemon.registry.registry_id
+        daemon.registry.register_resource(
+            kind="volume",
+            name="current-cache",
+            stack="dev",
+            generation="current",
+            scope="spec",
+            workspace="workspace",
+        )
+        reply = daemon._verb_adopt({"engine": "docker", "source_registry": lost})
+        assert not reply["ok"]
+        assert daemon.registry.registry_id == original
+        assert "empty registry" in str(reply["error"])
+    finally:
+        daemon.registry.close()
+
+
+def test_adopt_recovers_the_selected_lost_identity(monkeypatch, tmp_path: Path) -> None:
+    from bosn import labels
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    lost = "lost-registry"
+    raw = labels.ResourceLabels(
+        registry=lost,
+        kind="volume",
+        stack="dev",
+        generation="digest",
+        scope="spec",
+        workspace="workspace",
+        created="2026-01-01T00:00:00Z",
+    ).to_dict()
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            resource = DiscoveredResource("volume", "cache", raw)
+            return ScanResult(owned=[resource] if registry_id == lost else [], foreign=[resource])
+
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        reply = daemon._verb_adopt({"engine": "docker", "source_registry": lost})
+        assert reply["ok"]
+        assert daemon.registry.registry_id == lost
+        assert daemon.registry.get_resource_by_engine_identity("volume", "cache") is not None
+    finally:
+        daemon.registry.close()
+
+
 # -- client behavior -------------------------------------------------------
 
 

--- a/tests/test_doctor_integrity.py
+++ b/tests/test_doctor_integrity.py
@@ -19,16 +19,29 @@ from bosn.registry import Registry
 
 
 def _corrupt_mid_file(path: Path) -> None:
-    """Flip bytes well past the header so sqlite reports page corruption, not open failure.
+    """Flip bytes well past the header so sqlite fails on pages, not at open time.
 
     A file of random junk bytes fails at *connection* time ("file is not a database"),
     before PRAGMA integrity_check can even run. Corrupting live pages in the middle of a
-    real database lets sqlite open the file, walk the btree, and report the damage
-    through PRAGMA integrity_check -- the actual code path cmd_doctor must handle.
+    real database lets sqlite open the file and then hit the damage.
+
+    How it surfaces is platform-dependent, and both ways must be handled: the PRAGMA may
+    *report* the corruption as a string, or the pager may give up and *raise*
+    "database disk image is malformed". This exact split cost a CI failure -- Windows
+    reported, Linux raised -- so `integrity_check` converts the raise into a diagnosis
+    and doctor prints guidance either way. Never assume the reporting path.
     """
     data = bytearray(path.read_bytes())
     mid = len(data) // 2
     for i in range(mid, min(mid + 512, len(data))):
+        data[i] = 0xFF
+    path.write_bytes(bytes(data))
+
+
+def _corrupt_beyond_repair(path: Path) -> None:
+    """Damage every page after the header, the case that makes the PRAGMA itself raise."""
+    data = bytearray(path.read_bytes())
+    for i in range(1024, len(data)):
         data[i] = 0xFF
     path.write_bytes(bytes(data))
 
@@ -65,6 +78,40 @@ def test_doctor_surfaces_bad_integrity_and_prints_recovery_guidance(tmp_path: Pa
     assert str(db_path) in captured.err
     assert ".recover" in captured.err
     assert "sqlite3" in captured.err
+
+
+def test_doctor_diagnoses_a_database_too_damaged_to_even_check(tmp_path: Path, capsys) -> None:
+    """The case that broke CI: the PRAGMA raises instead of reporting.
+
+    On Linux this corruption makes `PRAGMA integrity_check` raise "database disk image is
+    malformed" rather than return a row. Doctor must still print a diagnosis and the
+    recovery commands -- a traceback here would fail the user in exactly the situation
+    the command exists for. Platform-independent because it forces the raising path.
+    """
+    db_path = tmp_path / "registry.sqlite3"
+    with Registry(db_path) as registry:
+        for index in range(200):
+            registry.register_resource(
+                kind="volume",
+                name=f"cache-{index}",
+                stack="dev",
+                generation="digest",
+                scope="spec",
+                workspace="workspace",
+            )
+    _corrupt_beyond_repair(db_path)
+    before = hashlib.sha256(db_path.read_bytes()).hexdigest()
+
+    exit_code = cli.main(
+        ["--state-dir", str(tmp_path), "--engine", "definitely-not-an-engine-binary", "doctor"]
+    )
+
+    captured = capsys.readouterr()
+    assert "registry integrity: ok" not in captured.out
+    assert "VACUUM INTO" in captured.err
+    assert ".recover" in captured.err
+    assert exit_code is not None
+    assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before
 
 
 def test_doctor_never_mutates_the_corrupted_database(tmp_path: Path, capsys) -> None:

--- a/tests/test_doctor_integrity.py
+++ b/tests/test_doctor_integrity.py
@@ -1,0 +1,80 @@
+"""`doctor` must diagnose sqlite corruption and print non-destructive recovery guidance.
+
+Registry.integrity_check() (src/bosn/registry.py) already proves the read-only happy
+path (tests/test_registry.py::test_integrity_check_is_read_only). What is untested is
+the failure path: cmd_doctor's response when integrity_check reports something other
+than "ok". These tests corrupt a *real* database file (not a from-scratch garbage file,
+which sqlite would refuse to open at all) so integrity_check reports the corruption
+instead of raising, then assert doctor surfaces it, prints copy-pasteable backup-then-
+`.recover` commands, and never mutates the corrupted file itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from bosn import cli
+from bosn.registry import Registry
+
+
+def _corrupt_mid_file(path: Path) -> None:
+    """Flip bytes well past the header so sqlite reports page corruption, not open failure.
+
+    A file of random junk bytes fails at *connection* time ("file is not a database"),
+    before PRAGMA integrity_check can even run. Corrupting live pages in the middle of a
+    real database lets sqlite open the file, walk the btree, and report the damage
+    through PRAGMA integrity_check -- the actual code path cmd_doctor must handle.
+    """
+    data = bytearray(path.read_bytes())
+    mid = len(data) // 2
+    for i in range(mid, min(mid + 512, len(data))):
+        data[i] = 0xFF
+    path.write_bytes(bytes(data))
+
+
+def _make_corrupted_registry(tmp_path: Path) -> Path:
+    db_path = tmp_path / "registry.sqlite3"
+    with Registry(db_path) as registry:
+        registry.register_resource(
+            kind="volume",
+            name="cache",
+            stack="dev",
+            generation="digest",
+            scope="spec",
+            workspace="workspace",
+        )
+    _corrupt_mid_file(db_path)
+    return db_path
+
+
+def test_doctor_surfaces_bad_integrity_and_prints_recovery_guidance(tmp_path: Path, capsys) -> None:
+    db_path = _make_corrupted_registry(tmp_path)
+
+    cli.main(
+        ["--state-dir", str(tmp_path), "--engine", "definitely-not-an-engine-binary", "doctor"]
+    )
+
+    captured = capsys.readouterr()
+    assert "registry integrity: ok" not in captured.out
+    assert "registry integrity:" in captured.out
+
+    # Exact, copy-pasteable commands: back up first, then .recover -- never overwrite
+    # the original file in place.
+    assert "VACUUM INTO" in captured.err
+    assert str(db_path) in captured.err
+    assert ".recover" in captured.err
+    assert "sqlite3" in captured.err
+
+
+def test_doctor_never_mutates_the_corrupted_database(tmp_path: Path, capsys) -> None:
+    """Non-destructiveness is the actual safety property: hash before and after."""
+    db_path = _make_corrupted_registry(tmp_path)
+    before = hashlib.sha256(db_path.read_bytes()).hexdigest()
+
+    cli.main(
+        ["--state-dir", str(tmp_path), "--engine", "definitely-not-an-engine-binary", "doctor"]
+    )
+
+    after = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    assert after == before, "doctor must never write to a database it is only diagnosing"

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,0 +1,432 @@
+"""``adopt --legacy``: documented clud/soldr/zccache contracts, never name guessing.
+
+This is the acceptance test for GitHub issue #41's last unimplemented criterion.  Every
+test either proves a family adopts *only* its own managed resources, or proves the module
+refuses rather than guesses when the contract is not satisfied.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bosn import cli, legacy
+from bosn.engine import EngineResult
+from bosn.resources import DiscoveredResource, ResourceScanner, TransferError
+
+OURS = "our-registry-uuid"
+
+
+class FakeEngine:
+    """Records commands and replays canned list/inspect output, like test_resources.py."""
+
+    def __init__(self, listings: dict[str, list[dict]], inspects: dict[str, dict] | None = None):
+        self.listings = listings
+        self.inspects = inspects or {}
+        self.commands: list[list[str]] = []
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        self.commands.append(list(args))
+        if "inspect" in args:
+            name = args[-1]
+            return EngineResult(0, json.dumps(self.inspects.get(name, {})), "")
+        kind = (
+            "volume"
+            if args[0] == "volume"
+            else "image"
+            if args[0] == "images"
+            else "container"
+            if args[0] == "ps"
+            else None
+        )
+        rows = self.listings.get(kind or "", [])
+        return EngineResult(0, "\n".join(json.dumps(row) for row in rows), "")
+
+
+class TransferEngine:
+    """Accepts every engine call that ``recreate_volume_with_labels`` issues."""
+
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        self.commands.append(list(args))
+        return EngineResult(0, "", "")
+
+
+class AttachedEngine:
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        if args[:2] == ["ps", "--all"]:
+            return EngineResult(0, "container-id", "")
+        return EngineResult(0, "", "")
+
+
+def clud_volume_labels(**overrides: str) -> dict[str, str]:
+    base = {
+        "com.clud.docker-build.managed": "true",
+        "com.clud.docker-build.stack": "soldr",
+        "com.clud.docker-build.project-key": "abc123",
+        "com.clud.docker-build.project-root": "/home/dev/project",
+        "com.clud.docker-build.cache-role": "target",
+    }
+    base.update(overrides)
+    return base
+
+
+def soldr_volume_labels(**overrides: str) -> dict[str, str]:
+    """Exactly what soldr's producer stamps on a volume -- no `.schema`.
+
+    Verified in soldr/ci/perf_local.py: `docker volume create` passes only `.managed` and
+    `.source-root`; `.schema` goes on the runner *container*, which is never adopted here.
+    Putting `.schema` in this fixture would model the container and hide the real case.
+    """
+    base = {
+        "io.soldr.perf-local.managed": "true",
+        "io.soldr.perf-local.source-root": "/home/dev/checkout",
+    }
+    base.update(overrides)
+    return base
+
+
+def zccache_volume_labels(**overrides: str) -> dict[str, str]:
+    base = {
+        "io.zccache.perf-local.managed": "true",
+        "io.zccache.perf-local.workspace": "/home/dev/zc-project",
+    }
+    base.update(overrides)
+    return base
+
+
+# -- family qualification: label-only, never name-based --------------------
+
+
+def test_clud_family_qualifies_only_by_its_managed_label() -> None:
+    assert legacy.CLUD.qualifies(clud_volume_labels())
+    assert not legacy.CLUD.qualifies(soldr_volume_labels())
+    assert not legacy.CLUD.qualifies({})
+
+
+def test_a_legacy_looking_name_without_the_managed_label_is_never_adopted() -> None:
+    """The anti-name-guessing test: name alone, even a perfect legacy-style name, proves
+    nothing.  Only the family's own managed label is ownership proof -- exactly the
+    standard labels.py already holds bosn's own contract to."""
+    engine = FakeEngine(
+        {
+            "volume": [
+                {"Name": "clud-docker-build-soldr-abc123-target", "Labels": ""},
+            ]
+        }
+    )
+    plan = legacy.plan_adoption(
+        ResourceScanner(engine),  # type: ignore[arg-type]
+        legacy.CLUD,
+        registry_id=OURS,
+        now=1000.0,
+    )
+    assert plan.eligible == ()
+    assert plan.is_empty()
+
+
+def test_each_family_adopts_only_its_own_resources() -> None:
+    engine = FakeEngine(
+        {
+            "volume": [
+                {"Name": "clud-cache", "Labels": json.dumps(clud_volume_labels())},
+                {"Name": "soldr-cache", "Labels": json.dumps(soldr_volume_labels())},
+                {"Name": "zc-cache", "Labels": json.dumps(zccache_volume_labels())},
+            ]
+        }
+    )
+    scanner = ResourceScanner(engine)  # type: ignore[arg-type]
+    clud_plan = legacy.plan_adoption(scanner, legacy.CLUD, registry_id=OURS, now=1000.0)
+    soldr_plan = legacy.plan_adoption(scanner, legacy.SOLDR, registry_id=OURS, now=1000.0)
+    zccache_plan = legacy.plan_adoption(scanner, legacy.ZCCACHE, registry_id=OURS, now=1000.0)
+
+    assert [e.resource.name for e in clud_plan.eligible] == ["clud-cache"]
+    assert [e.resource.name for e in soldr_plan.eligible] == ["soldr-cache"]
+    assert [e.resource.name for e in zccache_plan.eligible] == ["zc-cache"]
+
+
+# -- label mapping -----------------------------------------------------------
+
+
+def test_clud_maps_stack_and_project_root_onto_bosn_workspace_and_stack() -> None:
+    mapped = legacy.CLUD.map_labels(clud_volume_labels(), registry_id=OURS, now=1000.0)
+    assert mapped.registry == OURS
+    assert mapped.kind == "volume"
+    assert mapped.stack == "soldr"
+    assert mapped.workspace == "/home/dev/project"
+    assert mapped.scope == "stack"
+    assert mapped.generation == legacy.LEGACY_GENERATION_SENTINEL
+
+
+def test_soldr_maps_source_root_onto_workspace_and_uses_a_stack_sentinel() -> None:
+    mapped = legacy.SOLDR.map_labels(soldr_volume_labels(), registry_id=OURS, now=1000.0)
+    assert mapped.workspace == "/home/dev/checkout"
+    assert mapped.stack == "soldr-perf-local"
+
+
+def test_generation_and_created_never_come_from_the_legacy_producer() -> None:
+    """No legacy producer stamps a content digest onto a volume; the sentinel/derivation
+    is explicit, not a guess (see legacy.py's module docstring)."""
+    mapped = legacy.CLUD.map_labels(clud_volume_labels(), registry_id=OURS, now=1_700_000_000.0)
+    assert mapped.generation == legacy.LEGACY_GENERATION_SENTINEL
+    assert mapped.created == "2023-11-14T22:13:20Z"
+
+
+# -- unrecognized producer schema: refuse, never migrate blindly ------------
+
+
+def test_an_unrecognized_soldr_schema_is_refused_not_migrated() -> None:
+    with pytest.raises(legacy.LegacyAdoptionError, match="schema"):
+        legacy.SOLDR.map_labels(
+            soldr_volume_labels(**{"io.soldr.perf-local.schema": "1"}),
+            registry_id=OURS,
+            now=1000.0,
+        )
+
+
+def test_a_real_soldr_volume_adopts_even_though_it_carries_no_schema_label() -> None:
+    """The contract soldr actually produces must adopt, or the family is dead on arrival.
+
+    soldr stamps `.schema` on the runner *container* but not on its cache volumes
+    (verified in ci/perf_local.py), and volumes are the only kind this path relabels.
+    Requiring `.schema` would therefore refuse 100% of real soldr volumes -- a feature
+    that rejects its own documented contract every time. An absent label is "no version
+    claim"; `.managed` + `.source-root` still have to be present.
+    """
+    mapped = legacy.SOLDR.map_labels(soldr_volume_labels(), registry_id=OURS, now=1000.0)
+
+    assert mapped.registry == OURS
+    assert mapped.workspace == "/home/dev/checkout"
+    assert mapped.kind == "volume"
+
+
+def test_a_soldr_volume_missing_its_source_root_still_fails_closed() -> None:
+    """Relaxing the schema rule must not relax the required fields it sat in front of."""
+    without_root = soldr_volume_labels()
+    del without_root["io.soldr.perf-local.source-root"]
+    with pytest.raises(legacy.LegacyAdoptionError, match="workspace"):
+        legacy.SOLDR.map_labels(without_root, registry_id=OURS, now=1000.0)
+
+
+def test_plan_adoption_puts_unrecognized_schema_volumes_in_refused_not_eligible() -> None:
+    engine = FakeEngine(
+        {
+            "volume": [
+                {
+                    "Name": "soldr-stale-schema",
+                    "Labels": json.dumps(
+                        soldr_volume_labels(**{"io.soldr.perf-local.schema": "99"})
+                    ),
+                },
+            ]
+        }
+    )
+    plan = legacy.plan_adoption(
+        ResourceScanner(engine),  # type: ignore[arg-type]
+        legacy.SOLDR,
+        registry_id=OURS,
+        now=1000.0,
+    )
+    assert plan.eligible == ()
+    assert len(plan.refused) == 1
+    assert plan.refused[0][0].name == "soldr-stale-schema"
+    assert "schema" in plan.refused[0][1]
+
+
+# -- zccache: no observed producer, fails closed without a workspace -------
+
+
+def test_zccache_without_a_workspace_label_fails_closed() -> None:
+    labels_without_workspace = zccache_volume_labels()
+    del labels_without_workspace["io.zccache.perf-local.workspace"]
+    with pytest.raises(legacy.LegacyAdoptionError, match="workspace"):
+        legacy.ZCCACHE.map_labels(labels_without_workspace, registry_id=OURS, now=1000.0)
+
+
+def test_zccache_with_a_workspace_label_adopts_like_the_other_families() -> None:
+    mapped = legacy.ZCCACHE.map_labels(zccache_volume_labels(), registry_id=OURS, now=1000.0)
+    assert mapped.workspace == "/home/dev/zc-project"
+    assert mapped.stack == "zccache-perf-local"
+
+
+# -- containers/images: immutable, always skipped, never adopted -----------
+
+
+def test_containers_and_images_are_skipped_not_adopted() -> None:
+    engine = FakeEngine(
+        {
+            "container": [
+                {"Names": "soldr-runner", "Labels": json.dumps(soldr_volume_labels())},
+            ],
+            "image": [
+                {"ID": "sha256:deadbeef", "Labels": json.dumps(soldr_volume_labels())},
+            ],
+        }
+    )
+    plan = legacy.plan_adoption(
+        ResourceScanner(engine),  # type: ignore[arg-type]
+        legacy.SOLDR,
+        registry_id=OURS,
+        now=1000.0,
+    )
+    assert plan.eligible == ()
+    assert {r.name for r in plan.skipped_immutable} == {"soldr-runner", "sha256:deadbeef"}
+
+
+# -- unknown family: refuse and list known families -------------------------
+
+
+def test_resolve_family_lists_known_families_on_refusal() -> None:
+    with pytest.raises(legacy.UnknownLegacyFamilyError) as excinfo:
+        legacy.resolve_family("acme-corp")
+    message = str(excinfo.value)
+    assert "clud" in message and "soldr" in message and "zccache" in message
+
+
+def test_known_families_are_exactly_the_three_documented_ones() -> None:
+    assert legacy.known_families() == ["clud", "soldr", "zccache"]
+
+
+# -- apply_plan: staged relabel, same mechanism as --transfer --------------
+
+
+def test_apply_plan_recreates_each_eligible_volume_with_the_new_labels() -> None:
+    engine = TransferEngine()
+    resource = DiscoveredResource("volume", "clud-cache", clud_volume_labels())
+    mapped = legacy.CLUD.map_labels(clud_volume_labels(), registry_id=OURS, now=1000.0)
+    plan = legacy.LegacyAdoptionPlan(
+        family=legacy.CLUD,
+        eligible=(legacy.LegacyPlanEntry(resource=resource, new_labels=mapped),),
+    )
+    adopted = legacy.apply_plan(engine, plan)  # type: ignore[arg-type]
+    assert adopted == ["clud-cache"]
+    recreated = next(
+        cmd
+        for cmd in engine.commands
+        if cmd[:2] == ["volume", "create"] and cmd[-1] == "clud-cache"
+    )
+    assert any(f"com.zackees.bosn.registry={OURS}" in arg for arg in recreated)
+    assert any("com.zackees.bosn.workspace=/home/dev/project" in arg for arg in recreated)
+
+
+def test_apply_plan_refuses_an_attached_volume() -> None:
+    resource = DiscoveredResource("volume", "clud-cache", clud_volume_labels())
+    mapped = legacy.CLUD.map_labels(clud_volume_labels(), registry_id=OURS, now=1000.0)
+    plan = legacy.LegacyAdoptionPlan(
+        family=legacy.CLUD,
+        eligible=(legacy.LegacyPlanEntry(resource=resource, new_labels=mapped),),
+    )
+    with pytest.raises(TransferError, match="attached"):
+        legacy.apply_plan(AttachedEngine(), plan)  # type: ignore[arg-type]
+
+
+# -- CLI: unknown --legacy value refuses without touching the daemon --------
+
+
+def test_cli_unknown_legacy_family_refuses_and_lists_known_families(tmp_path, capsys) -> None:
+    exit_code = cli.main(
+        ["--state-dir", str(tmp_path), "--json", "adopt", "--legacy", "acme", "--yes"]
+    )
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["code"] == "adopt.unknown_legacy_family"
+    assert "clud" in payload["next"] and "soldr" in payload["next"] and "zccache" in payload["next"]
+
+
+# -- CLI: missing --yes reports the plan and mutates nothing ---------------
+
+
+def test_cli_missing_yes_reports_the_plan_without_mutating(tmp_path, capsys, monkeypatch) -> None:
+    from bosn import daemon as daemon_mod
+    from bosn import engine as engine_mod
+
+    def fake_request(verb, *_args, **_kwargs):
+        assert verb == "status"
+        return {"ok": True, "registry_id": OURS}
+
+    engine = FakeEngine(
+        {"volume": [{"Name": "clud-cache", "Labels": json.dumps(clud_volume_labels())}]}
+    )
+    monkeypatch.setattr(daemon_mod, "request", fake_request)
+    monkeypatch.setattr(engine_mod, "Engine", lambda *_a, **_k: engine)
+
+    exit_code = cli.main(["--state-dir", str(tmp_path), "--json", "adopt", "--legacy", "clud"])
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["applied"] is False
+    assert payload["would_adopt"] == ["clud-cache"]
+    # Nothing beyond the read-only listing commands was ever issued.
+    assert not any(cmd[:2] == ["volume", "create"] for cmd in engine.commands)
+    assert not any(cmd[:2] == ["volume", "rm"] for cmd in engine.commands)
+
+
+# -- CLI: full flow relabels and registers, protected by the quiet period --
+
+
+def test_cli_legacy_adoption_applies_and_registers_through_compose_adopt(
+    tmp_path, capsys, monkeypatch
+) -> None:
+    from bosn import daemon as daemon_mod
+    from bosn import engine as engine_mod
+
+    calls: list[str] = []
+
+    def fake_request(verb, *_args, **_kwargs):
+        calls.append(verb)
+        if verb == "status":
+            return {"ok": True, "registry_id": OURS}
+        if verb == "compose-adopt":
+            return {"ok": True, "adopted": ["clud-cache"]}
+        raise AssertionError(f"unexpected verb {verb}")
+
+    monkeypatch.setattr(daemon_mod, "request", fake_request)
+
+    def scan_only_once(_binary=None):
+        # First call builds the scanner's engine; reuse a listing-capable engine that
+        # also accepts the staged-copy commands `apply_plan` issues.
+        class Combined:
+            def __init__(self) -> None:
+                self.commands: list[list[str]] = []
+
+            def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+                self.commands.append(list(args))
+                if "inspect" in args:
+                    return EngineResult(0, "{}", "")
+                if args[:1] == ["volume"] and args[1] == "ls":
+                    return EngineResult(
+                        0,
+                        json.dumps(
+                            {"Name": "clud-cache", "Labels": json.dumps(clud_volume_labels())}
+                        ),
+                        "",
+                    )
+                if args[:2] == ["ps", "--all"] and "--filter" in args:
+                    return EngineResult(0, "", "")  # not attached
+                return EngineResult(0, "", "")
+
+        return Combined()
+
+    monkeypatch.setattr(engine_mod, "Engine", scan_only_once)
+
+    exit_code = cli.main(
+        ["--state-dir", str(tmp_path), "--json", "adopt", "--legacy", "clud", "--yes"]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["adopted"] == ["clud-cache"]
+    assert payload["applied"] is True
+    assert calls == ["status", "compose-adopt"]
+
+
+def test_within_quiet_period_still_protects_a_freshly_adopted_legacy_resource() -> None:
+    """Registration itself is the daemon's `compose-adopt`, which calls `resources.adopt`
+    -- the same function lost-registry recovery uses, so the same quiet-period guarantee
+    applies without any extra plumbing here."""
+    from bosn.resources import within_quiet_period
+
+    adopted_at = 1_700_000_000.0
+    assert within_quiet_period(adopted_at, adopted_at + 23 * 3600)
+    assert not within_quiet_period(adopted_at, adopted_at + 25 * 3600)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -128,3 +128,7 @@ def test_policy_flags_work_before_or_after_the_verb() -> None:
 def test_gc_apply_flips_dry_run() -> None:
     assert opts(["gc"]).dry_run is True
     assert opts(["gc", "--apply"]).dry_run is False
+
+
+def test_adopt_can_select_a_lost_registry_identity() -> None:
+    assert opts(["adopt", "--from-registry", "lost-registry"]).source_registry == "lost-registry"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -132,3 +132,7 @@ def test_gc_apply_flips_dry_run() -> None:
 
 def test_adopt_can_select_a_lost_registry_identity() -> None:
     assert opts(["adopt", "--from-registry", "lost-registry"]).source_registry == "lost-registry"
+
+
+def test_adopt_can_select_exact_resources_for_transfer() -> None:
+    assert opts(["adopt", "--transfer", "volume:cache"]).transfer == ("volume:cache",)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -136,3 +136,19 @@ def test_adopt_can_select_a_lost_registry_identity() -> None:
 
 def test_adopt_can_select_exact_resources_for_transfer() -> None:
     assert opts(["adopt", "--transfer", "volume:cache"]).transfer == ("volume:cache",)
+
+
+def test_adopt_legacy_family_defaults_to_none() -> None:
+    assert opts(["adopt"]).legacy is None
+
+
+def test_adopt_legacy_family_is_captured() -> None:
+    assert opts(["adopt", "--legacy", "soldr"]).legacy == "soldr"
+
+
+def test_adopt_yes_defaults_to_false() -> None:
+    assert opts(["adopt"]).yes is False
+
+
+def test_adopt_yes_flag_is_captured() -> None:
+    assert opts(["adopt", "--legacy", "clud", "--yes"]).yes is True

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -38,6 +38,23 @@ def test_registry_id_is_a_stable_uuid(tmp_path: Path) -> None:
     assert len(original) == 36
 
 
+def test_integrity_check_is_read_only(tmp_path: Path) -> None:
+    path = tmp_path / "registry.sqlite3"
+    with Registry(path) as registry:
+        registry.register_resource(
+            kind="volume",
+            name="cache",
+            stack="dev",
+            generation="digest",
+            scope="spec",
+            workspace="workspace",
+        )
+    before = path.read_bytes()
+    with Registry(path, read_only=True) as registry:
+        assert registry.integrity_check() == "ok"
+    assert path.read_bytes() == before
+
+
 def test_registry_ids_differ_across_databases(tmp_path: Path) -> None:
     with Registry(tmp_path / "a.sqlite3") as a, Registry(tmp_path / "b.sqlite3") as b:
         assert a.registry_id != b.registry_id

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -540,6 +540,31 @@ def test_startup_reconciliation_repairs_remove_before_registry_crash(
     assert registry.get_resource(stale.id) is None
 
 
+def test_recovery_recomputes_current_local_manifest_generation(
+    registry: Registry, tmp_path: Path
+) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(
+        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8"
+    )
+    stale = label_dict(
+        **{
+            labels.WORKSPACE: str(tmp_path),
+            labels.STACK: "dev",
+            labels.GENERATION: "sha256:old",
+        }
+    )
+    scan = ScanResult(owned=[DiscoveredResource("volume", "cache", stale)])
+
+    assert resources.recompute_manifest_generations(registry, scan) == 1
+    from bosn.manifest import generation_digest, load
+
+    manifest = load(tmp_path)
+    assert registry.generation_recorded(
+        generation_digest(manifest, manifest.stack("dev")), "dev", str(tmp_path)
+    )
+
+
 def test_adopted_resources_are_protected_by_the_quiet_period(clock: FakeClock) -> None:
     """Recovery is never followed by a mass age-out."""
     adopted_at = clock.now()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -545,3 +545,39 @@ def test_adopted_resources_are_protected_by_the_quiet_period(clock: FakeClock) -
     adopted_at = clock.now()
     assert resources.within_quiet_period(adopted_at, clock.advance(23 * 3600))
     assert not resources.within_quiet_period(adopted_at, clock.advance(2 * 3600))
+
+
+def test_explicit_volume_transfer_stages_data_before_recreating_labels(
+    registry: Registry,
+) -> None:
+    class TransferEngine:
+        def __init__(self) -> None:
+            self.commands: list[list[str]] = []
+
+        def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+            self.commands.append(args)
+            return EngineResult(0, "", "")
+
+    engine = TransferEngine()
+    resource = DiscoveredResource("volume", "foreign-cache", label_dict(registry=THEIRS))
+
+    assert resources.transfer_volume(registry, engine, resource) == "foreign-cache"  # type: ignore[arg-type]
+    assert engine.commands[0] == ["ps", "--all", "--filter", "volume=foreign-cache", "--quiet"]
+    assert engine.commands[1][:2] == ["volume", "create"]
+    assert engine.commands[1][2].startswith("bosn-transfer-")
+    recreated = next(
+        command
+        for command in engine.commands
+        if command[:2] == ["volume", "create"] and command[-1] == "foreign-cache"
+    )
+    assert any(f"{labels.REGISTRY}={registry.registry_id}" in arg for arg in recreated)
+
+
+def test_explicit_volume_transfer_refuses_an_attached_volume(registry: Registry) -> None:
+    class AttachedEngine:
+        def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+            return EngineResult(0, "container-id", "")
+
+    resource = DiscoveredResource("volume", "foreign-cache", label_dict(registry=THEIRS))
+    with pytest.raises(resources.TransferError, match="attached"):
+        resources.transfer_volume(registry, AttachedEngine(), resource)  # type: ignore[arg-type]

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -522,6 +522,43 @@ def test_startup_reconciliation_repairs_create_before_registry_crash(
     assert len(registry.list_resources()) == 1
 
 
+def test_startup_reconciliation_leaves_lifecycle_state_alone(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """Observing an already-registered resource must not count as using it.
+
+    The daemon idle-retires and restarts constantly. If reconciliation refreshed rows it
+    merely observed, every restart would revert `bosn done` to active and push `last_used`
+    forward, so done-collection never fires and idle/superseded age never accumulates --
+    age-based GC would go inert and the disk would grow without bound.
+    """
+    from bosn.gc import done_workspaces, mark_done
+
+    resource = registry.register_resource(
+        kind="volume",
+        name="warm-cache",
+        stack="dev",
+        generation="digest",
+        scope="spec",
+        workspace="workspace",
+    )
+    mark_done(registry, "workspace")
+    before = registry.get_resource(resource.id)
+    assert before is not None and before.state == "done"
+
+    clock.advance(10_000)
+    scan = ScanResult(
+        owned=[DiscoveredResource("volume", "warm-cache", label_dict())], scanned_kinds={"volume"}
+    )
+    assert resources.reconcile_owned(registry, scan) == []
+
+    after = registry.get_resource(resource.id)
+    assert after is not None
+    assert after.state == "done", "reconciliation reverted `bosn done`"
+    assert after.last_used == before.last_used, "reconciliation reset the idle-age clock"
+    assert done_workspaces(registry) == {"workspace"}
+
+
 def test_startup_reconciliation_repairs_remove_before_registry_crash(
     registry: Registry,
 ) -> None:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -506,6 +506,40 @@ def test_adoption_is_idempotent(registry: Registry, clock: FakeClock) -> None:
     assert len(registry.list_resources()) == 1
 
 
+def test_startup_reconciliation_repairs_create_before_registry_crash(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """A complete owned engine object is sufficient to repair a missing SQLite row."""
+    scan = ScanResult(owned=[DiscoveredResource("volume", "created-first", label_dict())])
+
+    assert resources.reconcile_owned(registry, scan) == ["created-first"]
+    recovered = registry.get_resource_by_engine_identity("volume", "created-first")
+    assert recovered is not None
+    assert recovered.state == "adopted"
+    assert registry.generation_recorded(recovered.generation, recovered.stack, recovered.workspace)
+
+    assert resources.reconcile_owned(registry, scan) == []
+    assert len(registry.list_resources()) == 1
+
+
+def test_startup_reconciliation_repairs_remove_before_registry_crash(
+    registry: Registry,
+) -> None:
+    stale = registry.register_resource(
+        kind="volume",
+        name="removed-first",
+        stack="dev",
+        generation="digest",
+        scope="spec",
+        workspace="workspace",
+    )
+    prior = registry.list_resources()
+    scan = ScanResult(scanned_kinds={"volume"})
+
+    assert resources.reconcile_owned(registry, scan, prior_resources=prior) == []
+    assert registry.get_resource(stale.id) is None
+
+
 def test_adopted_resources_are_protected_by_the_quiet_period(clock: FakeClock) -> None:
     """Recovery is never followed by a mass age-out."""
     adopted_at = clock.now()


### PR DESCRIPTION
Fixes #41

`bosn adopt` covered only the happy path: it refused when more than one foreign registry id existed, then rewrote the current database's `registry_id` to the old one — which on a non-empty registry instantly made its own resources foreign. There was also no startup reconciliation, so a crash between an engine create and its registry write left a complete owned object invisible to `status` and GC.

## Changes

- **Recovery is scoped and selectable.** `adopt --from-registry <id>` recovers one named lost identity; a non-empty registry never has its identity mutated implicitly. Multiple candidates produce exact copy-pasteable commands rather than a blanket refusal.
- **Ownership transfer is explicit.** `adopt --transfer KIND:NAME` relabels only named detached volumes via staged copy + recreate, preserving the current registry id.
- **Startup reconciliation** repairs both crash boundaries and is idempotent.
- **`adopt --legacy <family> --yes`** migrates the three documented pre-bosn label families (`com.clud.docker-build`, `io.soldr.perf-local`, `io.zccache.perf-local`). Qualification is by the family's `managed` label only — never by resource name, per the label contract's "name prefixes are never ownership proof".
- **Doctor** reports read-only sqlite integrity and, when integrity is bad, prints exact `VACUUM INTO` backup + `sqlite3 .recover` commands. Proven non-destructive by hashing a corrupted db before and after.

## Review findings addressed

- **CRITICAL — reconciliation reset lifecycle state.** `reconcile_owned` called `reconcile_resource` for *every* owned resource, not just missing rows, and that call means "I am using this now" (`last_used = now`, `state = 'active'`). Since the daemon idle-retires and restarts constantly, every restart reverted `bosn done` to active, reset `last_used` so age-based GC went inert (unbounded disk growth — the exact failure this project exists to prevent), and flipped `adopted` to `active`, stripping the 24h quiet period so pressure could evict data recovery had just restored. Reproduced directly: one pass moved `done → active` and `done_workspaces` `{'/ws'} → set()`. Reconciliation now repairs only the missing-row boundary.
- **soldr `.schema` is validated when present, not required.** soldr stamps `.schema` on the runner *container* but not on its volumes, and volumes are the only kind this path relabels — requiring it refused 100% of real soldr volumes. A present-but-unrecognized value still refuses. This is safe because soldr `1f7066d5` bumped `RUNNER_SCHEMA` to `"2"` in the same commit that first labeled volumes at all, so schema-1 volumes carry no labels and cannot qualify; the populations are disjoint by label presence.

## Acceptance criteria

- [x] RED→GREEN tests cover crashes after engine create and at the removal boundary, with idempotent startup reconciliation
- [x] Lost-database recovery restores one prior identity without stranding resources
- [x] Ownership transfer relabels only explicitly selected resources and preserves the current registry id
- [x] Multiple foreign registries produce exact selectable commands
- [x] `adopt --legacy` handles the documented clud/soldr/zccache contracts without guessing from names
- [x] SQLite `integrity_check` / copy / `.recover` guidance is tested and non-destructive

Note: `io.zccache.perf-local` is implemented from its design-documented namespace — no producer emitting those labels exists in the zccache repo, so its one assumed field is called out as an assumption and fails closed.

## Verification

`ci/lint.py` → LINT OK (ruff format, ruff check, pyright). 402 local tests pass; the 26 Docker-marked tests are Linux-CI only and run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)