### PR TITLE
fix: normalize workspace identity at the IPC boundary

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -628,10 +628,17 @@ class Daemon:
 
     def _verb_done(self, request: dict[str, Any]) -> dict[str, Any]:
         from bosn.gc import mark_done
+        from bosn.paths import normalize_workspace_path
 
         workspace = str(request.get("workspace") or "")
         if not workspace:
             return {"ok": False, "error": "done requires a workspace"}
+        # The bundled CLI already sends a normalized identity (workspace_of() resolves the
+        # manifest root before it ever reaches IPC), but the wire contract itself accepts a
+        # raw string. Any other spelling -- /cygdrive/, MSYS, a trailing slash, drive-letter
+        # case -- must still match the identity mark_workspace_done matches against by exact
+        # SQL equality, or this silently marks nothing while reporting ok=True.
+        workspace = normalize_workspace_path(workspace)
         return {"ok": True, "marked": mark_done(self.registry, workspace)}
 
     def _verb_adopt(self, request: dict[str, Any]) -> dict[str, Any]:
@@ -721,12 +728,18 @@ class Daemon:
         from bosn.converge import Converger, ConvergeResult
         from bosn.engine import Engine
         from bosn.manifest import load
+        from bosn.paths import normalize_workspace_path
 
         manifest = load(Path(str(request.get("manifest") or "")))
         converged = ConvergeResult.from_dict(dict(request.get("result") or {}))
         workspace = str(request.get("workspace") or "")
         if not workspace:
             return {"ok": False, "error": "execution-acquire requires workspace"}
+        # Same boundary gap as `done`, on the write side: an un-normalized spelling here
+        # would record the container's registry row under an identity that `done` (which
+        # does normalize) can never match, permanently pinning the resource. Normalizing is
+        # a no-op for the CLI's already-canonical value.
+        workspace = normalize_workspace_path(workspace)
         session = str(uuid.uuid4())
         with self._execution_lock:
             if self._stopping:
@@ -775,12 +788,21 @@ class Daemon:
         from bosn.converge import generation_coalescing_key, workspace_of
         from bosn.engine import Engine
         from bosn.manifest import load
+        from bosn.paths import normalize_workspace_path
 
         manifest = load(Path(manifest_path))
         stack = manifest.stack(request.get("stack") or None)
         engine_binary = str(request.get("engine") or self.engine_binary)
         coalescing_key = generation_coalescing_key(manifest, stack, Engine(engine_binary))
