### PR TITLE
fix: validate lease holders by process start identity

### DIFF
--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -886,7 +886,10 @@ class Converger:
                     self.registry.acquire_lease(
                         dependency.id,
                         pid=os.getpid(),
-                        proc_start=process_start_time(os.getpid()) or self.registry.clock.now(),
+                        # None falls through to the PID-only liveness check rather than a
+                        # wall-clock guess that could later mismatch the real process start
+                        # and make a live holder's lease look expired (see process_alive).
+                        proc_start=process_start_time(os.getpid()),
                     )
                     for dependency in dependencies
                 )

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -29,6 +29,31 @@ REGISTERED = "registered"
 ROLLED = "rolled"
 CONTAINER_HEARTBEAT_TIMEOUT_SECONDS = 600
 
+# process_start_time() is a subprocess-spawning probe (~0.35s measured on Windows via
+# PowerShell) but its answer is constant for the life of this process, so it is memoized
+# here rather than re-probed once per lease dependency. Keyed on pid so a fork into a child
+# process (a different pid) cannot reuse the parent's cached value.
+_own_process_start_time_cache: tuple[int, float | None] | None = None
+
+
+def _own_process_start_time() -> float | None:
+    """Memoized ``process_start_time(os.getpid())`` for the current process.
+
+    Deliberately does not cache a ``None`` result: a probe failure may be transient (e.g. a
+    momentarily unavailable PowerShell/WMI provider), and re-probing outside any lock is
+    cheap, whereas caching ``None`` would downgrade every lease acquired by this process for
+    its entire lifetime to PID-only identity.
+    """
+    global _own_process_start_time_cache
+    pid = os.getpid()
+    cached = _own_process_start_time_cache
+    if cached is not None and cached[0] == pid:
+        return cached[1]
+    value = process_start_time(pid)
+    if value is not None:
+        _own_process_start_time_cache = (pid, value)
+    return value
+
 
 @dataclass(frozen=True)
 class ConvergeResult:
@@ -866,6 +891,18 @@ class Converger:
     def _acquire_execution_container(
         self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
     ) -> tuple[str, tuple[Lease, ...]]:
+        # Computed before the write lock, not inside it: process_start_time() spawns a
+        # subprocess (~0.35s measured via PowerShell on Windows), and lifecycle_guard() holds
+        # a cross-process `BEGIN IMMEDIATE` exclusive write lock. Probing once per dependency
+        # inside that lock would hold it for an extra ~1.5s per converge (container + image +
+        # N volumes), pushing concurrent daemon writers -- which only have a 5s busy_timeout
+        # -- toward "database is locked". The value is constant for the life of this process,
+        # so one memoized probe outside the lock serves every dependency's lease.
+        #
+        # None falls through to the PID-only liveness check rather than a wall-clock guess
+        # that could later mismatch the real process start and make a live holder's lease
+        # look expired (see process_alive).
+        proc_start = _own_process_start_time()
         with self.registry.lifecycle_guard():
             name, container_id, resource, created = self._ensure_container_locked(
                 converged, stack_name=stack_name, workspace=workspace
@@ -886,10 +923,7 @@ class Converger:
                     self.registry.acquire_lease(
                         dependency.id,
                         pid=os.getpid(),
-                        # None falls through to the PID-only liveness check rather than a
-                        # wall-clock guess that could later mismatch the real process start
-                        # and make a live holder's lease look expired (see process_alive).
-                        proc_start=process_start_time(os.getpid()),
+                        proc_start=proc_start,
                     )
                     for dependency in dependencies
                 )

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -21,7 +21,7 @@ from bosn import labels
 from bosn.engine import Engine, EngineError
 from bosn.manifest import Manifest, StackSpec, dockerfile_external_images, generation_digest
 from bosn.registry import Lease, Registry, Resource
-from bosn.resources import ResourceScanner
+from bosn.resources import ResourceScanner, process_start_time
 
 # What converge did, in the order of increasing work.
 REUSED = "reused"
@@ -886,7 +886,7 @@ class Converger:
                     self.registry.acquire_lease(
                         dependency.id,
                         pid=os.getpid(),
-                        proc_start=self.registry.clock.now(),
+                        proc_start=process_start_time(os.getpid()) or self.registry.clock.now(),
                     )
                     for dependency in dependencies
                 )

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -419,6 +419,7 @@ class Daemon:
         """Execute a maintenance pass, recording every outcome and scheduling its retry."""
         from bosn.engine import Engine
         from bosn.gc import Collector
+        from bosn.resources import prune_dead_leases
 
         self.registry.log_event("maintenance.reap.started")
         try:
@@ -432,6 +433,17 @@ class Daemon:
             self.registry.log_event("maintenance.reap.error", f"{type(exc).__name__}: {exc}")
             self._set_next_maintenance(self.clock.now() + self.maintenance_interval_seconds)
             return
+
+        self.registry.log_event("maintenance.prune_leases.started")
+        try:
+            pruned = prune_dead_leases(self.registry)
+            self.registry.log_event("maintenance.prune_leases.finished", f"pruned={len(pruned)}")
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - a pruning failure must be visible, not silent
+            self.registry.log_event(
+                "maintenance.prune_leases.error", f"{type(exc).__name__}: {exc}"
+            )
 
         engine = Engine(self.engine_binary)
         info = engine.info()

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -133,6 +133,10 @@ class Lease:
         return (now - self.heartbeat_at) > self.ttl_seconds
 
 
+class RegistryError(RuntimeError):
+    """A schema migration could not be completed safely."""
+
+
 class Registry:
     """A WAL-mode sqlite registry. Use as a context manager or call close()."""
 
@@ -289,16 +293,40 @@ class Registry:
             "(resource_id, workspace, stack, generation, last_used, state) "
             "SELECT id, workspace, stack, generation, last_used, state FROM resources"
         )
-        self._relax_lease_proc_start_nullability()
+        # Not gated on SCHEMA_VERSION like the v1->v2 step above: this shape change is
+        # backward-compatible (a NOT-NULL writer's INSERT still satisfies a nullable column,
+        # so an old and a new binary can both operate on either shape) and it is safe to run
+        # every open, so `PRAGMA table_info` introspection is the simpler, idempotent gate.
+        # Bumping SCHEMA_VERSION would only be needed if a future change made the old shape
+        # actively unsafe to read/write, which this one does not.
+        try:
+            self._relax_lease_proc_start_nullability()
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:
+            raise RegistryError(
+                "registry migration 'relax_lease_proc_start_nullability' failed: "
+                f"{type(exc).__name__}: {exc}; the database was left unchanged (the migration "
+                "runs in its own transaction), so retry opening the registry -- if this "
+                "persists, back up and remove the registry file to rebuild it by rescanning "
+                "engine labels"
+            ) from exc
 
     def _relax_lease_proc_start_nullability(self) -> None:
         """Allow ``proc_start`` to be NULL for PID-only leases.
 
-        Databases created before this change have ``leases.proc_start REAL NOT NULL``.
-        A wall-clock fallback there is dangerous: if the identity probe fails at acquire
-        time but succeeds later during a liveness check, the stored value would not match
-        the process's real start time and a live holder's lease could look expired. SQLite
-        has no ``ALTER COLUMN``, so relaxing the constraint means rebuilding the table.
+        Databases created before this change have ``leases.proc_start REAL NOT NULL``. Every
+        row already stored there is a wall-clock guess, not a real process identity: the
+        pre-migration ``converge.py`` wrote ``registry.clock.now()`` at acquire time, which
+        essentially never matches the holder's real process start time (that would require
+        acquiring the lease within the liveness check's tolerance of the process's own
+        launch). Carrying that guess forward as if it were identity is actively dangerous --
+        a later liveness check would compare it against the real start time, find a mismatch,
+        and judge a live holder's lease expired, letting GC reap an in-use resource. So this
+        rebuild does not preserve legacy ``proc_start`` values at all: every migrated lease
+        becomes PID-only (``proc_start IS NULL``), which is exactly the semantics the nullable
+        column exists to express, and falls through to the safe PID-only liveness check.
+        SQLite has no ``ALTER COLUMN``, so relaxing the constraint means rebuilding the table.
         """
         columns = self.conn.execute("PRAGMA table_info(leases)").fetchall()
         proc_start_column = next((c for c in columns if c["name"] == "proc_start"), None)
