### PR TITLE
feat: declare bind mounts and volume destinations in the manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,26 +125,42 @@ Startup `.cmd` loop, so it leaves a console window open.)
 
 This is the part most likely to surprise you, and it decides how you write the Dockerfile.
 
-**Declared volumes exist only when a command runs. `docker build` never sees them.**
+**Mounts exist only when a command runs. `docker build` never sees them.**
 
-| Path | What it is | When |
+| Declared as | Lands at | bosn's relationship to it |
 | --- | --- | --- |
-| `/bosn/<volume-name>` | each declared volume, read-write | command execution only |
-| `/bosn-daemon/heartbeat` | the daemon's liveness file, read-only | command execution only |
+| `[stack.X.volumes]` | `/bosn/<name>`, or an explicit `destination` | owns it — labels, tracks, and may delete it |
+| `[stack.X.mounts]` | the `destination` you give | only references it — never labeled, never deleted |
+| *(automatic)* | `/bosn-daemon/heartbeat`, read-only | the daemon's liveness file |
 
-That is the entire mount set, and it has three consequences:
+That distinction is the whole reason binds are a separate table: bosn deletes Docker objects
+it owns, and a host path is not one.
 
-**Your source tree is not bind-mounted.** Your Dockerfile `COPY`s it in, which is what makes
-the content digest meaningful — and it means editing a copied source file rolls a new
-generation and rebuilds. That is the model, not a bug.
+**Bind-mount your source tree if you want an edit-in-place loop:**
 
-**Anything you want cached during the build needs a BuildKit cache mount**
-(`RUN --mount=type=cache,...`), not a bosn volume. bosn does not manage the builder cache
-(see Status), so that cache is outside its accounting — it is also the one thing bosn will
-never delete out from under you.
+```toml
+[stack.test.mounts]
+repo = { source = ".", destination = "/repo" }
+conf = { source = "./config", destination = "/etc/app", readonly = true }
+```
+
+`source` is relative to the manifest root and must exist — a missing source is an error, not
+an empty directory the engine creates for you. A destination inside `/bosn/*`, a relative
+destination, or two mounts sharing one destination are all refused at parse time.
+
+**The declaration is digested; a bind source's contents are not.** Moving a mount rolls the
+generation. Editing a file that is only visible through a bind does not — that is exactly
+what a bind is for, and hashing a live working tree would rebuild on every keystroke. Files
+your Dockerfile `COPY`s are still content-digested as usual, so you choose per path whether
+something participates in identity.
+
+**Anything you want cached during the *build* needs a BuildKit cache mount**
+(`RUN --mount=type=cache,...`), not a bosn volume — mounts are run-time only. bosn does not
+manage the builder cache (see Status), so it is outside bosn's accounting, and also the one
+thing bosn will never delete out from under you.
 
 **Declaring a volume wires it to nothing.** The manifest has no `env` or `workdir` key, so
-the Dockerfile has to point the toolchain at the mount:
+either point the toolchain at the mount from the Dockerfile:
 
 ```dockerfile
 ENV CARGO_HOME=/bosn/cargo-reg \
@@ -152,7 +168,13 @@ ENV CARGO_HOME=/bosn/cargo-reg \
     CARGO_TARGET_DIR=/bosn/target
 ```
 
-Without those lines the example above creates three volumes and warms none of them.
+or give the volume the destination the image already expects, which is the easier path when
+adopting an existing image:
+
+```toml
+[stack.test.volumes]
+cargo-reg = { scope = "machine", destination = "/root/.cargo" }
+```
 
 The image also needs a POSIX shell with `date`, `stat`, and `sleep`: the persistent
 container's PID 1 is a shell loop, and `bosn shell` execs `sh`. Distroless and scratch

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -19,7 +19,14 @@ from dataclasses import dataclass
 
 from bosn import labels
 from bosn.engine import Engine, EngineError
-from bosn.manifest import Manifest, StackSpec, dockerfile_external_images, generation_digest
+from bosn.manifest import (
+    RESERVED_HEARTBEAT,
+    RESERVED_PREFIX,
+    Manifest,
+    StackSpec,
+    dockerfile_external_images,
+    generation_digest,
+)
 from bosn.registry import Lease, Registry, Resource
 from bosn.resources import ResourceScanner, process_start_time
 
