### PR TITLE
fix: restore one-word tasks and discovery state

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -8,6 +8,8 @@ silent no-op and never a fallback to raw Docker.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import sqlite3
 import sys
@@ -826,6 +828,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     }
     handler = handlers.get(opts.verb)
     if handler is not None:
+        if opts.json and opts.verb not in {"tasks", "gc"}:
+            # Older human-oriented verbs already return useful exit codes and write
+            # diagnostics to stderr.  Adapt that boundary once so JSON callers never
+            # need to parse prose while those commands are migrated individually.
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = handler(opts)
+            if code:
+                message = stderr.getvalue().strip() or f"{opts.verb} failed"
+                return _error(
+                    code="command.failed",
+                    message=message,
+                    next_step="resolve the reported condition and retry the command",
+                    as_json=True,
+                )
+            return code
         return handler(opts)
 
     error = VerbNotImplementedError(opts.verb, VERBS[opts.verb][1])

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 import sys
 from collections.abc import Callable, Sequence
 
@@ -43,6 +44,13 @@ _POLICY_FLAG_KEYS = (
     "max_builds",
     "build_ttl_seconds",
 )
+
+_GLOBAL_VALUE_FLAGS = {
+    "--engine",
+    "--state-dir",
+    "--manifest",
+    *(f"--{key.replace('_', '-')}" for key in _POLICY_FLAG_KEYS),
+}
 
 
 def _add_policy_flags(parser: argparse.ArgumentParser, *, default: object) -> None:
@@ -298,8 +306,16 @@ def cmd_tasks(opts: Options) -> int:
     registered = []
     registry_reason = "registry not initialized"
     if db_path.exists():
-        with Registry(db_path, read_only=True) as registry:
-            registered = registry.list_resources()
+        try:
+            with Registry(db_path, read_only=True) as registry:
+                registered = registry.list_resources()
+        except (OSError, sqlite3.DatabaseError) as exc:
+            return _error(
+                code="registry.unreadable",
+                message=f"cannot read registry: {exc}",
+                next_step="run `bosn doctor` and follow its SQLite recovery guidance",
+                as_json=opts.json,
+            )
         registry_reason = "daemon job state unavailable; run `bosn jobs`"
 
     def readiness(stack_name: str) -> dict[str, object]:
@@ -612,6 +628,23 @@ def cmd_gc(opts: Options) -> int:
             next_step="inspect `bosn status` and retry after resolving the reported error",
             as_json=opts.json,
         )
+    if opts.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not bool(reply.get("errors")),
+                    "result": reply["result"],
+                    "dry_run": opts.dry_run,
+                    "would_stop": reply.get("would_stop", []),
+                    "stopped": reply.get("stopped", []),
+                    "removed": reply.get("removed", []),
+                    "errors": reply.get("errors", []),
+                    "advisories": reply.get("advisories", []),
+                },
+                indent=2,
+            )
+        )
+        return 1 if reply.get("errors") else 0
     print(json.dumps({**reply["result"], "dry_run": opts.dry_run}, indent=2))
     for name in reply.get("would_stop", []):
         print(f"would stop {name}")
@@ -752,16 +785,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     # A manifest task is the friendly front door: `bosn unit` is equivalent to
     # `bosn run --task unit`.  Fixed verbs remain reserved, so adding a task called
     # `status` never changes the meaning of `bosn status`.
-    if (
-        raw_argv
-        and not raw_argv[0].startswith("-")
-        and raw_argv[0]
-        not in {
-            *VERBS,
-            DAEMON_VERB,
-        }
-    ):
-        raw_argv = ["run", "--task", raw_argv[0], *raw_argv[1:]]
+    command_index: int | None = None
+    skip_value = False
+    for index, token in enumerate(raw_argv):
+        if skip_value:
+            skip_value = False
+            continue
+        if token in _GLOBAL_VALUE_FLAGS:
+            skip_value = True
+            continue
+        if token.startswith("--"):
+            continue
+        command_index = index
+        break
+    if command_index is not None and raw_argv[command_index] not in {*VERBS, DAEMON_VERB}:
+        task = raw_argv[command_index]
+        raw_argv[command_index : command_index + 1] = ["run", "--task", task]
     parser = build_parser()
     ns = parser.parse_args(raw_argv)
     opts = from_namespace(ns)

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -101,6 +101,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--manifest", default=None, help="path to bosn.toml (default: nearest one upward)"
     )