@@ -319,7 +347,7 @@ class Registry:
             self.conn.execute(
                 "INSERT INTO leases_nullable"
                 "(id, resource_id, pid, proc_start, acquired_at, heartbeat_at, ttl_seconds) "
-                "SELECT id, resource_id, pid, proc_start, acquired_at, heartbeat_at, "
+                "SELECT id, resource_id, pid, NULL, acquired_at, heartbeat_at, "
                 "ttl_seconds FROM leases"
             )
             self.conn.execute("DROP TABLE leases")

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS leases (
     id            TEXT PRIMARY KEY,
     resource_id   TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
     pid           INTEGER NOT NULL,
-    proc_start    REAL NOT NULL,
+    proc_start    REAL,
     acquired_at   REAL NOT NULL,
     heartbeat_at  REAL NOT NULL,
     ttl_seconds   REAL NOT NULL
@@ -124,7 +124,7 @@ class Lease:
     id: str
     resource_id: str
     pid: int
-    proc_start: float
+    proc_start: float | None
     acquired_at: float
     heartbeat_at: float
     ttl_seconds: float
@@ -289,6 +289,51 @@ class Registry:
             "(resource_id, workspace, stack, generation, last_used, state) "
             "SELECT id, workspace, stack, generation, last_used, state FROM resources"
         )
+        self._relax_lease_proc_start_nullability()
+
+    def _relax_lease_proc_start_nullability(self) -> None:
+        """Allow ``proc_start`` to be NULL for PID-only leases.
+
+        Databases created before this change have ``leases.proc_start REAL NOT NULL``.
+        A wall-clock fallback there is dangerous: if the identity probe fails at acquire
+        time but succeeds later during a liveness check, the stored value would not match
+        the process's real start time and a live holder's lease could look expired. SQLite
+        has no ``ALTER COLUMN``, so relaxing the constraint means rebuilding the table.
+        """
+        columns = self.conn.execute("PRAGMA table_info(leases)").fetchall()
+        proc_start_column = next((c for c in columns if c["name"] == "proc_start"), None)
+        if proc_start_column is None or not proc_start_column["notnull"]:
+            return
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            self.conn.execute(
+                "CREATE TABLE leases_nullable ("
+                "id TEXT PRIMARY KEY, "
+                "resource_id TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE, "
+                "pid INTEGER NOT NULL, "
+                "proc_start REAL, "
+                "acquired_at REAL NOT NULL, "
+                "heartbeat_at REAL NOT NULL, "
+                "ttl_seconds REAL NOT NULL)"
+            )
+            self.conn.execute(
+                "INSERT INTO leases_nullable"
+                "(id, resource_id, pid, proc_start, acquired_at, heartbeat_at, ttl_seconds) "
+                "SELECT id, resource_id, pid, proc_start, acquired_at, heartbeat_at, "
+                "ttl_seconds FROM leases"
+            )
+            self.conn.execute("DROP TABLE leases")
+            self.conn.execute("ALTER TABLE leases_nullable RENAME TO leases")
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_leases_resource ON leases(resource_id)"
+            )
+            self.conn.execute("COMMIT")
+        except KeyboardInterrupt:
+            self.conn.execute("ROLLBACK")
+            raise
+        except Exception:
+            self.conn.execute("ROLLBACK")
+            raise
 
     def _deduplicate_resources(self) -> None:
         duplicates = self.conn.execute(
@@ -644,7 +689,7 @@ class Registry:
         resource_id: str,
         *,
         pid: int,
-        proc_start: float,
+        proc_start: float | None,
         ttl_seconds: float = 900.0,
     ) -> Lease:
         now = self.clock.now()
@@ -673,12 +718,26 @@ class Registry:
         rows = self._exec("SELECT * FROM leases WHERE resource_id = ?", (resource_id,)).fetchall()
         return [_lease_from_row(row) for row in rows]
 
+    def all_leases(self) -> list[Lease]:
+        rows = self._exec("SELECT * FROM leases").fetchall()
+        return [_lease_from_row(row) for row in rows]
+
     def heartbeat(self, lease_id: str) -> None:
         self._exec("UPDATE leases SET heartbeat_at = ? WHERE id = ?", (self.clock.now(), lease_id))
 
     def release_lease(self, lease_id: str) -> None:
         self._exec("DELETE FROM leases WHERE id = ?", (lease_id,))
         self.log_event("lease.released", lease_id)
+
+    def prune_lease(self, lease_id: str) -> None:
+        """Delete a confirmed-dead lease found during maintenance.
+
+        A distinct event from ``lease.released`` -- that one is a holder's own graceful
+        release, this one is the daemon reclaiming a lease whose holder is gone. Deleting a
+        row that is already gone is a silent no-op, which is what keeps pruning idempotent.
+        """
+        self._exec("DELETE FROM leases WHERE id = ?", (lease_id,))
+        self.log_event("lease.pruned", lease_id)
 
     # -- generations -------------------------------------------------------
 

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -201,7 +201,7 @@ def _parse_linux_process_start(
             if line.startswith("btime ")
         )
         return boot + (ticks / clock_ticks_per_sec)
-    except (IndexError, ValueError, StopIteration):
+    except (IndexError, ValueError, StopIteration, ZeroDivisionError):
         return None
 
 
@@ -223,25 +223,36 @@ def process_start_time(pid: int) -> float | None:
     if pid <= 0:
         return None
     if os.name == "nt":
-        # WMIC is removed on current Windows; PowerShell's CIM provider is available on
-        # every supported v1 host and returns the creation time without name guessing.
+        # WMIC is removed on current Windows; the CIM provider (Get-CimInstance) is
+        # available on every supported v1 host and returns the creation time without name
+        # guessing *and* without throwing on another user's process the way
+        # `(Get-Process -Id $pid).StartTime` does (access-denied there surfaces as a
+        # null-valued-expression error on stderr, which is discarded below).
         # Note: this spawns a PowerShell process (~1s) per call. process_alive() only
         # invokes it once a lease's TTL has already elapsed, so it is not on the hot path
         # of a normal heartbeat -- but a maintenance sweep iterating many expired leases
         # pays this cost per lease. A cache is deliberately not added here: keying on pid
         # alone is unsafe across PID reuse in a long-lived daemon, and there is no cheap
         # cache key (pid, start) available before the very probe the cache would replace.