@@ -700,12 +707,19 @@ class Converger:
     ) -> dict[str, dict[str, str | bool]]:
         mounts: dict[str, dict[str, str | bool]] = {}
         for volume, volume_name in zip(stack.volumes, volume_names, strict=True):
-            destination = f"/bosn/{volume.name}"
+            destination = volume.mount_at()
             mounts[destination] = {
                 "type": "volume",
                 "source": volume_name,
                 "destination": destination,
                 "rw": True,
+            }
+        for mount in stack.mounts:
+            mounts[mount.destination] = {
+                "type": "bind",
+                "source": str(mount.resolve_source(self.manifest.root)),
+                "destination": mount.destination,
+                "rw": not mount.readonly,
             }
         heartbeat = (self.registry.path.parent / "daemon.heartbeat").resolve()
         heartbeat.touch(exist_ok=True)
@@ -834,10 +848,21 @@ class Converger:
             for mount in raw_mounts
             if isinstance(mount, dict) and mount.get("Destination")
         }
+        # "Managed" is whatever this generation declares, plus anything still sitting in
+        # bosn's reserved namespace even if the current declaration no longer names it --
+        # that catches a volume whose default destination moved. A dropped bind mount is
+        # *not* caught here: its declaration lived outside the reserved namespace, so a
+        # leftover copy is indistinguishable from a foreign mount. That's fine -- removing
+        # a mount from the manifest changes the digest, and the generation check above
+        # forces replacement before this comparison ever runs. A destination outside both
+        # is a mount the user added out-of-band; bosn doesn't own it and must not treat its
+        # mere presence as staleness.
         managed_destinations = {
             destination
             for destination in actual
-            if destination.startswith("/bosn/") or destination == "/bosn-daemon/heartbeat"
+            if destination in expected
+            or destination.startswith(RESERVED_PREFIX)
+            or destination == RESERVED_HEARTBEAT
         }
         if managed_destinations != set(expected):
             return False

--- a/src/bosn/manifest.py
+++ b/src/bosn/manifest.py
@@ -23,15 +23,37 @@ from typing import Any
 MANIFEST_NAME = "bosn.toml"
 VALID_SCOPES = {"spec", "stack", "machine"}
 
+# bosn mounts its own objects under this prefix and keeps the daemon heartbeat beside
+# it. User mounts may not land here: a collision would shadow a managed volume or the
+# liveness file the container's PID 1 watches.
+RESERVED_PREFIX = "/bosn/"
+RESERVED_HEARTBEAT = "/bosn-daemon/heartbeat"
+
 
 class ManifestError(ValueError):
     """The manifest is malformed, or names something that does not exist."""
+
+
+def _validate_destination(destination: str, *, what: str, name: str) -> str:
+    """A mount destination must be absolute, unique, and outside bosn's own namespace."""
+    if not destination.startswith("/"):
+        raise ManifestError(
+            f"{what} {name!r} has destination {destination!r}; it must be an absolute path"
+        )
+    normalized = destination.rstrip("/") or "/"
+    if normalized == RESERVED_HEARTBEAT.rstrip("/") or normalized.startswith(RESERVED_PREFIX):
+        raise ManifestError(
+            f"{what} {name!r} would mount at {destination!r}, inside bosn's reserved "
+            f"namespace ({RESERVED_PREFIX}*, {RESERVED_HEARTBEAT}); choose another destination"
+        )
+    return normalized
 
 
 @dataclass(frozen=True)
 class VolumeSpec:
     name: str
     scope: str
+    destination: str | None = None
 
     def __post_init__(self) -> None:
         if self.scope not in VALID_SCOPES:
@@ -39,6 +61,61 @@ class VolumeSpec:
                 f"volume {self.name!r} has unknown scope {self.scope!r}; "
                 f"expected one of {sorted(VALID_SCOPES)}"
             )