+    parser.add_argument(
+        "--json", action="store_true", help="emit structured machine-readable output"
+    )
     # Policy is global because every command must resolve exactly the same snapshot.
     # The daemon repeats its three operational flags after the verb for spawned argv
     # compatibility; the remaining flags belong before the verb like --engine.
@@ -114,8 +117,7 @@ def build_parser() -> argparse.ArgumentParser:
             sub.add_argument("--stack", default=None, help="stack to use (default: the default)")
             sub.add_argument("--task", default=None, help="run a manifest task by name")
             sub.add_argument("--manifest", default=None, dest="sub_manifest")
-        if verb in {"tasks", "status"}:
-            sub.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+        sub.add_argument("--json", action="store_true", default=argparse.SUPPRESS)
         if verb == "gc":
             group = sub.add_mutually_exclusive_group()
             group.add_argument(
@@ -590,14 +592,26 @@ def cmd_gc(opts: Options) -> int:
             "gc", opts.state_dir, engine=opts.engine, dry_run=opts.dry_run, policy_flags=flags
         )
     except ConfigError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+        return _error(
+            code="policy.invalid",
+            message=str(exc),
+            next_step="correct the named policy value and retry",
+            as_json=opts.json,
+        )
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
-        print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
-        return 1
+        return _error(
+            code="daemon.unreachable",
+            message=f"cannot reach the bosn daemon: {exc}",
+            next_step="start or restart the daemon, then retry",
+            as_json=opts.json,
+        )
     if not reply.get("ok"):
-        print(str(reply.get("error") or "gc failed"), file=sys.stderr)
-        return 1
+        return _error(
+            code="gc.failed",
+            message=str(reply.get("error") or "gc failed"),
+            next_step="inspect `bosn status` and retry after resolving the reported error",
+            as_json=opts.json,
+        )
     print(json.dumps({**reply["result"], "dry_run": opts.dry_run}, indent=2))
     for name in reply.get("would_stop", []):
         print(f"would stop {name}")

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -14,6 +14,7 @@ import json
 import sqlite3
 import sys
 from collections.abc import Callable, Sequence
+from typing import NoReturn
 
 from bosn import __version__, ipc
 from bosn.engine import Engine
@@ -69,6 +70,23 @@ def _error(*, code: str, message: str, next_step: str, as_json: bool = False) ->
     return 1
 
 
