### PR TITLE
ci: validate the Windows and macOS v1 paths on native runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Every lane only reads the checkout; none publishes anything.
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Linux (lint + unit + docker)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,34 @@ jobs:
           set -e
           ls dist/
           test -n "$(ls dist/*-py3-none-any.whl)"
+
+  native:
+    name: ${{ matrix.name }} (lint + unit)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: Windows
+          - os: macos-latest
+            name: macOS
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install
+        run: ./install
+
+      - name: Lint
+        run: ./lint
+
+      - name: Test (unit)
+        run: ./test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bosn
 
-[![CI (Linux)](https://github.com/zackees/bosn/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/zackees/bosn/actions/workflows/ci.yml)
+[![CI](https://github.com/zackees/bosn/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/zackees/bosn/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
@@ -21,7 +21,8 @@ stay warm while total storage stays bounded, without anyone remembering to clean
 > and refers to the project as *dockhand*; the design is unchanged, the name is not.
 >
 > Not yet built: the `bosn-docker` compatibility subset, `bosn init` from `compose.yaml`,
-> daemon-owned background jobs (`bosn attach`), macOS/Windows CI, and podman.
+> daemon-owned background jobs (`bosn attach`), and podman. macOS and Windows now have
+> native, non-Docker CI lanes; see [Platform CI coverage](#platform-ci-coverage).
 
 ## Why this exists
 
@@ -335,9 +336,31 @@ Ruff's BLE001 can flag the blind except, but the actual defect is the *missing*
 
 Suppress a line with `# noqa: KBI001` when a case is genuinely intentional.
 
-CI runs on Linux only. Docker-backed tests carry a `docker` pytest marker: they skip when no
-engine is reachable, and `ci/test.py` excludes them outright on non-Linux CI runners, so the
-unit suite stands alone without an engine.
+Docker-backed tests carry a `docker` pytest marker: they skip when no engine is reachable,
+and `ci/test.py` excludes them outright on non-Linux CI runners, so the unit suite stands
+alone without an engine.
+
+### Platform CI coverage
+
+CI gates merges on three lanes, run in parallel:
+
+| Lane | Runner | Steps | Docker-backed tests |
+| --- | --- | --- | --- |
+| Linux | `ubuntu-latest` | install, lint, unit + docker tests, wheel build | yes |
+| Windows | `windows-latest` | install, lint, unit tests | no |
+| macOS | `macos-latest` | install, lint, unit tests | no |
+
+The Windows and macOS lanes run `./install`, `./lint`, and `./test` under bash (the runners
+ship Git Bash / a POSIX shell), exercising native process, path, and filesystem behavior on
+real Windows and macOS runners instead of Linux-only string fixtures. Dedicated cmd.exe,
+PowerShell, and MSYS path/argv coverage lives in the test suite itself, not in the CI step
+shell.
+
+**Docker-backed scenarios remain Linux-only.** Hosted macOS runners provide no Docker daemon,
+and hosted Windows runners cannot run Linux containers, so `ci/test.py` excludes the `docker`
+marker on those platforms automatically (see above). Getting real Docker Desktop coverage on
+macOS or Windows requires a self-hosted runner with Docker Desktop installed and licensed —
+none is configured today; this remains a manual follow-up for the maintainer.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ alone without an engine.
 
 ### Platform CI coverage
 
-CI gates merges on three lanes, run in parallel:
+CI runs three lanes in parallel on every pull request:
 
 | Lane | Runner | Steps | Docker-backed tests |
 | --- | --- | --- | --- |
@@ -353,8 +353,11 @@ CI gates merges on three lanes, run in parallel:
 The Windows and macOS lanes run `./install`, `./lint`, and `./test` under bash (the runners
 ship Git Bash / a POSIX shell), exercising native process, path, and filesystem behavior on
 real Windows and macOS runners instead of Linux-only string fixtures. Dedicated cmd.exe,
-PowerShell, and MSYS path/argv coverage lives in the test suite itself, not in the CI step
+PowerShell, and MSYS path coverage lives in the test suite itself, not in the CI step
 shell.
+
+These lanes are advisory until they are added to branch protection's required status
+checks; that is a repository setting, not something the workflow can assert for itself.
 
 **Docker-backed scenarios remain Linux-only.** Hosted macOS runners provide no Docker daemon,
 and hosted Windows runners cannot run Linux containers, so `ci/test.py` excludes the `docker`

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -12,6 +12,12 @@ def test_per_user_login_launcher_can_be_enabled_and_removed(
     monkeypatch, tmp_path: Path, platform: str
 ) -> None:
     """Every supported OS has a reversible, per-user login launcher."""
+    # autostart.path() reads $APPDATA in preference to `home`, so on a real Windows host
+    # this parametrization would write bosn-daemon.cmd into the *actual* Start Menu
+    # Startup folder and delete it again -- invisible on Linux CI, where APPDATA is unset.
+    # A failure between those two steps would strand a self-restarting daemon launcher in
+    # a developer's login items. Clearing it keeps the write under `home`.
+    monkeypatch.delenv("APPDATA", raising=False)
     monkeypatch.setattr(autostart.subprocess, "run", lambda *_args, **_kwargs: None)
     installed = autostart.enable(platform=platform, home=tmp_path)
     assert installed.exists()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -186,11 +186,21 @@ def test_the_port_is_released_for_the_next_daemon(tmp_path: Path) -> None:
 
 
 def test_idle_retirement_stops_an_unused_daemon(tmp_path: Path) -> None:
+    """An unused daemon retires itself.
+
+    The maintenance deadline is pushed out of the way first because `_idle_watchdog`
+    runs `run_maintenance_if_due()` in the same 0.5s tick that checks retirement, and a
+    due maintenance pass probes the engine twice at `engine.DEFAULT_TIMEOUT` (60s) each.
+    On a host where the docker binary is present but its daemon is unreachable -- every
+    hosted Windows/macOS runner -- that blocks the tick for up to two minutes and this
+    assertion times out having measured engine probing rather than idle retirement.
+    """
     daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0.5)
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()
     assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
-    thread.join(timeout=20)
+    thread.join(timeout=30)
     assert not thread.is_alive(), "idle daemon should have retired itself"
     assert not daemon_mod.is_serving(tmp_path)
 

--- a/tests/test_daemon_jobs.py
+++ b/tests/test_daemon_jobs.py
@@ -317,6 +317,10 @@ def test_a_running_job_blocks_idle_retirement(
     """Retiring mid-build would destroy the build; the old idle-only rule would have."""
     state_dir = tmp_path / "state2"
     daemon = Daemon(state_dir=state_dir, idle_retire_seconds=0.2)
+    # See test_daemon.py::test_idle_retirement_stops_an_unused_daemon: a due maintenance
+    # pass probes the engine twice at 60s each inside the same watchdog tick that checks
+    # retirement, which on an engine-less runner outlasts the join deadline below.
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
     daemon.jobs.builder = builder
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()

--- a/tests/test_platform_native.py
+++ b/tests/test_platform_native.py
@@ -1,0 +1,237 @@
+"""Tests that only mean something when executed on their native OS.
+
+Issue #50: the repo claims Windows/macOS/Linux v1 support, but path identity, autostart,
+process liveness, and secret-file permissions were validated "mostly by string fixtures,
+not by their native shells or service managers." Every test in this module is either
+skip-marked to a no-op on platforms where it cannot exercise the real thing, or it spawns
+a real shell / real OS probe / real daemon process. None of it is fakeable with fixtures
+alone -- that is the point: a green Linux-only run must not be able to hide a Windows- or
+macOS-only regression, the way `os.kill(pid, 0)` raising `SystemError` on Windows and
+`PRAGMA integrity_check` raising on Linux both did this week.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from bosn import autostart
+from bosn import daemon as daemon_mod
+from bosn.daemon import Daemon
+from bosn.paths import normalize_workspace_path
+from bosn.registry import default_state_dir
+from bosn.resources import process_alive, process_start_time
+
+# -- 1. shell/path identity through real native shells ----------------------
+#
+# normalize_workspace_path() is documented as producing one canonical identity across
+# "native Windows, MSYS, WSL and UNC spellings." tests/test_paths.py proves that with
+# hardcoded strings; the tests below actually spawn cmd.exe, PowerShell, and Git Bash over
+# the SAME real directory and assert their three different spellings normalize to one
+# identity. A regression in the MSYS `/c/...` or `//?/` handling could pass every
+# string-fixture test while still misidentifying a real Git Bash workspace as a distinct
+# cache from its native-spelled counterpart -- this is the only kind of test that catches
+# that.
+
+_GIT_BASH = Path(r"C:\Program Files\Git\bin\bash.exe")
+
+
+def _probe_dir() -> Path:
+    """A real temp directory outside any MSYS bind-mount alias.
+
+    Deliberately rooted under the user's home rather than the OS temp dir: some Git Bash
+    installs remap /tmp to a non-cygdrive mount in /etc/fstab, which would make bash's pwd
+    output a spelling this module's normalizer was never meant to understand. Home is not
+    remapped, so `/c/Users/...` is what Git Bash actually reports there.
+    """
+    return Path(tempfile.mkdtemp(prefix="bosn_shell_probe_", dir=str(Path.home())))
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="native shell identity is only meaningful on Windows"
+)
+def test_cmd_and_powershell_agree_on_one_path_identity() -> None:
+    probe = _probe_dir()
+    try:
+        cmd_out = subprocess.run(
+            ["cmd", "/c", "cd"], cwd=probe, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        ps_out = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", "(Get-Location).Path"],
+            cwd=probe,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        expected = normalize_workspace_path(cmd_out)
+        assert normalize_workspace_path(ps_out) == expected
+    finally:
+        shutil.rmtree(probe, ignore_errors=True)
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="native shell identity is only meaningful on Windows"
+)
+def test_git_bash_msys_spelling_agrees_with_the_native_identity() -> None:
+    """Skips gracefully (not a silent pass) when Git Bash is absent from this runner."""
+    if not _GIT_BASH.exists():
+        pytest.skip(f"Git Bash not found at {_GIT_BASH}")
+
+    probe = _probe_dir()
+    try:
+        cmd_out = subprocess.run(
+            ["cmd", "/c", "cd"], cwd=probe, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        expected = normalize_workspace_path(cmd_out)
+
+        forward = str(probe).replace("\\", "/")
+        bash_out = subprocess.run(
+            [str(_GIT_BASH), "-c", f"cd '{forward}' && pwd"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        assert normalize_workspace_path(bash_out) == expected
+    finally:
+        shutil.rmtree(probe, ignore_errors=True)
+
+
+# -- 2. native process start identity ----------------------------------------
+#
+# process_start_time()'s macOS branch has never run on macOS in CI. This does not
+# duplicate test_process_start_time_returns_a_plausible_epoch_for_this_process (which only
+# checks that a plausible float comes back); it adds the alive/mismatch pairing that
+# lease-expiry safety actually depends on (see resources.process_alive and
+# lease_is_expired) -- a matching stored start time must read as alive past the TTL, and a
+# stale/mismatched one (modeling PID reuse) must not.
+
+
+@pytest.mark.skipif(
+    sys.platform not in ("win32", "linux", "darwin"),
+    reason="no native process-start probe implemented for this platform",
+)
+def test_native_process_start_pairs_matching_and_mismatched_identity_with_liveness() -> None:
+    pid = os.getpid()
+    start = process_start_time(pid)
+    assert start is not None, "native OS probe produced no start time for this live process"
+
+    assert process_alive(pid, proc_start=start) is True
+    # Far outside PROCESS_START_TOLERANCE_SECONDS: models a reused pid belonging to a
+    # different process, which must never read as the same live holder.
+    assert process_alive(pid, proc_start=start - 10_000) is False
+
+
+# -- 3. autostart adapters without mutating system-wide state ----------------
+#
+# autostart.enable()'s Windows and darwin branches are pure file writes under the injected
+# `home`; the Linux branch shells out to `systemctl --user enable --now`, so it is excluded
+# here (test_autostart.py already exercises it, safely, only via an explicit platform=
+# override with subprocess.run monkeypatched). The tests below call enable()/disable()
+# without a platform= override -- i.e. through the real dispatch this OS actually takes at
+# runtime -- while still keeping every write confined to tmp_path.
+
+
+@pytest.mark.skipif(
+    sys.platform == "linux",
+    reason="linux enable() shells out to systemctl; already covered safely in test_autostart.py",
+)
+def test_native_autostart_enable_and_disable_stay_under_the_injected_home(
+    monkeypatch, tmp_path: Path
+) -> None:
+    if sys.platform.startswith("win"):
+        # autostart.path() prefers $APPDATA over `home` when the env var is set. Clearing
+        # it is what keeps this call from ever touching the real per-user Startup folder.
+        monkeypatch.delenv("APPDATA", raising=False)
+
+    installed = autostart.enable(home=tmp_path)
+    assert installed.exists()
+    assert tmp_path in installed.parents or installed.parent == tmp_path
+
+    if sys.platform.startswith("win"):
+        assert installed.suffix == ".cmd"
+    elif sys.platform == "darwin":
+        assert installed.parent.name == "LaunchAgents"
+        assert installed.suffix == ".plist"
+
+    removed = autostart.disable(home=tmp_path)
+    assert removed == installed
+    assert not installed.exists()
+
+
+# -- 4. owner-only secret protection ------------------------------------------
+#
+# Daemon.serve_forever() writes daemon.secret and chmods it 0o600 (bosn/daemon.py). On
+# POSIX that permission bit is the entire protection against another local user reading the
+# IPC secret; this is the first time it runs natively on macOS. On Windows, POSIX mode bits
+# are meaningless (the real control is the ACL, which a hosted runner cannot meaningfully
+# assert against), so the Windows-side test instead proves the file lands under the
+# per-user state dir rather than some shared/system location.
+
+
+def _wait_until(predicate, timeout: float = 15.0, interval: float = 0.05) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+@contextlib.contextmanager
+def _served_daemon(tmp_path: Path):
+    """Yield a live Daemon so assertions run *before* shutdown deletes its files.
+
+    ``Daemon.shutdown()`` unlinks ``daemon.secret`` on exit, so any assertion on the file
+    must happen while the daemon is still serving -- returning a path computed after
+    teardown would race the cleanup and observe a file that no longer exists.
+    """
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    try:
+        assert _wait_until(lambda: daemon_mod.is_serving(tmp_path)), "daemon never came up"
+        yield daemon
+    finally:
+        daemon.request_stop()
+        thread.join(timeout=15)
+        daemon.shutdown()
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX file-mode bits are meaningless under Windows ACLs"
+)
+def test_secret_file_is_owner_only_on_posix(tmp_path: Path) -> None:
+    with _served_daemon(tmp_path):
+        secret_path = daemon_mod.secret_file(tmp_path)
+        assert secret_path.exists()
+        mode = stat.S_IMODE(secret_path.stat().st_mode)
+        assert mode == 0o600
+
+
+@pytest.mark.skipif(
+    os.name != "nt", reason="Windows: assert location, not ACLs, on a hosted runner"
+)
+def test_secret_file_lives_under_the_user_state_dir_on_windows(monkeypatch, tmp_path: Path) -> None:
+    with _served_daemon(tmp_path):
+        secret_path = daemon_mod.secret_file(tmp_path)
+        assert secret_path.exists()
+        assert secret_path.parent == tmp_path
+
+    # Separately (no daemon involved), prove the *real* default state dir the runtime picks
+    # at startup resolves under this user's profile, not a shared/system-wide location.
+    monkeypatch.delenv("BOSN_STATE_DIR", raising=False)
+    real_default = default_state_dir()
+    profile_root = os.environ.get("LOCALAPPDATA") or str(Path.home())
+    assert str(real_default).lower().startswith(profile_root.lower())

--- a/tests/test_platform_native.py
+++ b/tests/test_platform_native.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -46,66 +47,76 @@ from bosn.resources import process_alive, process_start_time
 _GIT_BASH = Path(r"C:\Program Files\Git\bin\bash.exe")
 
 
-def _probe_dir() -> Path:
-    """A real temp directory outside any MSYS bind-mount alias.
+def _bash_pwd(directory: Path) -> str:
+    """Git Bash's own spelling of `directory`, passed as argv so quoting is bash's job."""
+    return subprocess.run(
+        [str(_GIT_BASH), "-c", 'cd "$1" && pwd', "_", str(directory)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
 
-    Deliberately rooted under the user's home rather than the OS temp dir: some Git Bash
-    installs remap /tmp to a non-cygdrive mount in /etc/fstab, which would make bash's pwd
-    output a spelling this module's normalizer was never meant to understand. Home is not
-    remapped, so `/c/Users/...` is what Git Bash actually reports there.
+
+def _msys_probe_dir(tmp_path: Path) -> tuple[Path, Path | None]:
+    """A directory whose Git Bash spelling is the drive-rooted `/c/...` form.
+
+    Prefers pytest's `tmp_path` and returns no cleanup owner for it. Some environments
+    point TMPDIR at a directory that Git Bash remaps via /etc/fstab, so bash reports
+    `/tmp/...` instead of `/c/Users/...` -- a spelling `normalize_workspace_path` never
+    claimed to handle. Only then does this fall back to a home-rooted directory, which is
+    never remapped, and return it as the caller's responsibility to remove.
     """
-    return Path(tempfile.mkdtemp(prefix="bosn_shell_probe_", dir=str(Path.home())))
+    if re.match(r"^/[a-zA-Z]/", _bash_pwd(tmp_path)):
+        return tmp_path, None
+    fallback = Path(tempfile.mkdtemp(prefix="bosn_shell_probe_", dir=str(Path.home())))
+    return fallback, fallback
 
 
 @pytest.mark.skipif(
     sys.platform != "win32", reason="native shell identity is only meaningful on Windows"
 )
-def test_cmd_and_powershell_agree_on_one_path_identity() -> None:
-    probe = _probe_dir()
-    try:
-        cmd_out = subprocess.run(
-            ["cmd", "/c", "cd"], cwd=probe, capture_output=True, text=True, check=True
-        ).stdout.strip()
-        ps_out = subprocess.run(
-            ["powershell", "-NoProfile", "-Command", "(Get-Location).Path"],
-            cwd=probe,
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
+def test_native_windows_shells_agree_on_one_workspace_identity(tmp_path: Path) -> None:
+    """cmd.exe, PowerShell, and MSYS Git Bash must resolve to one cache identity.
 
-        expected = normalize_workspace_path(cmd_out)
-        assert normalize_workspace_path(ps_out) == expected
-    finally:
-        shutil.rmtree(probe, ignore_errors=True)
+    The value here is not that a normalizer regression gets caught -- the string fixtures
+    in test_paths.py already do that. It is that the *assumption baked into those fixtures*
+    gets checked against what the shells really emit. A fixture can only encode spellings
+    somebody already thought of; if a shell starts reporting a form nobody anticipated, a
+    real workspace silently splits into two caches and every string test still passes.
 
-
-@pytest.mark.skipif(
-    sys.platform != "win32", reason="native shell identity is only meaningful on Windows"
-)
-def test_git_bash_msys_spelling_agrees_with_the_native_identity() -> None:
-    """Skips gracefully (not a silent pass) when Git Bash is absent from this runner."""
+    The distinct-spelling assertion below is what keeps this honest: cmd and PowerShell
+    happen to emit byte-identical strings today, so without Git Bash's `/c/...` form this
+    would degrade into asserting `normalize(x) == normalize(x)`.
+    """
     if not _GIT_BASH.exists():
+        # windows-latest ships Git Bash; its absence in CI is a broken runner, not a
+        # reason to report success on a lane that then proves nothing about MSYS.
+        if os.environ.get("CI"):
+            pytest.fail(f"Git Bash missing at {_GIT_BASH} on a CI runner")
         pytest.skip(f"Git Bash not found at {_GIT_BASH}")
 
-    probe = _probe_dir()
+    probe, cleanup = _msys_probe_dir(tmp_path)
     try:
-        cmd_out = subprocess.run(
-            ["cmd", "/c", "cd"], cwd=probe, capture_output=True, text=True, check=True
-        ).stdout.strip()
-        expected = normalize_workspace_path(cmd_out)
+        spellings = [
+            subprocess.run(
+                ["cmd", "/c", "cd"], cwd=probe, capture_output=True, text=True, check=True
+            ).stdout.strip(),
+            subprocess.run(
+                ["powershell", "-NoProfile", "-Command", "(Get-Location).Path"],
+                cwd=probe,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip(),
+            _bash_pwd(probe),
+        ]
 
-        forward = str(probe).replace("\\", "/")
-        bash_out = subprocess.run(
-            [str(_GIT_BASH), "-c", f"cd '{forward}' && pwd"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-
-        assert normalize_workspace_path(bash_out) == expected
+        assert len(set(spellings)) >= 2, f"no cross-shell divergence to test: {spellings}"
+        identities = {normalize_workspace_path(spelling) for spelling in spellings}
+        assert len(identities) == 1, f"{spellings} split into {identities}"
     finally:
-        shutil.rmtree(probe, ignore_errors=True)
+        if cleanup is not None:
+            shutil.rmtree(cleanup, ignore_errors=True)
 
 
 # -- 2. native process start identity ----------------------------------------
@@ -144,8 +155,10 @@ def test_native_process_start_pairs_matching_and_mismatched_identity_with_livene
 
 
 @pytest.mark.skipif(
-    sys.platform == "linux",
-    reason="linux enable() shells out to systemctl; already covered safely in test_autostart.py",
+    not (sys.platform.startswith("win") or sys.platform == "darwin"),
+    # Mirrors autostart.path()'s dispatch rather than excluding "linux" by name: the
+    # systemctl branch is the *fallback*, so any other POSIX platform takes it too.
+    reason="only win/darwin enable() is a pure file write; the rest shell out to systemctl",
 )
 def test_native_autostart_enable_and_disable_stay_under_the_injected_home(
     monkeypatch, tmp_path: Path


### PR DESCRIPTION
Fixes #50

CI ran on Linux only, so the Windows and macOS paths this package claims as v1-supported were validated mostly by string fixtures rather than by their native shells, service managers, and process APIs.

That is not hypothetical. Two platform divergences reached `main` this week, both past a fully green Linux suite:

- `os.kill(pid, 0)` raises `SystemError` — **not** an `OSError`, so it escaped every handler — for a process owned by another user on Windows. That is exactly the PID-reuse case the lease-identity work exists for.
- `PRAGMA integrity_check` *raises* on Linux where it merely *reports* on Windows, so `doctor` crashed with a traceback in precisely the corrupt-database case it exists to diagnose.

And `_parse_darwin_process_start` has never executed on macOS — not once — despite governing lease liveness, and therefore deletion.

## Changes

- **Native CI job**: `windows-latest` + `macos-latest`, `fail-fast: false` so one platform cannot mask the other, running lint + the non-Docker suite. Runs under `bash` because `install`/`lint`/`test` are bash scripts and Windows runners default to PowerShell. Docker-skipping is not duplicated in the workflow — `ci/test.py` already drops the `docker` marker on non-Linux CI.
- **The Linux job is untouched** and remains the only lane with Docker and the wheel build.
- **Native platform tests** exercising real `cmd.exe` / PowerShell / MSYS path identity, native process start identity, autostart adapters, and secret-file permissions.
- **README** documents the three lanes and states plainly that Docker-backed coverage stays Linux-only (hosted macOS runners have no Docker daemon; hosted Windows runners cannot run Linux containers), and that real Docker Desktop coverage on those platforms needs a self-hosted runner.

## Acceptance criteria

- [ ] Focused RED→GREEN platform tests catch at least one behavior string-only Linux tests cannot validate
- [ ] Windows and macOS jobs gate merges for their supported non-Docker surface
- [ ] Shell/path identity exercised through cmd.exe, PowerShell, and MSYS on Windows
- [ ] Native process/permission/autostart adapters tested without mutating system-wide state
- [ ] Docker Desktop coverage and any self-hosted requirement documented and visible

## Note for the maintainer

These new checks only *gate* merges once added to the required-status-checks list in branch protection. That is a repo-settings change I have not made.

Draft while the first native runs report — the macOS lane is validating code that has never run on macOS, so its first result is expected to be informative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)