-        result = subprocess.run(
-            [
-                "powershell",
-                "-NoProfile",
-                "-Command",
-                f"(Get-Process -Id {pid}).StartTime.ToUniversalTime().Ticks",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    f"(Get-CimInstance Win32_Process -Filter 'ProcessId={pid}')"
+                    ".CreationDate.ToUniversalTime().Ticks",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            # Probe unavailable (missing/wedged powershell, timeout): process_alive()
+            # treats a None start time as "identity unknown" and fails open rather than
+            # ever deleting a resource that might belong to a live process.
+            return None
         return _parse_windows_process_start(result.stdout)
     if sys.platform == "linux":
         try:
@@ -250,11 +261,25 @@ def process_start_time(pid: int) -> float | None:
             clock_ticks_per_sec = os.sysconf("SC_CLK_TCK")
         except OSError:
             return None
+        if clock_ticks_per_sec is None or clock_ticks_per_sec <= 0:
+            return None
         return _parse_linux_process_start(stat_text, proc_stat_text, clock_ticks_per_sec)
     if sys.platform == "darwin":
-        result = subprocess.run(
-            ["ps", "-p", str(pid), "-o", "lstart="], capture_output=True, text=True, check=False
-        )
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "lstart="],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+                # `ps`'s day/month names (%a/%b) follow LC_TIME; pin to the "C" locale so
+                # the fixed English format `_parse_darwin_process_start` expects can never
+                # silently degrade identity checking to PID-only under a non-English locale.
+                env={**os.environ, "LC_ALL": "C"},
+            )
+        except (OSError, subprocess.SubprocessError):
+            # See the Windows branch above: probe unavailable -> fail open, never deletes.
+            return None
         return _parse_darwin_process_start(result.stdout)
     return None
 
@@ -273,6 +298,13 @@ def process_alive(pid: int, proc_start: float | None = None) -> bool:
     except ProcessLookupError:
         return False
     except PermissionError:
+        return True
+    except SystemError:
+        # Windows: os.kill(pid, 0) on another user's/SYSTEM's process raises SystemError
+        # (CPython returns a result with ERROR_ACCESS_DENIED still set as an exception,
+        # which is not an OSError subclass and would otherwise escape every handler here).
+        # Access-denied means the process exists and we cannot see it: treat as alive, the
+        # same fail-open posture as PermissionError above.
         return True
     except OSError:
         return False

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -13,6 +13,7 @@ Automatic deletion requires complete ownership proof, which is why there is no `
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import subprocess
@@ -173,13 +174,63 @@ class ResourceScanner:
 PROCESS_START_TOLERANCE_SECONDS = 2.0
 
 
+def _parse_windows_process_start(ticks_text: str) -> float | None:
+    """Parse .NET ``DateTime.Ticks`` (100ns units since 0001-01-01) into an epoch float."""
+    try:
+        return (int(ticks_text.strip()) / 10_000_000) - 62_135_596_800
+    except ValueError:
+        return None
+
+
+def _parse_linux_process_start(
+    stat_text: str, proc_stat_text: str, clock_ticks_per_sec: float
+) -> float | None:
+    """Parse ``/proc/<pid>/stat`` field 22 (starttime, in clock ticks since boot).
+
+    ``stat_text`` is the raw content of ``/proc/<pid>/stat``; the comm field can itself
+    contain spaces or parens, so the split happens after the last ``)``. ``proc_stat_text``
+    is the raw content of ``/proc/stat``, which supplies the boot time (``btime``, seconds
+    since epoch) that the tick count is relative to.
+    """
+    try:
+        fields = stat_text.rsplit(")", 1)[1].split()
+        ticks = int(fields[19])
+        boot = next(
+            int(line.split()[1])
+            for line in proc_stat_text.splitlines()
+            if line.startswith("btime ")
+        )
+        return boot + (ticks / clock_ticks_per_sec)
+    except (IndexError, ValueError, StopIteration):
+        return None
+
+
+def _parse_darwin_process_start(lstart_text: str) -> float | None:
+    """Parse ``ps -o lstart=`` output, e.g. ``Thu Aug 13 09:41:02 2026``."""
+    try:
+        return dt.datetime.strptime(lstart_text.strip(), "%a %b %d %H:%M:%S %Y").timestamp()
+    except ValueError:
+        return None
+
+
 def process_start_time(pid: int) -> float | None:
-    """Return an epoch creation time from an OS-owned process identity source."""
+    """Return an epoch creation time from an OS-owned process identity source.
+
+    This is a thin per-OS dispatch: it gathers the raw platform data (a subprocess call on
+    Windows/macOS, `/proc` reads on Linux) and hands it to a pure parsing helper so the
+    parsing logic itself can be unit-tested on any OS with captured sample input.
+    """
     if pid <= 0:
         return None
     if os.name == "nt":
         # WMIC is removed on current Windows; PowerShell's CIM provider is available on
         # every supported v1 host and returns the creation time without name guessing.
+        # Note: this spawns a PowerShell process (~1s) per call. process_alive() only
+        # invokes it once a lease's TTL has already elapsed, so it is not on the hot path
+        # of a normal heartbeat -- but a maintenance sweep iterating many expired leases
+        # pays this cost per lease. A cache is deliberately not added here: keying on pid
+        # alone is unsafe across PID reuse in a long-lived daemon, and there is no cheap
+        # cache key (pid, start) available before the very probe the cache would replace.
         result = subprocess.run(
             [
                 "powershell",
@@ -191,32 +242,20 @@ def process_start_time(pid: int) -> float | None:
             text=True,
             check=False,
         )
-        try:
-            return (int(result.stdout.strip()) / 10_000_000) - 62_135_596_800
-        except ValueError:
-            return None
+        return _parse_windows_process_start(result.stdout)
     if sys.platform == "linux":
         try:
-            fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(")", 1)[1].split()
-            ticks = int(fields[19])
-            boot = next(
-                int(line.split()[1])
-                for line in Path("/proc/stat").read_text(encoding="utf-8").splitlines()
-                if line.startswith("btime ")
-            )
-            return boot + (ticks / os.sysconf("SC_CLK_TCK"))
-        except (OSError, ValueError, StopIteration):
+            stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+            proc_stat_text = Path("/proc/stat").read_text(encoding="utf-8")
+            clock_ticks_per_sec = os.sysconf("SC_CLK_TCK")
+        except OSError:
             return None
+        return _parse_linux_process_start(stat_text, proc_stat_text, clock_ticks_per_sec)
     if sys.platform == "darwin":
         result = subprocess.run(
             ["ps", "-p", str(pid), "-o", "lstart="], capture_output=True, text=True, check=False
         )
-        try:
-            import datetime as dt
-
-            return dt.datetime.strptime(result.stdout.strip(), "%a %b %d %H:%M:%S %Y").timestamp()
-        except ValueError:
-            return None
+        return _parse_darwin_process_start(result.stdout)
     return None
 
 
@@ -263,6 +302,23 @@ def resource_is_leased(registry: Registry, resource_id: str, *, alive_probe=proc
         not lease_is_expired(lease, now, alive_probe=alive_probe)
         for lease in registry.leases_for(resource_id)
     )
+
+
+def prune_dead_leases(registry: Registry, *, alive_probe=process_alive) -> list[str]:
+    """Delete every lease that is both expired by time and confirmed dead.
+
+    Reuses ``lease_is_expired`` so pruning applies exactly the same liveness proof as the
+    rest of the lease lifecycle -- a lease is never deleted on TTL alone. Idempotent: a
+    pruned lease's row is gone, so a second pass finds nothing left to prune and returns an
+    empty list without error.
+    """
+    now = registry.clock.now()
+    pruned: list[str] = []
+    for lease in registry.all_leases():
+        if lease_is_expired(lease, now, alive_probe=alive_probe):
+            registry.prune_lease(lease.id)
+            pruned.append(lease.id)
+    return pruned
 
 
 # -- adoption --------------------------------------------------------------

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -14,7 +14,11 @@ Automatic deletion requires complete ownership proof, which is why there is no `
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from bosn import labels
 from bosn.clock import Clock, SystemClock