+class _JSONArgumentParser(argparse.ArgumentParser):
+    """Suppress argparse prose when the caller explicitly requests JSON."""
+
+    def error(self, message: str) -> NoReturn:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "code": "parse.invalid",
+                    "message": message,
+                    "next": "correct the command arguments and retry",
+                }
+            )
+        )
+        raise SystemExit(2)
+
+
 # verb -> (help text, phase that lands it)
 VERBS: dict[str, tuple[str, str]] = {
     "run": ("run an ad-hoc command in a stack", "implemented"),
@@ -93,10 +111,9 @@ class VerbNotImplementedError(RuntimeError):
         self.phase = phase
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="bosn", description="bosn - container lifecycle supervisor"
-    )
+def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
+    parser_type = _JSONArgumentParser if json_errors else argparse.ArgumentParser
+    parser = parser_type(prog="bosn", description="bosn - container lifecycle supervisor")
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument(
         "--engine",
@@ -803,7 +820,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if command_index is not None and raw_argv[command_index] not in {*VERBS, DAEMON_VERB}:
         task = raw_argv[command_index]
         raw_argv[command_index : command_index + 1] = ["run", "--task", task]
-    parser = build_parser()
+    parser = build_parser(json_errors="--json" in raw_argv)
     ns = parser.parse_args(raw_argv)
     opts = from_namespace(ns)
 
@@ -832,17 +849,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             # Older human-oriented verbs already return useful exit codes and write
             # diagnostics to stderr.  Adapt that boundary once so JSON callers never
             # need to parse prose while those commands are migrated individually.
+            stdout = io.StringIO()
             stderr = io.StringIO()
-            with contextlib.redirect_stderr(stderr):
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
                 code = handler(opts)
             if code:
-                message = stderr.getvalue().strip() or f"{opts.verb} failed"
+                message = (stderr.getvalue() + stdout.getvalue()).strip() or f"{opts.verb} failed"
                 return _error(
                     code="command.failed",
                     message=message,
                     next_step="resolve the reported condition and retry the command",
                     as_json=True,
                 )
+            print(stdout.getvalue(), end="")
+            print(stderr.getvalue(), end="", file=sys.stderr)
             return code
         return handler(opts)
 

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -266,6 +266,7 @@ def _open_manifest_and_registry(opts: Options, *, read_only: bool = False):
 
 def cmd_tasks(opts: Options) -> int:
     from bosn.manifest import ManifestError, find_manifest, generation_digest, load
+    from bosn.registry import Registry, default_db_path
 
     try:
         manifest_path = opts.manifest or find_manifest()
@@ -277,6 +278,27 @@ def cmd_tasks(opts: Options) -> int:
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
         return 1
+
+    db_path = (opts.state_dir / "registry.sqlite3") if opts.state_dir else default_db_path()
+    registered = []
+    registry_reason = "registry not initialized"
+    if db_path.exists():
+        with Registry(db_path, read_only=True) as registry:
+            registered = registry.list_resources()
+        registry_reason = "daemon job state unavailable; run `bosn jobs`"
+
+    def readiness(stack_name: str) -> dict[str, object]:
+        resources = [
+            resource
+            for resource in registered
+            if resource.stack == stack_name and resource.workspace == str(manifest.root)
+        ]
+        return {
+            "state": "ready" if resources else "unregistered",
+            "resources": len(resources),
+            "generations": sorted({resource.generation for resource in resources}),
+            "jobs": {"state": "unavailable", "reason": registry_reason},
+        }
 
     try:
         payload = {
@@ -292,10 +314,18 @@ def cmd_tasks(opts: Options) -> int:
                     # generation digest before job coalescing and registration.
                     "content_digest": generation_digest(manifest, stack),
                     "volumes": {v.name: v.scope for v in stack.volumes},
+                    "readiness": readiness(name),
                 }
                 for name, stack in manifest.stacks.items()
             },
-            "tasks": {name: {"stack": t.stack, "cmd": t.cmd} for name, t in manifest.tasks.items()},
+            "tasks": {
+                name: {
+                    "stack": t.stack,
+                    "cmd": t.cmd,
+                    "readiness": readiness(t.stack or manifest.default_stack().name),
+                }
+                for name, t in manifest.tasks.items()
+            },
         }
     except ManifestError as exc:
         print(str(exc), file=sys.stderr)
@@ -687,8 +717,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+    raw_argv = list(argv if argv is not None else sys.argv[1:])
+    # A manifest task is the friendly front door: `bosn unit` is equivalent to
+    # `bosn run --task unit`.  Fixed verbs remain reserved, so adding a task called
+    # `status` never changes the meaning of `bosn status`.
+    if (
+        raw_argv
+        and not raw_argv[0].startswith("-")
+        and raw_argv[0]
+        not in {
+            *VERBS,
+            DAEMON_VERB,
+        }
+    ):
+        raw_argv = ["run", "--task", raw_argv[0], *raw_argv[1:]]
     parser = build_parser()
-    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    ns = parser.parse_args(raw_argv)
     opts = from_namespace(ns)
 
     if opts.verb is None:

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -50,6 +50,15 @@ def _add_policy_flags(parser: argparse.ArgumentParser, *, default: object) -> No
         parser.add_argument(f"--{key.replace('_', '-')}", type=float, default=default)
 
 
