### PR TITLE
fix: accept every supported shell's path spelling, not just compare them

### DIFF
--- a/src/bosn/manifest.py
+++ b/src/bosn/manifest.py
@@ -105,11 +105,20 @@ class MountSpec:
     def resolve_source(self, root: Path) -> Path:
         """The absolute host path, relative to the manifest root.
 
+        The spelling is whatever shell wrote the manifest. A path typed in Git Bash reads
+        `/c/work/repo`, which `Path` on Windows would join into `C:\\c\\work\\repo` -- a
+        directory that does not exist, so the check below would reject a source that is
+        perfectly valid. Unlike argv, a string inside bosn.toml never passes through MSYS
+        path conversion, so nothing upstream has already fixed it.
+
         A missing source is an error rather than a silently engine-created empty
         directory: mounting a directory that was supposed to hold your source tree, and
         getting an empty one, fails much later and much more confusingly.
         """
-        resolved = (root / self.source).resolve()
+        from bosn.paths import to_host_path
+
+        spelled = to_host_path(self.source)
+        resolved = (spelled if spelled.is_absolute() else root / spelled).resolve()
         if not resolved.exists():
             raise ManifestError(
                 f"mount {self.name!r} sources {self.source!r}, which resolves to "
@@ -198,7 +207,12 @@ def find_manifest(start: Path | None = None) -> Path | None:
 
 
 def load(path: Path | str) -> Manifest:
-    path = Path(path)
+    # Accepts whatever spelling the caller's shell produced. Argv from Git Bash is usually
+    # converted to a native path before it reaches us, but "usually" is not a contract:
+    # MSYS_NO_PATHCONV, a path built inside a script, or an IPC client all bypass it.
+    from bosn.paths import to_host_path
+
+    path = to_host_path(path)
     if path.is_dir():
         path = path / MANIFEST_NAME
     if not path.is_file():

--- a/src/bosn/paths.py
+++ b/src/bosn/paths.py
@@ -19,6 +19,31 @@ import re
 from pathlib import Path
 
 
+def to_host_path(path: str | Path) -> Path:
+    """A shell's spelling of a path, as this OS's filesystem wants it.
+
+    `normalize_workspace_path` answers "are these the same workspace?" and normcases to
+    get there, which makes its result an identity, not a usable path. This answers the
+    other question -- "what do I open?" -- and preserves case, because a mount source or a
+    manifest location is handed to the engine and to the filesystem.
+
+    Only drive-rooted spellings are rewritten. A plain POSIX path is returned untouched,
+    so this is a no-op on Linux and macOS rather than something that has to be guarded at
+    every call site.
+    """
+    raw = str(path)
+    forward = raw.replace("\\", "/")
+    forward = re.sub(r"^//\?/", "", forward)
+    match = re.match(r"^/(?:mnt/|cygdrive/)?([a-zA-Z])/(.*)$", forward)
+    if match is None:
+        return Path(raw)
+    if os.name != "nt":
+        # `/c/x` on a POSIX host is a real path that happens to look like an MSYS
+        # spelling. Rewriting it to `C:/x` there would invent a path that cannot exist.
+        return Path(raw)
+    return Path(f"{match.group(1).upper()}:/{match.group(2)}")
+
+
 def normalize_workspace_path(path: str | Path) -> str:
     raw = str(path).replace("\\", "/")
     raw = re.sub(r"^//\?/", "", raw)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -439,3 +439,27 @@ def test_the_digest_splits_copied_files_from_bind_source_contents(tmp_path: Path
 
     (root / "copied.py").write_text("print('edited')\n", encoding="utf-8")
     assert digest() != baseline, "a COPYed file must roll the generation"
+
+
+def test_a_git_bash_spelled_bind_source_resolves(tmp_path: Path) -> None:
+    r"""A manifest written in one shell must work when read in another.
+
+    Argv from Git Bash is usually MSYS-converted to a native path before bosn sees it, but
+    a string inside bosn.toml never passes through that conversion. `/c/work/repo` would
+    otherwise be joined into `C:\c\work\repo` and rejected as missing.
+    """
+    import os
+
+    root = _write(tmp_path, BIND_SAMPLE)
+    (root / "src").mkdir()
+    native = str((root / "src").resolve())
+    if os.name != "nt":
+        pytest.skip("drive-letter spellings only differ on Windows")
+
+    drive = native[0].lower()
+    tail = native[2:].replace("\\", "/").lstrip("/")
+    body = BIND_SAMPLE.replace('source = "."', f'source = "/{drive}/{tail}"')
+
+    stack = load(_write(tmp_path, body)).stacks["test"]
+
+    assert stack.mounts[0].resolve_source(root) == (root / "src").resolve()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 from bosn.paths import normalize_workspace_path
 
 
@@ -28,3 +31,45 @@ def test_wsl_is_rejected_with_the_transport_explanation(monkeypatch, capsys) -> 
     monkeypatch.setattr("bosn.paths.in_wsl", lambda: True)
     assert bosn.cli.main(["--version"]) == 1
     assert "does not support WSL" in capsys.readouterr().err
+
+
+# -- shell spellings must be interchangeable, not just comparable ------------
+
+
+def test_to_host_path_accepts_every_supported_shells_spelling(tmp_path) -> None:
+    """`normalize_workspace_path` answers "same workspace?"; this answers "what do I open?".
+
+    The identity function normcases, so its output is not a usable path. A bind mount
+    source and a manifest location are handed to the filesystem and the engine, so they
+    need the real spelling with case intact.
+    """
+    from bosn.paths import to_host_path
+
+    native = str(tmp_path.resolve())
+    if os.name != "nt":
+        assert to_host_path(native) == Path(native)
+        return
+
+    drive = native[0].lower()
+    tail = native[2:].replace("\\", "/").lstrip("/")
+    for spelling in (
+        native,
+        f"/{drive}/{tail}",
+        f"/mnt/{drive}/{tail}",
+        f"/cygdrive/{drive}/{tail}",
+    ):
+        assert to_host_path(spelling).resolve() == tmp_path.resolve(), spelling
+
+    # Case is preserved -- unlike the identity function, which lowercases.
+    assert str(to_host_path(native)) == native
+
+
+def test_to_host_path_leaves_a_real_posix_path_alone() -> None:
+    """`/c/x` is a legitimate directory on Linux; rewriting it would invent `C:/x`."""
+    from bosn.paths import to_host_path
+
+    result = to_host_path("/c/projects/thing")
+    if os.name == "nt":
+        assert result == Path("C:/projects/thing")
+    else:
+        assert result == Path("/c/projects/thing")


### PR DESCRIPTION
Follow-up to #77, prompted by testing whether Git Bash and cmd.exe paths are actually interchangeable. They were not.

## What was broken

| Boundary | `C:\Users\...\src` | `/c/Users/.../src` |
| --- | --- | --- |
| Workspace identity | ✅ | ✅ same identity |
| **Bind mount source** | ✅ | ❌ resolved to `C:\c\Users\...`, rejected as missing |
| **Manifest path** | ✅ | ❌ `no manifest at \c\Users\...` |

bosn already knew how to read those spellings — but only for *identity*. `normalize_workspace_path` answers "are these the same workspace?" and normcases to get there, which makes its result an identity, not a path you can open. Nothing answered "what do I open?"

## The fix

`paths.to_host_path` converts a drive-rooted spelling (`/c/…`, `/mnt/c/…`, `/cygdrive/c/…`, `\?\C:\…`) to the native form **with case preserved**, because the result goes to the filesystem and to the engine rather than into a comparison. Applied at the two boundaries that take caller-written paths: `MountSpec.resolve_source` and `manifest.load`.

**On POSIX it is a deliberate no-op.** `/c/x` is a real directory on Linux; rewriting it to `C:/x` would invent a path that cannot exist. Pinned by a test.

## Why argv did not already cover this

MSYS rewrites absolute paths before a native binary sees them, so `bosn --manifest /c/work/bosn.toml` usually arrives already converted. But a string *inside* `bosn.toml` never passes through that conversion — and neither does a path built inside a script, or one sent by an IPC client. "Usually" is not a contract, and the manifest case is the one this feature actually needs.

## Verification

After:

```
--- bind mount source (MountSpec.resolve_source) ---
native  -> C:\Users\niteris\...\src
msys    -> C:\Users\niteris\...\src

--- manifest root discovery from an msys-spelled path ---
native  -> loaded, root=C:\Users\niteris\...
msys    -> loaded, root=C:\Users\niteris\...
```

430 tests pass, `ci/lint.py` clean. New tests cover all four spellings, case preservation, the POSIX no-op, and a `bosn.toml` whose bind source is written in Git Bash form.

Also fixes a `SyntaxWarning` I introduced in the new test's docstring — `\c` is an invalid escape, so the docstring is now raw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)