@@ -166,6 +170,56 @@ class ResourceScanner:
 # -- leases ----------------------------------------------------------------
 
 
+PROCESS_START_TOLERANCE_SECONDS = 2.0
+
+
+def process_start_time(pid: int) -> float | None:
+    """Return an epoch creation time from an OS-owned process identity source."""
+    if pid <= 0:
+        return None
+    if os.name == "nt":
+        # WMIC is removed on current Windows; PowerShell's CIM provider is available on
+        # every supported v1 host and returns the creation time without name guessing.
+        result = subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                f"(Get-Process -Id {pid}).StartTime.ToUniversalTime().Ticks",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        try:
+            return (int(result.stdout.strip()) / 10_000_000) - 62_135_596_800
+        except ValueError:
+            return None
+    if sys.platform == "linux":
+        try:
+            fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(")", 1)[1].split()
+            ticks = int(fields[19])
+            boot = next(
+                int(line.split()[1])
+                for line in Path("/proc/stat").read_text(encoding="utf-8").splitlines()
+                if line.startswith("btime ")
+            )
+            return boot + (ticks / os.sysconf("SC_CLK_TCK"))
+        except (OSError, ValueError, StopIteration):
+            return None
+    if sys.platform == "darwin":
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="], capture_output=True, text=True, check=False
+        )
+        try:
+            import datetime as dt
+
+            return dt.datetime.strptime(result.stdout.strip(), "%a %b %d %H:%M:%S %Y").timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 def process_alive(pid: int, proc_start: float | None = None) -> bool:
     """Liveness probe for a lease holder.
 
@@ -176,8 +230,6 @@ def process_alive(pid: int, proc_start: float | None = None) -> bool:
     if pid <= 0:
         return False
     try:
-        import os
-
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
@@ -185,7 +237,12 @@ def process_alive(pid: int, proc_start: float | None = None) -> bool:
         return True
     except OSError:
         return False
-    return True
+    if proc_start is None:
+        return True
+    actual = process_start_time(pid)
+    # An unavailable identity probe fails conservatively: it may leak a lease but never
+    # deletes resources belonging to a live process.
+    return actual is None or abs(actual - proc_start) <= PROCESS_START_TOLERANCE_SECONDS
 
 
 def lease_is_expired(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from bosn.engine import Engine, engine_reachable
+from bosn.resources import process_start_time
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +16,25 @@ def isolated_state_dir(tmp_path_factory, monkeypatch) -> None:
     state_dir = tmp_path_factory.mktemp("bosn-state")
     monkeypatch.setenv("BOSN_STATE_DIR", str(state_dir))
     monkeypatch.delenv("BOSN_PORT", raising=False)
+
+
+_LIVE_PROC_START: float | None = None
+_LIVE_PROC_START_PROBED = False
+
+
+def live_proc_start() -> float | None:
+    """The real process creation time of the test process, for tests that hold a lease.
+
+    A lease whose ``proc_start`` is a wall-clock guess no longer survives its TTL: liveness
+    now proves holder identity, not just the PID. Tests that mean "this live process holds
+    the lease" must therefore store the identity the probe will actually report. Probed once
+    per session because the Windows probe spawns a PowerShell process.
+    """
+    global _LIVE_PROC_START, _LIVE_PROC_START_PROBED
+    if not _LIVE_PROC_START_PROBED:
+        _LIVE_PROC_START = process_start_time(os.getpid())
+        _LIVE_PROC_START_PROBED = True
+    return _LIVE_PROC_START
 
 
 _ENGINE_REACHABLE: bool | None = None

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -25,6 +25,7 @@ from bosn.converge import (
 from bosn.engine import EngineError, EngineResult
 from bosn.manifest import load
 from bosn.registry import Registry
+from conftest import live_proc_start
 
 SAMPLE = """
 [stack.test]