+def _error(*, code: str, message: str, next_step: str, as_json: bool = False) -> int:
+    """Emit the stable machine error envelope while preserving readable stderr."""
+    if as_json:
+        print(json.dumps({"ok": False, "code": code, "message": message, "next": next_step}))
+    else:
+        print(message, file=sys.stderr)
+    return 1
+
+
 # verb -> (help text, phase that lands it)
 VERBS: dict[str, tuple[str, str]] = {
     "run": ("run an ad-hoc command in a stack", "implemented"),
@@ -276,8 +285,12 @@ def cmd_tasks(opts: Options) -> int:
             )
         manifest = load(manifest_path)
     except ManifestError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+        return _error(
+            code="manifest.invalid",
+            message=str(exc),
+            next_step="create or select a valid bosn.toml with --manifest",
+            as_json=opts.json,
+        )
 
     db_path = (opts.state_dir / "registry.sqlite3") if opts.state_dir else default_db_path()
     registered = []
@@ -328,8 +341,12 @@ def cmd_tasks(opts: Options) -> int:
             },
         }
     except ManifestError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+        return _error(
+            code="manifest.digest_failed",
+            message=str(exc),
+            next_step="fix the manifest or Dockerfile inputs, then retry",
+            as_json=opts.json,
+        )
     print(json.dumps(payload, indent=2))
     return 0
 

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -32,6 +32,7 @@ class Options:
     stack: str | None = None
     task: str | None = None
     args: tuple[str, ...] = ()
+    json: bool = False
 
     # gc
     dry_run: bool = True
@@ -125,6 +126,7 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         stack=_as_str(get("stack")),
         task=_as_str(get("task")),
         args=get_list("args"),
