### PR TITLE
release: 0.1.0a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "bosn"
-version = "0.1.0"
-description = "A machine-wide lifecycle supervisor for container development resources"
+version = "0.1.0a1"
+description = "Let your agents use Docker all day without filling the disk"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"

--- a/src/bosn/__init__.py
+++ b/src/bosn/__init__.py
@@ -1,5 +1,5 @@
 """bosn - a machine-wide lifecycle supervisor for container development resources."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.0a1"
 
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "bosn"
-version = "0.1.0"
+version = "0.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "running-process" },


### PR DESCRIPTION
First real release — PyPI holds only a `0.0.0` placeholder today.

## Version choice

`0.1.0` was declared in `pyproject.toml` but never published, so an alpha of it is the honest next step rather than inventing a new minor:

```
0.0.0 < 0.1.0a1 < 0.1.0    # PEP 440
```

An upgrade over the published placeholder, and a genuine pre-release of the version already declared.

**Pre-release rather than `0.1.0` final** because the README now says plainly what is not done: the Docker front door is a narrow subset, `bosn-docker compose` does not label volumes or networks, and podman and the `docker` shims are unbuilt. Shipping that as a stable `0.1.0` would oversell it.

## Also

Aligns the package summary with the rewritten README. It still read *"A machine-wide lifecycle supervisor for container development resources"* — the category description #72 replaced — which would have been the first line on the PyPI page, directly above a body arguing that framing is wrong. The README ships as the long description, so the two are visible together.

## Verification

- 413 tests pass, `ci/lint.py` clean
- Wheel inspected: 27 files, no strays, both console scripts (`bosn`, `bosn-docker`), MIT license included
- Package name is reserved by the repo owner

Publishing to PyPI from local credentials once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)