-        workspace = str(request.get("workspace") or workspace_of(manifest))
+        # Same boundary gap as `done`: an un-normalized spelling here would both write
+        # registry rows under an identity `done` can never match, and fragment the job
+        # slot's (workspace, stack) coalescing key so two spellings of one workspace could
+        # run unserialized -- the same per-worktree splitting issue #1 fixed for the CLI
+        # path. `workspace_of` already normalizes; normalizing an explicit request value too
+        # keeps both branches of this `or` producing the same canonical form.
+        workspace = normalize_workspace_path(
+            str(request.get("workspace") or workspace_of(manifest))
+        )
 
         submission = self.jobs.submit(
             workspace=workspace,

--- a/src/bosn/paths.py
+++ b/src/bosn/paths.py
@@ -1,4 +1,15 @@
-"""Canonical path identities across native Windows, MSYS, WSL and UNC spellings."""
+"""Canonical path identities across the supported shells' path spellings.
+
+Issue #1 names cmd.exe, PowerShell, MSYS Git Bash, macOS, and Linux as the supported
+shells, so a native Windows path, a `/c/...` MSYS spelling, a `//?/` UNC-prefixed path,
+and a plain POSIX path must all resolve to one identity. WSL itself is rejected outright
+(see `in_wsl`) rather than supported, but its `/mnt/c/...` spelling is recognized anyway,
+defensively, the same way Cygwin's `/cygdrive/c/...` spelling is: neither shell is
+supported, but the cost of recognizing either prefix is one alternation, and the
+alternative -- silently rooting the identity at a nonexistent path like
+`c:\\cygdrive\\c\\...` -- is a workspace identity that never matches, which is exactly the
+silent split this module exists to prevent.
+"""
 
 from __future__ import annotations
 
@@ -11,7 +22,7 @@ from pathlib import Path
 def normalize_workspace_path(path: str | Path) -> str:
     raw = str(path).replace("\\", "/")
     raw = re.sub(r"^//\?/", "", raw)
-    match = re.match(r"^/(?:mnt/)?([a-zA-Z])/(.*)$", raw)
+    match = re.match(r"^/(?:mnt/|cygdrive/)?([a-zA-Z])/(.*)$", raw)
     if match:
         raw = f"{match.group(1).upper()}:/{match.group(2)}"
     if re.match(r"^[a-zA-Z]:/", raw) or raw.startswith("//"):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -145,6 +145,39 @@ def test_unknown_verb_is_rejected_not_ignored(served: Daemon) -> None:
     assert "unknown daemon verb" in reply["error"]
 
 
+def test_done_normalizes_the_request_workspace_before_matching(tmp_path: Path) -> None:
+    """The IPC contract must accept any supported spelling, not only the CLI's own.
+
+    `_verb_done` used to pass `request["workspace"]` straight into an exact-match SQL
+    query. The bundled CLI always sends an already-normalized identity, so this never
+    showed up there -- but any other IPC client sending an equivalent-but-differently-
+    spelled path (MSYS, WSL, a trailing slash, drive-letter case) would match zero rows
+    and get back `{"ok": True, "marked": 0}`: a silent no-op reported as success. This
+    proves a request spelled differently from the stored identity still marks it.
+    """
+    from bosn.paths import normalize_workspace_path
+
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        canonical = normalize_workspace_path(r"C:\Users\Me\work")
+        daemon.registry.register_resource(
+            kind="volume",
+            name="cache",
+            stack="s",
+            generation="g",
+            scope="spec",
+            workspace=canonical,
+        )
+        differently_spelled = "/c/Users/Me/work"
+        assert differently_spelled != canonical
+
+        reply = daemon.dispatch("done", {"workspace": differently_spelled})
+
+        assert reply == {"ok": True, "marked": 1}
+    finally:
+        daemon.registry.close()
+
+
 def test_requests_refresh_the_heartbeat(served: Daemon) -> None:
     before = served.heartbeat_at
     time.sleep(0.05)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -8,6 +8,14 @@ def test_windows_native_msys_wsl_and_extended_spellings_share_an_identity() -> N
     assert normalize_workspace_path(r"\\?\C:\Users\Me\work") == expected
 
 
+def test_cygdrive_spelling_shares_the_same_identity() -> None:
+    # Cygwin is not one of the supported shells (see the module docstring), but it is
+    # accepted defensively so a stray /cygdrive/ spelling roots at the real drive instead of
+    # a bogus c:\cygdrive\c\... identity that would silently split the workspace in two.
+    expected = normalize_workspace_path(r"C:\Users\Me\work")
+    assert normalize_workspace_path("/cygdrive/c/Users/Me/work") == expected
+
+
 def test_unc_case_and_separator_spellings_share_an_identity() -> None:
     assert normalize_workspace_path(r"\\Server\Share\Work") == normalize_workspace_path(
         "//server/share/work"

--- a/tests/test_platform_native.py
+++ b/tests/test_platform_native.py
@@ -144,6 +144,43 @@ def test_native_process_start_pairs_matching_and_mismatched_identity_with_livene
     assert process_alive(pid, proc_start=start - 10_000) is False
 
 
+# -- 2b. Windows access-denied liveness path (issue #68) ---------------------
+#
+# process_alive()'s SystemError handler exists because os.kill(pid, 0) on another
+# user's/SYSTEM's process raises SystemError on Windows -- not an OSError, so it escapes
+# every ordinary handler. The existing unit tests only prove the handler catches what a
+# monkeypatch hands it; they never prove real CPython on a real Windows host still throws
+# that (as opposed to, say, PermissionError, which CPython's Windows os.kill also produces
+# depending on the OS/runtime privilege level and would take a different -- but still
+# fail-open -- branch in process_alive). PID 4 is the Windows "System" process: always
+# present, always owned by SYSTEM, and never killable/inspectable by an ordinary user, so
+# it reliably exercises this branch without any monkeypatching.
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="only Windows raises SystemError here")
+def test_native_windows_access_denied_pid_reads_as_alive() -> None:
+    """process_alive(4) must fail open (report alive) through the REAL os.kill call.
+
+    This intentionally does not assert *which* exception type os.kill(4, 0) raises --
+    that is exactly the detail the issue says may differ between a developer box and a
+    possibly more/less privileged hosted `windows-latest` runner. What must never differ,
+    on any Windows host, is the outward behavior: an access-denied probe against a real,
+    live, other-user process is never mistaken for a dead one.
+    """
+    assert process_alive(4) is True
+
+    # Separately, record what os.kill(4, 0) actually raises on this host so a change in
+    # CPython/Windows behavior is legible rather than silent. Observed on a Windows 10 dev
+    # box (see issue #68): SystemError, not OSError. A hosted windows-latest runner may
+    # instead see PermissionError (an OSError subclass) if it runs at a different privilege
+    # level -- process_alive() has a dedicated branch for each, and both fail open, so this
+    # assertion accepts either known type. It intentionally does NOT accept "no exception
+    # at all": that would mean the OS started permitting the probe outright, at which point
+    # this test -- and the handler it is documenting -- would have nothing left to guard.
+    with pytest.raises((SystemError, PermissionError)):
+        os.kill(4, 0)
+
+
 # -- 3. autostart adapters without mutating system-wide state ----------------
 #
 # autostart.enable()'s Windows and darwin branches are pure file writes under the injected


### PR DESCRIPTION
Fixes #67
Fixes #68

`registry.mark_workspace_done` matches with exact SQL string equality:

```sql
WHERE resource_uses.workspace = ? AND resources.scope != 'machine'
```

but the daemon took `workspace` from the request as a raw string. Any spelling that differed from the stored identity matched zero rows, and `done` returned `{"ok": true, "marked": 0}` — **a silent no-op reported as success**, leaving the caller believing their caches were now collectable when nothing was marked.

## Scope: three verbs, not one

The bundled CLI was never exposed — it sends `workspace_of(manifest)`, already normalized. The gap is the wire contract, which any non-CLI client hits.

Fixing only `done` would have been *worse than fixing nothing*: a client would then write registry rows under a raw identity via `converge` / `execution-acquire` that the now-normalized `done` could never match, permanently pinning those resources. So all three normalize:

| Verb | Side | Consequence of the gap |
|---|---|---|
| `done` | read | silent no-op reported as success |
| `execution-acquire` | write | container row written under an identity `done` can't match |
| `converge` | write | same, **plus** fragments the job slot's `(workspace, stack)` coalescing key, letting two spellings of one workspace build unserialized |

That last one is the per-worktree splitting problem #1 already fixed for the CLI path, reachable again through IPC.

`_verb_adopt` takes no `workspace` argument and needed no change.

Normalization is idempotent, so applying it to `workspace_of`'s already-canonical value is a no-op — verified across every supported spelling, including the round-trip.

## Also

- **`/cygdrive/c/...` is recognized.** It previously fell through to a bogus identity rooted at a nonexistent `c:\cygdrive\c\...`. All five Windows spellings now collapse to one identity. Cygwin is not a supported shell, so this is defense in depth; `paths.py`'s docstring now states the supported set explicitly instead of implying WSL is supported when `in_wsl()` rejects it.
- **The Windows access-denied liveness path is covered natively (#68).** `os.kill(4, 0)` against the `System` process raises `SystemError` — *not* an `OSError` — so it escapes ordinary handlers; unhandled, one poisoned lease aborted the whole prune loop and every GC pass after it. Only a real probe proves the handler still fails open. The test accepts either `SystemError` or `PermissionError`, since hosted runners may differ in privilege, but fails if the OS stops raising at all — that would mean the handler's premise changed.

## Verification

Both fixes are RED→GREEN. Without the `done` fix the new daemon test reports exactly the production symptom:

```
assert {'ok': True, 'marked': 0} == {'ok': True, 'marked': 1}
```

`ci/lint.py` → LINT OK. 410 passed, 2 skipped locally; Docker-marked tests run on the Linux lane.

## Judgment call left open

#67 asks whether `marked: 0` should be distinguishable from success. Deliberately not changed here: once the boundaries normalize, `marked: 0` is no longer a *false* signal — it truthfully means no active uses exist under that identity. Distinguishing "unknown workspace" would need a notion of workspace existence the registry doesn't have, and the wire-format risk isn't justified by a problem this fix already resolves. An additive field remains available later without a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)