+        json=bool(get("json", False)),
         dry_run=bool(get("dry_run", True)),
         port=None if port is None else int(str(port)),
         idle_retire_seconds=None if idle is None else float(str(idle)),

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -132,6 +132,19 @@ def test_done_json_error_uses_the_common_envelope(tmp_path, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["code"] == "command.failed"
     assert payload["next"] == "resolve the reported condition and retry the command"
+
+
+def test_doctor_json_failure_emits_one_parseable_envelope(tmp_path, capsys) -> None:
+    assert cli.main(["--json", "--engine", "definitely-not-an-engine", "doctor"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["code"] == "command.failed"
+
+
+def test_json_parse_error_has_the_stable_envelope(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--json", "gc", "--apply", "--dry-run"])
+    assert exc.value.code == 2
+    assert json.loads(capsys.readouterr().out)["code"] == "parse.invalid"
     assert cli.VERBS["cancel"][1] == "implemented"
 
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -98,6 +98,13 @@ def test_tasks_json_manifest_error_has_stable_remedy(tmp_path, capsys) -> None:
         "message": payload["message"],
         "next": "create or select a valid bosn.toml with --manifest",
     }
+
+
+def test_gc_json_daemon_error_has_stable_remedy(tmp_path, capsys) -> None:
+    assert cli.main(["--state-dir", str(tmp_path), "gc", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["code"] == "daemon.unreachable"
+    assert payload["next"] == "start or restart the daemon, then retry"
     assert cli.VERBS["cancel"][1] == "implemented"
 
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -87,6 +87,17 @@ def test_tasks_json_reports_unregistered_readiness(tmp_path, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["stacks"]["dev"]["readiness"]["state"] == "unregistered"
     assert payload["tasks"]["unit"]["readiness"]["jobs"]["state"] == "unavailable"
+
+
+def test_tasks_json_manifest_error_has_stable_remedy(tmp_path, capsys) -> None:
+    assert cli.main(["--state-dir", str(tmp_path), "tasks", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": False,
+        "code": "manifest.invalid",
+        "message": payload["message"],
+        "next": "create or select a valid bosn.toml with --manifest",
+    }
     assert cli.VERBS["cancel"][1] == "implemented"
 
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from bosn import cli
@@ -45,6 +47,46 @@ def test_every_designed_verb_is_registered() -> None:
 def test_attach_and_cancel_are_no_longer_placeholders() -> None:
     """Both landed with daemon-owned jobs; `attach`'s stale 'phase 6' label went with them."""
     assert cli.VERBS["attach"][1] == "implemented"
+
+
+def test_one_word_manifest_task_dispatches_as_run(monkeypatch) -> None:
+    seen = {}
+
+    def run_task(opts) -> int:
+        seen["task"] = opts.task
+        return 17
+
+    monkeypatch.setattr(cli, "cmd_run", run_task)
+    assert cli.main(["unit"]) == 17
+    assert seen == {"task": "unit"}
+
+
+def test_builtin_verb_name_is_reserved_from_task_dispatch(monkeypatch) -> None:
+    seen = []
+    monkeypatch.setattr(cli, "cmd_run", lambda _opts: seen.append("run") or 0)
+    monkeypatch.setattr(cli, "cmd_status", lambda _opts: seen.append("status") or 0)
+
+    assert cli.main(["status"]) == 0
+    assert seen == ["status"]
+
+
+def test_tasks_json_reports_unregistered_readiness(tmp_path, capsys) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    manifest = tmp_path / "bosn.toml"
+    manifest.write_text(
+        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n[task.unit]\ncmd = 'echo unit'\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            ["--state-dir", str(tmp_path / "state"), "--manifest", str(manifest), "tasks", "--json"]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["stacks"]["dev"]["readiness"]["state"] == "unregistered"
+    assert payload["tasks"]["unit"]["readiness"]["jobs"]["state"] == "unavailable"
     assert cli.VERBS["cancel"][1] == "implemented"
 
 
@@ -65,10 +107,9 @@ def test_cancel_fails_closed_when_no_daemon_is_running(tmp_path, capsys) -> None
     assert "cannot reach the bosn daemon" in capsys.readouterr().err
 
 
-def test_unknown_verb_is_rejected() -> None:
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["definitely-not-a-verb"])
-    assert exc.value.code != 0
+def test_unknown_first_token_is_diagnosed_as_an_unknown_manifest_task(capsys) -> None:
+    assert cli.main(["definitely-not-a-verb"]) == 1
+    assert "no bosn.toml" in capsys.readouterr().err
 
 
 def test_doctor_reports_unreachable_engine_and_scheduler_state_without_crashing(

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -125,6 +125,13 @@ def test_gc_json_daemon_error_has_stable_remedy(tmp_path, capsys, monkeypatch) -
     payload = json.loads(capsys.readouterr().out)
     assert payload["code"] == "daemon.unreachable"
     assert payload["next"] == "start or restart the daemon, then retry"
+
+
+def test_done_json_error_uses_the_common_envelope(tmp_path, capsys) -> None:
+    assert cli.main(["--state-dir", str(tmp_path), "done", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["code"] == "command.failed"
+    assert payload["next"] == "resolve the reported condition and retry the command"
     assert cli.VERBS["cancel"][1] == "implemented"
 
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -61,6 +61,20 @@ def test_one_word_manifest_task_dispatches_as_run(monkeypatch) -> None:
     assert seen == {"task": "unit"}
 
 
+def test_one_word_task_keeps_leading_global_options(monkeypatch, tmp_path) -> None:
+    seen = {}
+
+    def run_task(opts) -> int:
+        seen["task"] = opts.task
+        seen["manifest"] = opts.manifest
+        return 0
+
+    manifest = tmp_path / "bosn.toml"
+    monkeypatch.setattr(cli, "cmd_run", run_task)
+    assert cli.main(["--manifest", str(manifest), "unit"]) == 0
+    assert seen == {"task": "unit", "manifest": manifest}
+
+
 def test_builtin_verb_name_is_reserved_from_task_dispatch(monkeypatch) -> None:
     seen = []
     monkeypatch.setattr(cli, "cmd_run", lambda _opts: seen.append("run") or 0)
@@ -100,7 +114,13 @@ def test_tasks_json_manifest_error_has_stable_remedy(tmp_path, capsys) -> None:
     }
 
 
-def test_gc_json_daemon_error_has_stable_remedy(tmp_path, capsys) -> None:
+def test_gc_json_daemon_error_has_stable_remedy(tmp_path, capsys, monkeypatch) -> None:
+    from bosn import daemon
+
+    def unavailable(*_args, **_kwargs):
+        raise daemon.DaemonError("down")
+
+    monkeypatch.setattr(daemon, "request", unavailable)
     assert cli.main(["--state-dir", str(tmp_path), "gc", "--json"]) == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["code"] == "daemon.unreachable"


### PR DESCRIPTION
Implements #42's core task dispatch, registry-backed 	asks --json readiness, and stable JSON manifest/discovery errors. Structured remedies for every command path remain in progress.