+        if self.destination is not None:
+            object.__setattr__(
+                self,
+                "destination",
+                _validate_destination(self.destination, what="volume", name=self.name),
+            )
+
+    def mount_at(self) -> str:
+        """Where this volume lands in the container.
+
+        Defaults to bosn's own namespace; an explicit destination lets an existing image
+        keep the paths its ENV already points at instead of rewriting its Dockerfile.
+        """
+        return self.destination or f"{RESERVED_PREFIX}{self.name}"
+
+
+@dataclass(frozen=True)
+class MountSpec:
+    """A host path bind-mounted into the container.
+
+    bosn *owns* volumes and may delete them; it only *references* a bind source and must
+    never touch it. That distinction is why binds are a separate table rather than another
+    volume scope: nothing here is ever labeled, registered, or collected.
+    """
+
+    name: str
+    source: str
+    destination: str
+    readonly: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.source:
+            raise ManifestError(f"mount {self.name!r} must set `source`")
+        if not self.destination:
+            raise ManifestError(f"mount {self.name!r} must set `destination`")
+        object.__setattr__(
+            self,
+            "destination",
+            _validate_destination(self.destination, what="mount", name=self.name),
+        )
+
+    def resolve_source(self, root: Path) -> Path:
+        """The absolute host path, relative to the manifest root.
+
+        A missing source is an error rather than a silently engine-created empty
+        directory: mounting a directory that was supposed to hold your source tree, and
+        getting an empty one, fails much later and much more confusingly.
+        """
+        resolved = (root / self.source).resolve()
+        if not resolved.exists():
+            raise ManifestError(
+                f"mount {self.name!r} sources {self.source!r}, which resolves to "
+                f"{resolved} and does not exist"
+            )
+        return resolved
 
 
 @dataclass(frozen=True)
@@ -49,6 +126,7 @@ class StackSpec:
     family: str | None = None
     default: bool = False
     volumes: tuple[VolumeSpec, ...] = ()
+    mounts: tuple[MountSpec, ...] = ()
 
     def referenced_files(self, root: Path) -> list[Path]:
         """Files whose byte content folds into this stack's digest."""
@@ -132,6 +210,31 @@ def load(path: Path | str) -> Manifest:
     return parse(raw, root=path.parent)
 
 
+def _refuse_duplicate_destinations(
+    stack: str, volumes: tuple[VolumeSpec, ...], mounts: tuple[MountSpec, ...]
+) -> None:
+    """Two mounts at one destination is last-writer-wins in Docker; refuse it here.
+
+    The engine accepts the container and one of the two simply does not appear, which
+    surfaces as a mysteriously empty directory rather than an error.
+    """
+    seen: dict[str, str] = {}
+    for volume in volumes:
+        seen[volume.mount_at()] = f"volume {volume.name!r}"
+    for mount in mounts:
+        previous = seen.get(mount.destination)
+        if previous is not None:
+            raise ManifestError(
+                f"[stack.{stack}] mounts {mount.destination!r} twice: "
+                f"{previous} and mount {mount.name!r}"
+            )
+        seen[mount.destination] = f"mount {mount.name!r}"
+    destinations = [v.mount_at() for v in volumes]
+    if len(set(destinations)) != len(destinations):
+        duplicated = sorted({d for d in destinations if destinations.count(d) > 1})
+        raise ManifestError(f"[stack.{stack}] mounts {duplicated} more than once")
+
+
 def parse(raw: dict, root: Path) -> Manifest:
     manifest = Manifest(root=root)
 
@@ -139,9 +242,27 @@ def parse(raw: dict, root: Path) -> Manifest:
         if not isinstance(body, dict):
             raise ManifestError(f"[stack.{name}] must be a table")
         volumes = tuple(
-            VolumeSpec(name=vol_name, scope=str((vol_body or {}).get("scope", "spec")))
+            VolumeSpec(
+                name=vol_name,
+                scope=str((vol_body or {}).get("scope", "spec")),
+                destination=(
+                    str((vol_body or {}).get("destination"))
+                    if (vol_body or {}).get("destination")
+                    else None
+                ),
+            )
             for vol_name, vol_body in (body.get("volumes") or {}).items()
         )