@@ -1134,7 +1135,7 @@ def test_active_execution_lease_prevents_generation_replacement(
     first, code, _output = converger.run(["true"])
     assert code == 0
     resource = next(row for row in registry.list_resources() if row.kind == "container")
-    lease = registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=registry.clock.now())
+    lease = registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=live_proc_start())
     try:
         (project / "Dockerfile").write_text("FROM alpine\nRUN echo changed\n", encoding="utf-8")
         rolled_converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -335,6 +335,110 @@ def test_maintenance_deadline_persists_across_scheduler_wake(monkeypatch, tmp_pa
         wake.registry.close()
 
 
+def test_maintenance_logs_prune_leases_started_and_finished(monkeypatch, tmp_path: Path) -> None:
+    """Issue #45's dead-lease cleanup must be observable, not just idempotent."""
+    clock = FakeClock()
+
+    class ReachableEngine:
+        def __init__(self, _binary: str) -> None:
+            pass
+
+        def info(self) -> EngineInfo:
+            return EngineInfo(binary="docker", reachable=True)
+
+    class RecordingCollector:
+        def __init__(self, _registry, _engine, *, config=None) -> None:
+            pass
+
+        def collect(self, **_kwargs):
+            class Result:
+                def summary(self):
+                    return {"removed": 0}
+
+            return Result()
+
+    import bosn.engine
+    import bosn.gc
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.engine, "Engine", ReachableEngine)
+    monkeypatch.setattr(bosn.gc, "Collector", RecordingCollector)
+    monkeypatch.setattr(bosn.resources, "prune_dead_leases", lambda _registry: ["lease-1"])
+    daemon = Daemon(state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60)
+    try:
+        assert daemon.run_maintenance_if_due() is True
+        # events() returns newest-first; reverse to read the pass in chronological order.
+        events = [(row["kind"], row["detail"]) for row in reversed(daemon.registry.events())]
+        kinds = [kind for kind, _detail in events]
+        assert "maintenance.prune_leases.started" in kinds
+        assert ("maintenance.prune_leases.finished", "pruned=1") in events
+        # Prune runs strictly between reap and gc.
+        assert kinds.index("maintenance.reap.finished") < kinds.index(
+            "maintenance.prune_leases.started"
+        )
+        assert kinds.index("maintenance.prune_leases.finished") < kinds.index(
+            "maintenance.gc.started"
+        )
+    finally:
+        daemon.registry.close()
+
+
+def test_maintenance_prune_leases_failure_is_logged_and_does_not_block_gc(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A pruning failure must be visible, and the pass must still continue on to GC."""
+    clock = FakeClock()
+
+    class ReachableEngine:
+        def __init__(self, _binary: str) -> None:
+            pass
+
+        def info(self) -> EngineInfo:
+            return EngineInfo(binary="docker", reachable=True)
+
+    gc_calls: list[str] = []
+
+    class RecordingCollector:
+        def __init__(self, _registry, _engine, *, config=None) -> None:
+            pass
+
+        def collect(self, **_kwargs):
+            gc_calls.append("gc")
+
+            class Result:
+                def summary(self):
+                    return {"removed": 0}
+
+            return Result()
+
+    def _boom(_registry):
+        raise RuntimeError("lease table is locked")
+
+    import bosn.engine
+    import bosn.gc
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.engine, "Engine", ReachableEngine)
+    monkeypatch.setattr(bosn.gc, "Collector", RecordingCollector)
+    monkeypatch.setattr(bosn.resources, "prune_dead_leases", _boom)
+    daemon = Daemon(state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60)
+    try:
+        assert daemon.run_maintenance_if_due() is True
+        events = [(row["kind"], row["detail"]) for row in daemon.registry.events()]
+        kinds = [kind for kind, _detail in events]
+        assert "maintenance.prune_leases.started" in kinds
+        assert any(
+            kind == "maintenance.prune_leases.error" and "lease table is locked" in detail
+            for kind, detail in events
+        )
+        assert "maintenance.prune_leases.finished" not in kinds
+        # A pruning failure must not block the rest of the maintenance pass.
+        assert "maintenance.gc.started" in kinds
+        assert gc_calls == ["gc"]
+    finally:
+        daemon.registry.close()
+
+
 def test_malformed_persisted_maintenance_deadline_recovers(tmp_path: Path) -> None:
     clock = FakeClock()
     registry_path = tmp_path / "registry.sqlite3"

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -19,6 +19,7 @@ from bosn.engine import EngineResult
 from bosn.gc import Collector, done_workspaces, mark_done, status
 from bosn.registry import Registry
 from bosn.retention import DAY
+from conftest import live_proc_start
 
 OURS = "our-registry"
 
@@ -285,7 +286,7 @@ def test_live_lease_prevents_idle_stop_even_in_apply_mode(
     registry: Registry, clock: FakeClock
 ) -> None:
     resource = add(registry, "active", kind="container")
-    registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+    registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=live_proc_start())
     engine = FakeEngine({"active": label_dict(registry=registry.registry_id, kind="container")})
     clock.advance(2 * 3600)
 
@@ -340,7 +341,7 @@ def test_lease_acquired_after_planning_is_seen_before_idle_stop(
 
     def plan_then_lease(*args, **kwargs):
         verdicts = original_plan(*args, **kwargs)
-        registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+        registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=live_proc_start())
         return verdicts
 
     monkeypatch.setattr(gc_mod, "plan", plan_then_lease)
@@ -362,7 +363,7 @@ def test_dependency_lease_acquired_after_planning_is_seen_before_removal(
 
     def plan_then_lease(*args, **kwargs):
         verdicts = original_plan(*args, **kwargs)
-        registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+        registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=live_proc_start())
         return verdicts
 
     monkeypatch.setattr(gc_mod, "plan", plan_then_lease)
@@ -414,7 +415,7 @@ def test_idle_stop_serializes_concurrent_lease_acquisition(
 
     def acquire() -> None:
         attempting.set()
-        other.acquire_lease(resource.id, pid=os.getpid(), proc_start=clock.now())
+        other.acquire_lease(resource.id, pid=os.getpid(), proc_start=live_proc_start())
         engine.lease_acquired.set()
 
     thread = threading.Thread(target=acquire)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -336,3 +336,58 @@ def test_read_only_registry_refuses_missing_database_without_creating_it(tmp_pat
     with pytest.raises(sqlite3.OperationalError):
         Registry(path, read_only=True)
     assert not path.exists()
+
+
+def test_a_legacy_not_null_proc_start_column_is_rebuilt_as_nullable(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    """Databases created before PID-identity leases declared ``proc_start REAL NOT NULL``.
+
+    A failed identity probe must now store NULL rather than a wall-clock guess, so opening
+    an old database has to rebuild the table (sqlite has no ALTER COLUMN). The rebuild must
+    preserve existing lease rows, or reopening the registry after an upgrade would silently
+    drop every held lease and expose live resources to collection.
+    """
+    path = tmp_path / "registry.sqlite3"
+    with Registry(path, clock=clock) as reg:
+        resource = reg.register_resource(
+            kind="volume",
+            name="legacy-cache",
+            stack="test",
+            generation="sha256:g",
+            scope="spec",
+            workspace="/w",
+        )
+        resource_id = resource.id
+
+    # Recreate the pre-migration schema with a row in it, exactly as an old daemon left it.
+    legacy = sqlite3.connect(str(path), isolation_level=None)
+    legacy.execute("DROP TABLE leases")
+    legacy.execute(
+        "CREATE TABLE leases ("
+        "id TEXT PRIMARY KEY, "
+        "resource_id TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE, "
+        "pid INTEGER NOT NULL, "
+        "proc_start REAL NOT NULL, "
+        "acquired_at REAL NOT NULL, "
+        "heartbeat_at REAL NOT NULL, "
+        "ttl_seconds REAL NOT NULL)"
+    )
+    legacy.execute(
+        "INSERT INTO leases VALUES ('old-lease', ?, 4242, 1.5, 0.0, 0.0, 900.0)", (resource_id,)
+    )
+    legacy.close()
+
+    with Registry(path, clock=clock) as reg:
+        survived = reg.get_lease("old-lease")
+        assert survived is not None, "the rebuild must not drop existing leases"
+        assert survived.pid == 4242
+        assert survived.proc_start == 1.5
+
+        # The whole point of the rebuild: NULL is now accepted.
+        pid_only = reg.acquire_lease(resource_id, pid=99, proc_start=None)
+        assert pid_only.proc_start is None
+
+        columns = reg.conn.execute("PRAGMA table_info(leases)").fetchall()
+        proc_start = next(c for c in columns if c["name"] == "proc_start")
+        assert not proc_start["notnull"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from bosn.clock import FakeClock
-from bosn.registry import Registry
+from bosn.registry import Registry, RegistryError
 
 
 @pytest.fixture
@@ -345,8 +345,15 @@ def test_a_legacy_not_null_proc_start_column_is_rebuilt_as_nullable(
 
     A failed identity probe must now store NULL rather than a wall-clock guess, so opening
     an old database has to rebuild the table (sqlite has no ALTER COLUMN). The rebuild must
-    preserve existing lease rows, or reopening the registry after an upgrade would silently
-    drop every held lease and expose live resources to collection.
+    preserve existing lease *rows*, or reopening the registry after an upgrade would silently
+    drop every held lease and expose live resources to collection. But it must NOT preserve
+    the legacy ``proc_start`` *value*: every pre-migration value is a wall-clock guess (the
+    old ``converge.py`` stored ``registry.clock.now()`` at acquire time, not a real process
+    start time), so carrying it forward would let a later liveness check compare a live
+    holder's real start time against that guess, find a mismatch, and treat the lease as
+    expired -- exactly the bug this migration exists to prevent. The migration therefore
+    rewrites every legacy row's ``proc_start`` to NULL, downgrading it to a PID-only lease
+    rather than preserving bogus identity.
     """
     path = tmp_path / "registry.sqlite3"
     with Registry(path, clock=clock) as reg:
@@ -382,7 +389,7 @@ def test_a_legacy_not_null_proc_start_column_is_rebuilt_as_nullable(
         survived = reg.get_lease("old-lease")
         assert survived is not None, "the rebuild must not drop existing leases"
         assert survived.pid == 4242
-        assert survived.proc_start == 1.5
+        assert survived.proc_start is None, "legacy proc_start is a wall-clock guess, not identity"
 
         # The whole point of the rebuild: NULL is now accepted.
         pid_only = reg.acquire_lease(resource_id, pid=99, proc_start=None)
@@ -391,3 +398,40 @@ def test_a_legacy_not_null_proc_start_column_is_rebuilt_as_nullable(
         columns = reg.conn.execute("PRAGMA table_info(leases)").fetchall()
         proc_start = next(c for c in columns if c["name"] == "proc_start")
         assert not proc_start["notnull"]
+
+
+def test_a_failed_proc_start_migration_raises_a_named_recoverable_error(
+    tmp_path: Path, clock: FakeClock
+) -> None:
+    """A migration failure must not brick the registry behind an opaque sqlite traceback.
+
+    Simulate a realistic trigger: an orphan ``leases`` row (its ``resource_id`` points at a
+    resource that no longer exists) fails the foreign key check when copied into the rebuilt
+    table. The failure must surface as a ``RegistryError`` that names the migration and gives
+    a next step, not a bare ``sqlite3.IntegrityError`` from deep inside ``__init__``.
+    """
+    path = tmp_path / "registry.sqlite3"
+    with Registry(path, clock=clock):
+        pass  # create a fresh v2+ database with the current schema
+
+    legacy = sqlite3.connect(str(path), isolation_level=None)
+    legacy.execute("DROP TABLE leases")
+    legacy.execute(
+        "CREATE TABLE leases ("
+        "id TEXT PRIMARY KEY, "
+        "resource_id TEXT NOT NULL REFERENCES resources(id) ON DELETE CASCADE, "
+        "pid INTEGER NOT NULL, "
+        "proc_start REAL NOT NULL, "
+        "acquired_at REAL NOT NULL, "
+        "heartbeat_at REAL NOT NULL, "
+        "ttl_seconds REAL NOT NULL)"
+    )
+    # foreign_keys defaults to off on a raw connection, so this orphan insert is allowed here
+    # but will fail the FK check once the migration rebuilds the table under foreign_keys=ON.
+    legacy.execute(
+        "INSERT INTO leases VALUES ('orphan-lease', 'no-such-resource', 1, 1.0, 0.0, 0.0, 900.0)"
+    )
+    legacy.close()
+
+    with pytest.raises(RegistryError, match="relax_lease_proc_start_nullability"):
+        Registry(path, clock=clock)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -6,6 +6,7 @@ Unit tests drive a fake engine, so they run everywhere without Docker.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -193,6 +194,17 @@ def test_a_dead_holder_releases_after_one_ttl(registry: Registry, clock: FakeClo
     clock.advance(2)
     assert resources.lease_is_expired(lease, clock.now(), alive_probe=dead)
     assert not resources.resource_is_leased(registry, resource.id, alive_probe=dead)
+
+
+def test_pid_reuse_with_a_different_process_start_releases_expired_lease(
+    registry: Registry, clock: FakeClock, monkeypatch
+) -> None:
+    resource = _resource(registry)
+    lease = registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=1.0, ttl_seconds=60)
+    monkeypatch.setattr(resources, "process_start_time", lambda _pid: 99.0)
+
+    clock.advance(61)
+    assert resources.lease_is_expired(lease, clock.now())
 
 
 def test_process_alive_probe_is_true_for_this_process() -> None:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,8 +5,11 @@ Unit tests drive a fake engine, so they run everywhere without Docker.
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -20,6 +23,10 @@ from bosn.resources import DiscoveredResource, ResourceScanner, ScanResult
 
 OURS = "our-registry-uuid"
 THEIRS = "someone-elses-uuid"
+
+
+def _dead(pid, start=None):
+    return False
 
 
 def label_dict(registry: str = OURS, **overrides: str) -> dict[str, str]:
@@ -187,14 +194,13 @@ def test_a_live_holder_keeps_its_lease_past_the_ttl(registry: Registry, clock: F
 def test_a_dead_holder_releases_after_one_ttl(registry: Registry, clock: FakeClock) -> None:
     resource = _resource(registry)
     lease = registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
-    dead = lambda pid, start=None: False  # noqa: E731
 
     clock.advance(59)
-    assert not resources.lease_is_expired(lease, clock.now(), alive_probe=dead)
+    assert not resources.lease_is_expired(lease, clock.now(), alive_probe=_dead)
 
     clock.advance(2)
-    assert resources.lease_is_expired(lease, clock.now(), alive_probe=dead)
-    assert not resources.resource_is_leased(registry, resource.id, alive_probe=dead)
+    assert resources.lease_is_expired(lease, clock.now(), alive_probe=_dead)
+    assert not resources.resource_is_leased(registry, resource.id, alive_probe=_dead)
 
 
 def test_pid_reuse_with_a_different_process_start_releases_expired_lease(
@@ -209,8 +215,6 @@ def test_pid_reuse_with_a_different_process_start_releases_expired_lease(
 
 
 def test_process_alive_probe_is_true_for_this_process() -> None:
-    import os
-
     assert resources.process_alive(os.getpid())
     assert not resources.process_alive(2**31 - 1)
     assert not resources.process_alive(0)
@@ -297,7 +301,6 @@ def test_parse_linux_process_start_rejects_malformed_input(
 def test_parse_darwin_process_start_parses_lstart_format() -> None:
     result = resources._parse_darwin_process_start("Thu Aug 13 09:41:02 2026\n")
     assert result is not None
-    import datetime as dt
 
     expected = dt.datetime.strptime("Thu Aug 13 09:41:02 2026", "%a %b %d %H:%M:%S %Y").timestamp()
     assert result == expected
@@ -318,6 +321,112 @@ def test_process_start_time_returns_a_plausible_epoch_for_this_process() -> None
     assert now - result < 30 * 24 * 3600
 
 
+# -- probe robustness (#45 pre-push review findings) ------------------------
+
+
+def test_process_alive_treats_windows_access_denied_system_error_as_alive(monkeypatch) -> None:
+    """os.kill(pid, 0) raises SystemError (not OSError) for another user's process on
+    Windows -- CPython returns a result with ERROR_ACCESS_DENIED still set as an exception.
+    SystemError escapes every existing except clause, so a poisoned lease aborted the whole
+    prune_dead_leases loop. Access-denied means the process exists: treat it as alive, same
+    fail-open posture as the PermissionError branch.
+    """
+
+    def _raises_system_error(pid: int, sig: int) -> None:
+        raise SystemError("<class 'OSError'> returned a result with an exception set")
+
+    monkeypatch.setattr(os, "kill", _raises_system_error)
+    assert resources.process_alive(4) is True
+
+
+def test_windows_process_start_probe_uses_cim_not_get_process(monkeypatch) -> None:
+    """Get-Process's .StartTime throws access-denied on another user's process, silently
+    yielding an empty stdout (stderr is discarded). Get-CimInstance does not have this
+    problem, and the code comment already claimed it was in use -- assert the real command.
+    """
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(args, **kwargs):
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, stdout="0\n", stderr="")
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    resources.process_start_time(4)
+
+    command = captured["args"][-1]
+    assert "Get-CimInstance" in command
+    assert "Win32_Process" in command
+    assert "Get-Process" not in command
+
+
+def test_windows_probe_subprocess_call_has_a_timeout(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args, 0, stdout="0\n", stderr="")
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    resources.process_start_time(4)
+
+    assert captured.get("timeout") == 5
+
+
+def test_windows_probe_wedged_or_missing_powershell_returns_none_not_raise(monkeypatch) -> None:
+    def _times_out(args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args, timeout=5)
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(subprocess, "run", _times_out)
+    assert resources.process_start_time(4) is None
+
+    def _missing(args, **kwargs):
+        raise FileNotFoundError("powershell not found")
+
+    monkeypatch.setattr(subprocess, "run", _missing)
+    assert resources.process_start_time(4) is None
+
+
+def test_darwin_probe_subprocess_call_has_a_timeout_and_pins_locale(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args, 0, stdout="Thu Aug 13 09:41:02 2026\n", stderr="")
+
+    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    resources.process_start_time(4)
+
+    assert captured.get("timeout") == 5
+    env = captured.get("env")
+    assert isinstance(env, dict)
+    assert env.get("LC_ALL") == "C"
+
+
+def test_darwin_probe_missing_ps_returns_none_not_raise(monkeypatch) -> None:
+    def _missing(args, **kwargs):
+        raise FileNotFoundError("ps not found")
+
+    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(subprocess, "run", _missing)
+    assert resources.process_start_time(4) is None
+
+
+def test_parse_linux_process_start_rejects_zero_clock_ticks() -> None:
+    """A zero SC_CLK_TCK would otherwise raise ZeroDivisionError, escaping process_alive."""
+    stat_text = (
+        "1234 (proc) S 1 1234 1234 0 -1 4194304 100 0 0 0 "
+        "10 2 0 0 20 0 4 0 5000 123456789 0 0 0 0 0 0 0 0 0 0 0 0 0 17 2 0 0 0 0 0"
+    )
+    proc_stat_text = "cpu  0 0 0 0 0 0 0 0 0 0\nbtime 1700000000\nprocesses 500\n"
+    assert resources._parse_linux_process_start(stat_text, proc_stat_text, 0.0) is None
+
+
 # -- dead lease pruning ------------------------------------------------------
 
 
@@ -326,10 +435,9 @@ def test_prune_dead_leases_deletes_and_logs_an_expired_confirmed_dead_lease(
 ) -> None:
     resource = _resource(registry)
     lease = registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
-    dead = lambda pid, start=None: False  # noqa: E731
 
     clock.advance(61)
-    pruned = resources.prune_dead_leases(registry, alive_probe=dead)
+    pruned = resources.prune_dead_leases(registry, alive_probe=_dead)
 
     assert pruned == [lease.id]
     assert registry.get_lease(lease.id) is None
@@ -354,8 +462,7 @@ def test_prune_dead_leases_never_touches_a_live_or_unexpired_lease(
     assert registry.get_lease(unexpired.id) is not None
 
     # Confirmed dead, but the TTL has not elapsed for the long-lived lease: still untouched.
-    dead = lambda pid, start=None: False  # noqa: E731
-    pruned = resources.prune_dead_leases(registry, alive_probe=dead)
+    pruned = resources.prune_dead_leases(registry, alive_probe=_dead)
     assert pruned == [live_holder.id]
     assert registry.get_lease(unexpired.id) is not None
 
@@ -363,13 +470,12 @@ def test_prune_dead_leases_never_touches_a_live_or_unexpired_lease(
 def test_prune_dead_leases_is_idempotent(registry: Registry, clock: FakeClock) -> None:
     resource = _resource(registry)
     registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
-    dead = lambda pid, start=None: False  # noqa: E731
     clock.advance(61)
 
-    first = resources.prune_dead_leases(registry, alive_probe=dead)
+    first = resources.prune_dead_leases(registry, alive_probe=_dead)
     assert len(first) == 1
 
-    second = resources.prune_dead_leases(registry, alive_probe=dead)
+    second = resources.prune_dead_leases(registry, alive_probe=_dead)
     assert second == []
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 
 import pytest
@@ -213,6 +214,163 @@ def test_process_alive_probe_is_true_for_this_process() -> None:
     assert resources.process_alive(os.getpid())
     assert not resources.process_alive(2**31 - 1)
     assert not resources.process_alive(0)
+
+
+def test_matching_pid_and_process_start_stays_protected_beyond_the_ttl(
+    registry: Registry, clock: FakeClock, monkeypatch
+) -> None:
+    """A holder whose stored identity still matches reality is never mistaken for reuse."""
+    resource = _resource(registry)
+    lease = registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=1.0, ttl_seconds=60)
+    monkeypatch.setattr(resources, "process_start_time", lambda _pid: 1.0)
+
+    clock.advance(10_000)
+    assert lease.expired_by_time(clock.now())  # TTL elapsed...
+    assert not resources.lease_is_expired(lease, clock.now())  # ...but identity matches
+    assert resources.resource_is_leased(registry, resource.id)
+
+
+def test_acquire_lease_accepts_a_none_proc_start(registry: Registry, clock: FakeClock) -> None:
+    """A failed identity probe at acquire time stores None rather than a wall-clock guess.
+
+    ``process_alive`` treats a None ``proc_start`` as PID-only liveness, so a lease acquired
+    without a usable identity probe still protects a live holder past its TTL.
+    """
+    resource = _resource(registry)
+    lease = registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=None, ttl_seconds=60)
+    assert lease.proc_start is None
+    stored = registry.get_lease(lease.id)
+    assert stored is not None
+    assert stored.proc_start is None
+
+    clock.advance(10_000)
+    assert lease.expired_by_time(clock.now())
+    assert not resources.lease_is_expired(lease, clock.now())
+    assert resources.resource_is_leased(registry, resource.id)
+
+
+# -- process start parsing helpers ------------------------------------------
+
+
+def test_parse_windows_process_start_converts_dotnet_ticks() -> None:
+    # 2026-08-13T09:41:02.500Z as .NET DateTime.Ticks (100ns units since 0001-01-01).
+    epoch_ticks = 62_135_596_800
+    seconds_since_epoch = 1_786_699_262.5
+    ticks = int((seconds_since_epoch + epoch_ticks) * 10_000_000)
+    result = resources._parse_windows_process_start(f"{ticks}\r\n")
+    assert result is not None
+    assert abs(result - seconds_since_epoch) < 1e-3
+
+
+@pytest.mark.parametrize("raw", ["", "not-a-number", "NaN", "Get-Process : Cannot find a process"])
+def test_parse_windows_process_start_rejects_malformed_input(raw: str) -> None:
+    assert resources._parse_windows_process_start(raw) is None
+
+
+def test_parse_linux_process_start_computes_epoch_from_ticks_and_boot() -> None:
+    # A realistic /proc/<pid>/stat line: comm can contain spaces/parens, hence the
+    # rsplit-on-")" parsing. Field 22 (index 19 after the split) is starttime in ticks.
+    stat_text = (
+        "1234 (my proc (weird)) S 1 1234 1234 0 -1 4194304 100 0 0 0 "
+        "10 2 0 0 20 0 4 0 5000 123456789 0 0 0 0 0 0 0 0 0 0 0 0 0 17 2 0 0 0 0 0"
+    )
+    proc_stat_text = "cpu  0 0 0 0 0 0 0 0 0 0\nbtime 1700000000\nprocesses 500\n"
+    result = resources._parse_linux_process_start(stat_text, proc_stat_text, 100.0)
+    assert result == 1700000000 + (5000 / 100.0)
+
+
+@pytest.mark.parametrize(
+    "stat_text,proc_stat_text,clk_tck",
+    [
+        ("", "btime 1700000000\n", 100.0),
+        ("garbage no parens or fields", "btime 1700000000\n", 100.0),
+        ("1234 (ok) S 1 1234", "btime 1700000000\n", 100.0),  # too few fields
+        ("1234 (ok) S " + " ".join(["0"] * 30), "no btime line here\n", 100.0),
+    ],
+)
+def test_parse_linux_process_start_rejects_malformed_input(
+    stat_text: str, proc_stat_text: str, clk_tck: float
+) -> None:
+    assert resources._parse_linux_process_start(stat_text, proc_stat_text, clk_tck) is None
+
+
+def test_parse_darwin_process_start_parses_lstart_format() -> None:
+    result = resources._parse_darwin_process_start("Thu Aug 13 09:41:02 2026\n")
+    assert result is not None
+    import datetime as dt
+
+    expected = dt.datetime.strptime("Thu Aug 13 09:41:02 2026", "%a %b %d %H:%M:%S %Y").timestamp()
+    assert result == expected
+
+
+@pytest.mark.parametrize("raw", ["", "not a date", "2026-08-13 09:41:02"])
+def test_parse_darwin_process_start_rejects_malformed_input(raw: str) -> None:
+    assert resources._parse_darwin_process_start(raw) is None
+
+
+def test_process_start_time_returns_a_plausible_epoch_for_this_process() -> None:
+    """Integration: the current platform's dispatch produces a real, recent epoch time."""
+    result = resources.process_start_time(os.getpid())
+    assert result is not None
+    now = time.time()
+    assert result <= now + resources.PROCESS_START_TOLERANCE_SECONDS
+    # Generous ceiling: CI machines can have long uptimes, but this *process* is young.
+    assert now - result < 30 * 24 * 3600
+
+
+# -- dead lease pruning ------------------------------------------------------
+
+
+def test_prune_dead_leases_deletes_and_logs_an_expired_confirmed_dead_lease(
+    registry: Registry, clock: FakeClock
+) -> None:
+    resource = _resource(registry)
+    lease = registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
+    dead = lambda pid, start=None: False  # noqa: E731
+
+    clock.advance(61)
+    pruned = resources.prune_dead_leases(registry, alive_probe=dead)
+
+    assert pruned == [lease.id]
+    assert registry.get_lease(lease.id) is None
+    assert any(
+        row["kind"] == "lease.pruned" and row["detail"] == lease.id for row in registry.events()
+    )
+
+
+def test_prune_dead_leases_never_touches_a_live_or_unexpired_lease(
+    registry: Registry, clock: FakeClock
+) -> None:
+    resource = _resource(registry)
+    live_holder = registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
+    unexpired = registry.acquire_lease(resource.id, pid=998, proc_start=1.0, ttl_seconds=6000)
+    clock.advance(61)
+
+    # Expired by time, but the holder is still reported alive: never pruned.
+    always_alive = lambda pid, start=None: True  # noqa: E731
+    pruned = resources.prune_dead_leases(registry, alive_probe=always_alive)
+    assert pruned == []
+    assert registry.get_lease(live_holder.id) is not None
+    assert registry.get_lease(unexpired.id) is not None
+
+    # Confirmed dead, but the TTL has not elapsed for the long-lived lease: still untouched.
+    dead = lambda pid, start=None: False  # noqa: E731
+    pruned = resources.prune_dead_leases(registry, alive_probe=dead)
+    assert pruned == [live_holder.id]
+    assert registry.get_lease(unexpired.id) is not None
+
+
+def test_prune_dead_leases_is_idempotent(registry: Registry, clock: FakeClock) -> None:
+    resource = _resource(registry)
+    registry.acquire_lease(resource.id, pid=999, proc_start=1.0, ttl_seconds=60)
+    dead = lambda pid, start=None: False  # noqa: E731
+    clock.advance(61)
+
+    first = resources.prune_dead_leases(registry, alive_probe=dead)
+    assert len(first) == 1
+
+    second = resources.prune_dead_leases(registry, alive_probe=dead)
+    assert second == []
 
 
 # -- adoption --------------------------------------------------------------

--- a/tests/test_scenario_docker.py
+++ b/tests/test_scenario_docker.py
@@ -24,6 +24,7 @@ from bosn.manifest import load
 from bosn.registry import Registry
 from bosn.resources import ResourceScanner
 from bosn.retention import DAY
+from conftest import live_proc_start
 
 pytestmark = pytest.mark.docker
 
@@ -119,7 +120,9 @@ def test_full_lifecycle_run_lease_done_ttl_gc(
         # -- lease held: nothing is collectable, however old ------------------
         target = next(r for r in spec_volumes if r.kind == "volume")
         # This process is the lease holder, so the liveness probe genuinely succeeds.
-        lease = registry.acquire_lease(target.id, pid=os.getpid(), proc_start=1.0, ttl_seconds=900)
+        lease = registry.acquire_lease(
+            target.id, pid=os.getpid(), proc_start=live_proc_start(), ttl_seconds=900
+        )
         clock.advance(10 * DAY)
 
         collector = Collector(registry, engine)


### PR DESCRIPTION
Fixes #45

Leases store `pid` and `proc_start`, but `process_alive()` ignored `proc_start` entirely. After a client died and its PID was reused, an unrelated process kept the old lease alive indefinitely, pinning resources against every retention tier.

## Changes

- **Holder identity is actually checked.** `process_start_time(pid)` reads the OS process creation time (Linux `/proc`, Windows CIM, macOS `ps`), and `process_alive` compares it against the stored value within a documented 2s tolerance.
- **Dead lease pruning.** `prune_dead_leases` runs in the daemon maintenance pass, deletes only leases that are both expired by time *and* probe-confirmed dead, and logs `lease.pruned` per row. Idempotent by construction.
- **`proc_start` is nullable.** A failed probe stores `NULL` (PID-only liveness) rather than a wall-clock guess — a guess that later disagrees with the real start time would make a *live* holder's lease look expired and let GC reap in-use resources. Includes a table-rebuild migration; legacy rows migrate to PID-only for that same reason.
- **Platform parsing split into pure helpers**, so the Windows/Linux/macOS formats are unit-tested on any OS.

## Review findings addressed

A pre-push review caught that the branch failed in the exact scenario it was written for, all verified on a real Windows host:

- `os.kill(pid, 0)` raises `SystemError` (**not** `OSError`) for a process owned by another user, escaping every handler. Since PID reuse by a SYSTEM/service process is the motivating case, one poisoned lease aborted the whole prune loop and every subsequent GC pass. Access-denied now reads as alive.
- The Windows probe called `Get-Process`, whose `.StartTime` is null for another user's process, while its comment claimed CIM. Switched to `Get-CimInstance Win32_Process`, which returns the value.
- Both subprocess probes gained `timeout=5` and `OSError`/`SubprocessError` handling — a wedged `powershell` could hang the maintenance thread, or stall while holding the registry write lock.
- `process_start_time` was being spawned per-dependency *inside* `lifecycle_guard`'s exclusive write lock (~0.35s each); now hoisted out and memoized.
- A failed migration raises a named `RegistryError` instead of bricking the registry at construction.

## Acceptance criteria

- [x] Focused RED→GREEN test simulates PID reuse with a different start time and expires the old lease
- [x] A matching PID/start pair stays protected beyond the TTL
- [x] Windows, macOS, and Linux process-start probes have platform tests
- [x] Dead lease cleanup is idempotent and logged

## Verification

`ci/lint.py` → LINT OK (ruff format, ruff check, pyright). 360 passed, 1 skipped locally; the 26 Docker-marked tests are Linux-CI only and run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)