+        mounts = tuple(
+            MountSpec(
+                name=mount_name,
+                source=str((mount_body or {}).get("source", "")),
+                destination=str((mount_body or {}).get("destination", "")),
+                readonly=bool((mount_body or {}).get("readonly", False)),
+            )
+            for mount_name, mount_body in (body.get("mounts") or {}).items()
+        )
+        _refuse_duplicate_destinations(name, volumes, mounts)
         stack = StackSpec(
             name=name,
             dockerfile=body.get("dockerfile"),
@@ -149,6 +270,7 @@ def parse(raw: dict, root: Path) -> Manifest:
             family=body.get("family"),
             default=bool(body.get("default", False)),
             volumes=volumes,
+            mounts=mounts,
         )
         if stack.dockerfile is None and stack.image is None:
             raise ManifestError(f"[stack.{name}] must set either `dockerfile` or `image`")
@@ -189,7 +311,12 @@ def generation_digest(manifest: Manifest, stack: StackSpec) -> str:
         "dockerfile": stack.dockerfile,
         "image": stack.image,
         "family": stack.family,
-        "volumes": sorted((v.name, v.scope) for v in stack.volumes),
+        # Declarations are digested; a bind source's *contents* deliberately are not.
+        # Where something is mounted is part of this stack's identity, but the live
+        # working tree behind a bind is exactly the thing a bind exists to keep outside
+        # content identity -- and hashing it would be both enormous and never stable.
+        "volumes": sorted((v.name, v.scope, v.mount_at()) for v in stack.volumes),
+        "mounts": sorted((m.name, m.source, m.destination, m.readonly) for m in stack.mounts),
     }
     _hash_field(
         hasher,

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -124,7 +124,12 @@ class FakeEngine:
                 read_only = rendered.endswith(":ro")
                 core = rendered[:-3] if read_only else rendered
                 source, destination = core.rsplit(":", 1)
-                mount_type = "bind" if destination == "/bosn-daemon/heartbeat" else "volume"
+                # A named volume's "source" is a bare token; a bind source is always a
+                # path. That's the only signal available here to tell them apart.
+                is_path = "/" in source or "\\" in source
+                mount_type = (
+                    "bind" if destination == "/bosn-daemon/heartbeat" or is_path else "volume"
+                )
                 mounts.append(
                     {
                         "Type": mount_type,
@@ -184,6 +189,27 @@ class FakeEngine:
 def project(tmp_path: Path) -> Path:
     (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
     (tmp_path / "bosn.toml").write_text(SAMPLE, encoding="utf-8")
+    return tmp_path
+
+
+BIND_SAMPLE = """
+[stack.test]
+dockerfile = "Dockerfile"
+family = "rust"
+default = true
+
+[stack.test.mounts]
+repo = { source = "repo", destination = "/repo" }
+"""
+
+
+@pytest.fixture
+def bind_project(tmp_path: Path) -> Path:
+    """A stack with one declared bind mount and no volumes, so mount matching is isolated."""
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "repo").mkdir()
+    (tmp_path / "repo" / "marker").write_text("hi", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(BIND_SAMPLE, encoding="utf-8")
     return tmp_path
 
 
@@ -995,6 +1021,151 @@ def test_changed_required_mount_recreates_an_owned_container(converger: Converge
 
     assert len(engine.ran("container", "rm", "--force")) == 1
     assert len(engine.ran("create")) == 2
+
+
+# -- bind mounts -------------------------------------------------------------
+
+
+def test_volume_with_explicit_destination_mounts_there_not_under_bosn(
+    tmp_path: Path, registry: Registry
+) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(
+        """
+[stack.test]
+dockerfile = "Dockerfile"
+default = true
+
+[stack.test.volumes]
+target = { scope = "spec", destination = "/target" }
+""",
+        encoding="utf-8",
+    )
+    engine = FakeEngine()
+    converger = Converger(load(tmp_path), registry, engine)  # type: ignore[arg-type]
+
+    converger.run(["true"])
+
+    create = engine.ran("create")[0]
+    volume_args = [a for a in create if ":/target" in a]
+    assert len(volume_args) == 1
+    assert not any(":/bosn/target" in a for a in create)
+
+
+def test_bind_mount_reaches_the_container_with_source_destination_and_readonly(
+    tmp_path: Path, registry: Registry
+) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "secrets").mkdir()
+    (tmp_path / "bosn.toml").write_text(
+        """
+[stack.test]
+dockerfile = "Dockerfile"
+default = true
+
+[stack.test.mounts]
+secrets = { source = "secrets", destination = "/etc/app", readonly = true }
+""",
+        encoding="utf-8",
+    )
+    engine = FakeEngine()
+    converger = Converger(load(tmp_path), registry, engine)  # type: ignore[arg-type]
+
+    converger.run(["true"])
+
+    create = engine.ran("create")[0]
+    source = str((tmp_path / "secrets").resolve())
+    assert "--volume" in create
+    assert f"{source}:/etc/app:ro" in create
+
+
+def test_bind_mount_source_is_never_registered_labeled_or_collected(
+    bind_project: Path, registry: Registry
+) -> None:
+    """bosn owns volumes and may delete them; it only references a bind source."""
+    engine = FakeEngine()
+    converger = Converger(load(bind_project), registry, engine)  # type: ignore[arg-type]
+
+    converger.run(["true"])
+
+    resource_kinds = {r.kind for r in registry.list_resources()}
+    assert resource_kinds <= {"image", "container"}
+    repo_source = str((bind_project / "repo").resolve())
+    assert all(r.name != repo_source for r in registry.list_resources())
+    assert engine.ran("volume", "create") == []
+
+
+def test_container_matching_its_full_declared_mount_set_is_reused(
+    bind_project: Path, registry: Registry
+) -> None:
+    """The opposite failure: a bind-mounted container must not be needlessly replaced.
+
+    RED before the Task 2 fix: the old filter only ever counted `/bosn/*` and the
+    heartbeat as "managed", so a declared bind destination like `/repo` never appeared in
+    that set. The equality check against the full expected set then failed unconditionally,
+    and a container whose bind mount was correct in every respect still got torn down and
+    recreated on every single run.
+    """
+    engine = FakeEngine()
+    converger = Converger(load(bind_project), registry, engine)  # type: ignore[arg-type]
+    converger.run(["true"])
+    assert len(engine.ran("create")) == 1
+
+    converger.run(["true"])
+
+    assert len(engine.ran("create")) == 1, "an unchanged bind mount must not force a rebuild"
+    assert engine.ran("container", "rm", "--force") == []
+
+
+def test_bind_mount_source_drift_is_not_silently_reused() -> None:
+    """RED before the Task 2 fix: `/repo` is outside `/bosn/*`, so the old filter dropped it
+    from the "managed" set entirely and the per-entry source comparison below was never
+    reached -- a drifted bind source was invisible to the match, not merely tolerated."""
+    expected = {
+        "/bosn-daemon/heartbeat": {
+            "type": "bind",
+            "source": "/state/heartbeat",
+            "destination": "/bosn-daemon/heartbeat",
+            "rw": False,
+        },
+        "/repo": {
+            "type": "bind",
+            "source": "/host/repo",
+            "destination": "/repo",
+            "rw": True,
+        },
+    }
+    matching = [
+        {
+            "Type": "bind",
+            "Source": "/state/heartbeat",
+            "Destination": "/bosn-daemon/heartbeat",
+            "RW": False,
+        },
+        {"Type": "bind", "Source": "/host/repo", "Destination": "/repo", "RW": True},
+    ]
+    drifted_source = [
+        {
+            "Type": "bind",
+            "Source": "/state/heartbeat",
+            "Destination": "/bosn-daemon/heartbeat",
+            "RW": False,
+        },
+        {"Type": "bind", "Source": "/host/OLD-repo", "Destination": "/repo", "RW": True},
+    ]
+    drifted_destination = [
+        {
+            "Type": "bind",
+            "Source": "/state/heartbeat",
+            "Destination": "/bosn-daemon/heartbeat",
+            "RW": False,
+        },
+        {"Type": "bind", "Source": "/host/repo", "Destination": "/moved", "RW": True},
+    ]
+
+    assert Converger._container_mounts_match(matching, expected) is True
+    assert Converger._container_mounts_match(drifted_source, expected) is False
+    assert Converger._container_mounts_match(drifted_destination, expected) is False
 
 
 def test_changed_image_id_recreates_an_owned_container(converger: Converger) -> None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -319,3 +319,123 @@ def test_a_missing_referenced_file_is_an_error_not_a_zero(project: Path) -> None
     manifest = load(project)
     with pytest.raises(ManifestError, match="does not exist"):
         generation_digest(manifest, manifest.stacks["test"])
+
+
+# -- bind mounts and explicit volume destinations (#76) ----------------------
+
+
+BIND_SAMPLE = """
+[stack.test]
+dockerfile = "docker/test.Dockerfile"
+default = true
+
+[stack.test.volumes]
+target = { scope = "stack", destination = "/target" }
+cache  = { scope = "machine" }
+
+[stack.test.mounts]
+repo = { source = ".", destination = "/repo" }
+conf = { source = "docker", destination = "/etc/app", readonly = true }
+"""
+
+
+def _write(root: Path, body: str) -> Path:
+    (root / "docker").mkdir(exist_ok=True)
+    (root / "docker" / "test.Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (root / "bosn.toml").write_text(body, encoding="utf-8")
+    return root
+
+
+def test_mounts_and_explicit_volume_destinations_parse(tmp_path: Path) -> None:
+    stack = load(_write(tmp_path, BIND_SAMPLE)).stacks["test"]
+
+    assert {v.name: v.mount_at() for v in stack.volumes} == {
+        "target": "/target",  # explicit destination honored
+        "cache": "/bosn/cache",  # default when omitted
+    }
+    assert [(m.name, m.destination, m.readonly) for m in stack.mounts] == [
+        ("repo", "/repo", False),
+        ("conf", "/etc/app", True),
+    ]
+    assert stack.mounts[0].resolve_source(tmp_path) == tmp_path.resolve()
+
+
+def test_a_missing_bind_source_is_an_error_not_an_empty_directory(tmp_path: Path) -> None:
+    """Docker would create the source silently; an empty /repo fails much later."""
+    body = BIND_SAMPLE.replace('source = "."', 'source = "does-not-exist"')
+    stack = load(_write(tmp_path, body)).stacks["test"]
+
+    with pytest.raises(ManifestError, match="does not exist"):
+        stack.mounts[0].resolve_source(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "destination",
+    ["/bosn/target", "/bosn-daemon/heartbeat"],
+)
+def test_a_mount_inside_bosns_own_namespace_is_refused(tmp_path: Path, destination: str) -> None:
+    """Shadowing a managed volume or the heartbeat the container's PID 1 watches."""
+    body = BIND_SAMPLE.replace('destination = "/repo"', f'destination = "{destination}"')
+
+    with pytest.raises(ManifestError, match="reserved"):
+        load(_write(tmp_path, body))
+
+
+def test_a_relative_destination_is_refused(tmp_path: Path) -> None:
+    body = BIND_SAMPLE.replace('destination = "/repo"', 'destination = "repo"')
+
+    with pytest.raises(ManifestError, match="absolute"):
+        load(_write(tmp_path, body))
+
+
+def test_two_mounts_at_one_destination_are_refused(tmp_path: Path) -> None:
+    """Docker takes the last one silently, leaving the other mysteriously absent."""
+    body = BIND_SAMPLE.replace('destination = "/etc/app"', 'destination = "/repo"')
+
+    with pytest.raises(ManifestError, match="twice"):
+        load(_write(tmp_path, body))
+
+
+def test_a_bind_colliding_with_a_volume_destination_is_refused(tmp_path: Path) -> None:
+    body = BIND_SAMPLE.replace('destination = "/repo"', 'destination = "/target"')
+
+    with pytest.raises(ManifestError, match="twice"):
+        load(_write(tmp_path, body))
+
+
+def test_moving_a_mount_rolls_the_generation(tmp_path: Path) -> None:
+    """Where something is mounted is part of the stack's identity."""
+    before = load(_write(tmp_path, BIND_SAMPLE))
+    after = load(_write(tmp_path, BIND_SAMPLE.replace('"/repo"', '"/src"')))
+
+    assert generation_digest(before, before.stacks["test"]) != generation_digest(
+        after, after.stacks["test"]
+    )
+
+
+def test_the_digest_splits_copied_files_from_bind_source_contents(tmp_path: Path) -> None:
+    """The deliberate narrowing: a bind exists to keep its contents OUT of identity.
+
+    Proven both ways against one Dockerfile that COPYs a single file. Editing the copied
+    file rolls the generation; editing a sibling visible only through the bind does not.
+    Without that second half a live working tree would rebuild on every keystroke, which
+    is the reason for bind-mounting it in the first place.
+    """
+    root = _write(tmp_path, BIND_SAMPLE)
+    (root / "docker" / "test.Dockerfile").write_text(
+        "FROM alpine\nCOPY copied.py /copied.py\n", encoding="utf-8"
+    )
+    (root / "copied.py").write_text("print('one')\n", encoding="utf-8")
+    (root / "only_bind_mounted.py").write_text("print('one')\n", encoding="utf-8")
+
+    def digest() -> str:
+        loaded = load(root)
+        return generation_digest(loaded, loaded.stacks["test"])
+
+    baseline = digest()
+
+    (root / "only_bind_mounted.py").write_text("print('edited')\n", encoding="utf-8")
+    assert digest() == baseline, "a bind source's contents must not roll the generation"
+
+    (root / "copied.py").write_text("print('edited')\n", encoding="utf-8")
+    assert digest() != baseline, "a COPYed file must roll the generation"


### PR DESCRIPTION
Fixes #76

bosn mounted exactly two things into a run container: each declared volume at the hardcoded path `/bosn/<name>`, and the daemon heartbeat. No bind mounts, no choice of destination.

That ruled out the workload bosn was designed for. soldr's `ci/perf_local.py` bind-mounts its checkout root at `/repo` for an edit-in-place loop, and its image hardcodes `/root/.cargo`, `/venv`, `/target`, `/root/.cache/uv` (see #75, where this was conflict 1 and conflict 2).

## What lands

```toml
[stack.test.volumes]
target    = { scope = "stack" }                              # -> /bosn/target
cargo-reg = { scope = "machine", destination = "/root/.cargo" }   # image's own path

[stack.test.mounts]
repo = { source = ".", destination = "/repo" }
conf = { source = "./config", destination = "/etc/app", readonly = true }
```

**Binds are a separate table, not another volume scope**, because the lifecycles differ: bosn *owns* volumes and may delete them; it only *references* a bind source and must never touch it. Nothing under `mounts` is labeled, registered, or collectable — pinned by a test that asserts no volume row appears and the resolved host path never shows up as a registered resource.

## Digest semantics

**The declaration is digested; a bind source's contents are not.** Moving a mount rolls the generation; editing a file visible only through a bind does not — hashing a live working tree would rebuild on every keystroke, which is the entire reason for bind-mounting it. Files your Dockerfile `COPY`s are still content-digested, so you choose per path whether something participates in identity.

One test proves both halves against a Dockerfile that `COPY`s a single file. (My first version of it was vacuous — the fixture Dockerfile had no `COPY`, so nothing was digested either way and the assertion passed for the wrong reason.)

## Refused at parse time

Each with a specific error: a relative destination, anything inside `/bosn/*` or the heartbeat path, two mounts sharing a destination, a bind colliding with a volume destination, and a source that does not exist — Docker would silently create an empty directory there, and an empty `/repo` fails much later and far more confusingly than a parse error.

## The reuse trap, and a correction

`_container_mounts_match` filtered the actual mount set down to destinations starting with `/bosn/`. I predicted in #76 that a changed bind would therefore be *silently reused*. Building it showed the opposite: once binds exist in the expected set, a non-`/bosn/` destination can never enter `managed_destinations`, so the sets never match and the container is **torn down and rebuilt on every run**. Both are bugs; the real one is worth recording accurately.

The predicate is now the union of what this generation declares and anything still sitting in bosn's reserved namespace. A destination outside both is a mount the user added out-of-band — bosn does not own it and must not treat its presence as staleness. The comment says plainly what this does *not* cover (a dropped bind) and why that is safe (removing it changes the digest, and the generation check runs first).

## Verification

427 tests pass, `ci/lint.py` clean. End-to-end check:

```
volume destinations:
  target   scope=stack    -> /target
  cache    scope=machine  -> /bosn/cache
bind mounts:
  repo     ro=False  ...\src -> /repo
  conf     ro=True   ...\src -> /etc/app
```

README's execution-model section is rewritten — it previously stated flatly that your source tree is not bind-mounted, which this makes false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)