### PR TITLE
fix: govern every resource the Compose front door creates

### DIFF
--- a/src/bosn/accounting.py
+++ b/src/bosn/accounting.py
@@ -79,7 +79,16 @@ class StorageInventory:
 def resource_bytes(
     engine: Engine, resource: Resource, inventory: StorageInventory | None = None
 ) -> int | None:
-    """Return a resource's managed bytes, or None when the engine cannot attribute it."""
+    """Return a resource's managed bytes, or None when the engine cannot attribute it.
+
+    `docker system df -v` has no row shape for networks -- they hold no data, so there is
+    nothing to size. That absence must read as "known: zero bytes", not "unmeasured": `gc`
+    refuses to declare byte pressure resolved while any managed resource is unmeasured, so
+    treating every network as permanently unmeasured would wedge pressure resolution for
+    good on any project with a Compose-created network.
+    """
+    if resource.kind == "network":
+        return 0
     inventory = inventory or StorageInventory.collect(engine)
     return inventory.sizes.get((resource.kind, resource.name))
 

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -66,28 +66,153 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _yaml_scalar(value: str) -> str:
+    """Quote a label value so a YAML parser reads it back byte-for-byte.
+
+    Double quotes were the obvious choice and were wrong on Windows: YAML processes escape
+    sequences inside them, so a workspace of `C:\\Users\\me` contains `\\U`, which YAML reads
+    as the start of an 8-hex-digit unicode escape and rejects outright. Compose therefore
+    could not parse its own generated overlay on the platform bosn is developed on.
+
+    Single-quoted YAML performs no escape processing at all; the only special character is
+    the quote itself, escaped by doubling.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _parse_top_level_entries(text: str, section: str) -> list[str]:
+    """Collect entry names declared directly under a top-level `<section>:` block.
+
+    Deliberately narrow, matching the existing service-name parser's shape: only
+    lines that look exactly like `  name:` (two-space indent) immediately inside
+    the top-level block named `section` count. A line starting at column 0 ends
+    the block -- including one that opens a *different* top-level section -- so a
+    service's own nested `volumes:`/`networks:` keys (which live at four-or-more
+    space indent inside `services:`) are never mistaken for top-level
+    declarations. #47 tracks replacing this with a real YAML model.
+    """
+    names: list[str] = []
+    in_section = False
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if re.match(r"^\S", raw):
+            in_section = raw.rstrip() == f"{section}:"
+            continue
+        if not in_section:
+            continue
+        entry = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", raw)
+        if entry:
+            names.append(entry.group(1))
+    return names
+
+
+def _find_anonymous_service_volumes(text: str) -> list[str]:
+    """Find service-level `volumes:` list entries with no top-level name to label.
+
+    A service's short-syntax volume entry with no `:` (e.g. `- /data`) creates an
+    anonymous volume Compose names at runtime -- there is no stable top-level key
+    an overlay can attach `labels:` to. Entries of the form `name:/path` or
+    `./host:/path` are excluded: those reference a top-level named volume (already
+    labeled) or a bind mount (outside bosn's scope). Detection is line-based and
+    only looks inside a service's nested `    volumes:` list, matching the same
+    narrow parsing style as `_parse_top_level_entries`; #47 tracks a real parser.
+    """
+    found: list[str] = []
+    in_services = False
+    current_service: str | None = None
+    in_volumes_list = False
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if re.match(r"^\S", raw):
+            in_services = raw.rstrip() == "services:"
+            current_service = None
+            in_volumes_list = False
+            continue
+        if not in_services:
+            continue
+        service = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", raw)
+        if service:
+            current_service = service.group(1)
+            in_volumes_list = False
+            continue
+        if raw == "    volumes:":
+            in_volumes_list = True
+            continue
+        if in_volumes_list:
+            item = re.match(r"^      - ([^\s:]+)\s*$", raw)
+            if item and current_service:
+                found.append(f"{current_service}:{item.group(1)}")
+                continue
+            # Long (mapping) syntax, e.g. `- type: volume` / `- target: /data`, can
+            # declare an anonymous volume too (no `source:` key) but this line-based
+            # parser cannot see across the mapping to tell. Refuse rather than let it
+            # slip through unlabeled -- matches the fail-closed style of the rest of
+            # this parser.
+            if current_service and re.match(r"^      - [A-Za-z0-9_-]+: ", raw):
+                found.append(f"{current_service}:<long-syntax volume entry unsupported>")
+                continue
+            in_volumes_list = False
+    return found
+
+
 def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
+    """Generate an ephemeral Compose overlay that labels every resource Compose creates.
+
+    Services, top-level volumes, and top-level networks all get a full label
+    contract. Compose's implicit `default` network is labeled too, since it is
+    created whenever a service doesn't opt out -- even when the file declares no
+    `networks:` section at all. Anonymous service-level volumes have no top-level
+    key to attach labels to, so they cannot be governed through this overlay; the
+    front door refuses to run rather than let them come up unlabeled.
+    """
     if isinstance(registry_id, Registry):
         registry_id = registry_id.registry_id
-    """Generate an ephemeral Compose overlay that labels every service container."""
-    names = re.findall(r"^  ([A-Za-z0-9_-]+):\s*$", compose.read_text(encoding="utf-8"), re.M)
+    text = compose.read_text(encoding="utf-8")
+    names = _parse_top_level_entries(text, "services")
     if not names:
         raise DockerFrontDoorError("compose file has no services")
+    volume_names = _parse_top_level_entries(text, "volumes")
+    network_names = _parse_top_level_entries(text, "networks")
+    anonymous = _find_anonymous_service_volumes(text)
+    if anonymous:
+        raise DockerFrontDoorError(
+            "compose file declares service volume entries that cannot be governed "
+            "through this overlay (anonymous, or long-syntax this narrow parser "
+            f"cannot verify): {', '.join(anonymous)}; declare them under a "
+            "top-level `volumes:` entry using short `name:/path` syntax instead"
+        )
     created = dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z")
     workspace = str(compose.parent.resolve())
+
+    def label_block(resource_names: list[str], kind: str) -> list[str]:
+        block: list[str] = []
+        for name in resource_names:
+            contract = labels.ResourceLabels(
+                registry=registry_id,
+                kind=kind,
+                stack=name,
+                generation="compose",
+                scope="stack",
+                workspace=workspace,
+                created=created,
+            )
+            block += [f"  {name}:", "    labels:"]
+            block += [
+                f"      {key}: {_yaml_scalar(value)}" for key, value in contract.to_dict().items()
+            ]
+        return block
+
     lines = ["services:"]
-    for name in names:
-        contract = labels.ResourceLabels(
-            registry=registry_id,
-            kind="container",
-            stack=name,
-            generation="compose",
-            scope="stack",
-            workspace=workspace,
-            created=created,
-        )
-        lines += [f"  {name}:", "    labels:"]
-        lines += [f'      {key}: "{value}"' for key, value in contract.to_dict().items()]
+    lines += label_block(names, "container")
+    if volume_names:
+        lines.append("volumes:")
+        lines += label_block(volume_names, "volume")
+    lines.append("networks:")
+    governed_networks = network_names if "default" in network_names else [*network_names, "default"]
+    lines += label_block(governed_networks, "network")
+
     handle = tempfile.NamedTemporaryFile(
         mode="w", suffix=".bosn-compose.yaml", delete=False, encoding="utf-8"
     )

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -38,9 +38,19 @@ from bosn.retention import (
 
 _REMOVE_COMMANDS: dict[str, list[str]] = {
     "container": ["rm", "--force"],
+    # `docker network rm` has no `--force`: a network attached to a running container
+    # simply refuses removal, which is exactly the dependency check GC relies on if
+    # `_REMOVAL_ORDER` below is ever wrong.
+    "network": ["network", "rm"],
     "volume": ["volume", "rm", "--force"],
     "image": ["image", "rm", "--force"],
 }
+
+# Dependency-ordered GC removal: a container holds a network endpoint and a volume mount,
+# so both must go before the network/volume can be removed; images are least constrained
+# and go last. Lower sorts first. Kinds absent here (e.g. "builder") keep their relative
+# scan order via the default in the sort key below.
+_REMOVAL_ORDER: dict[str, int] = {"container": 0, "network": 1, "volume": 2, "image": 3}
 
 
 @dataclass
@@ -210,10 +220,14 @@ class Collector:
                         result.errors.append(message)
                         self.registry.log_event("container.stop_error", message)
 
-        # Containers retain their volumes even after they have stopped. Remove them
-        # first so a done workspace can be collected in one pass.
+        # Containers retain their volumes and network endpoints even after they have
+        # stopped, and a network with an attached endpoint refuses removal. Remove in
+        # dependency order -- containers, then networks, then volumes/images -- so a done
+        # workspace can be collected in one pass instead of leaving stranded networks
+        # behind for the next GC pass to retry.
         for verdict in sorted(
-            collectable(verdicts), key=lambda verdict: verdict.resource.kind != "container"
+            collectable(verdicts),
+            key=lambda verdict: _REMOVAL_ORDER.get(verdict.resource.kind, 99),
         ):
             with self.registry.lifecycle_guard():
                 resource = self.registry.get_resource(verdict.resource.id)

--- a/src/bosn/labels.py
+++ b/src/bosn/labels.py
@@ -22,7 +22,7 @@ CREATED = f"{NAMESPACE}.created"
 
 REQUIRED_LABELS: tuple[str, ...] = (REGISTRY, KIND, STACK, GENERATION, SCOPE, WORKSPACE, CREATED)
 
-KINDS: frozenset[str] = frozenset({"container", "volume", "image", "builder"})
+KINDS: frozenset[str] = frozenset({"container", "volume", "image", "builder", "network"})
 SCOPES: frozenset[str] = frozenset({"spec", "stack", "machine"})
 
 

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -34,12 +34,14 @@ _LIST_COMMANDS: dict[str, list[str]] = {
     # `docker images` shortens `.ID` to 12 characters unless told otherwise.  Adoption,
     # convergence, execution leases, and GC must all use the same immutable full ID.
     "image": ["images", "--no-trunc", "--format", "{{json .}}"],
+    "network": ["network", "ls", "--format", "{{json .}}"],
 }
 
 _INSPECT_COMMANDS: dict[str, list[str]] = {
     "container": ["inspect", "--format", "{{json .Config.Labels}}"],
     "volume": ["volume", "inspect", "--format", "{{json .Labels}}"],
     "image": ["image", "inspect", "--format", "{{json .Config.Labels}}"],
+    "network": ["network", "inspect", "--format", "{{json .Labels}}"],
 }
 
 
@@ -109,6 +111,8 @@ def _name_of(kind: str, row: dict[str, object]) -> str:
         return str(row.get("Name", ""))
     if kind == "image":
         return str(row.get("ID", ""))
+    # `container` rows carry `Names`; `network` rows carry `Name` (no plural) -- both fall
+    # through to this shared branch rather than getting a dedicated one.
     return str(row.get("Names") or row.get("Name") or row.get("ID", ""))
 
 

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -5,6 +5,7 @@ seconds to recreate from a warm image. A cache volume is the asset that turns a 
 cold build into 30 seconds. They get separate clocks:
 
 - containers idle-stop at 1 h and are removed at 24 h
+- networks share the container's 24 h removal clock -- disposable, not a cache
 - warm volumes live 72 h
 - superseded generations are capped at 24 h
 - machine-shared caches age only under pressure
@@ -103,7 +104,12 @@ def container_should_stop(resource: Resource, now: float, *, config: Config | No
 
 
 def _ttl_for(resource: Resource, *, config: Config) -> float:
-    if resource.kind == "container":
+    if resource.kind in ("container", "network"):
+        # A network is cheap to recreate -- `docker compose up` (or a plain `docker
+        # network create`) rebuilds it in milliseconds with no data to lose. It is
+        # disposable infrastructure like a container, not a warm cache asset like a
+        # volume, so it shares the container's short removal clock rather than the
+        # volume's 72 h warm TTL.
         return config.get("container_remove")
     return config.get("warm_volume_ttl")
 

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 
-from bosn.accounting import StorageInventory, desktop_vhdx, engine_storage_path
+from bosn.accounting import StorageInventory, desktop_vhdx, engine_storage_path, resource_bytes
 from bosn.engine import EngineResult
+from bosn.registry import Resource
 
 
 class Engine:
@@ -69,6 +70,34 @@ def test_engine_storage_path_prefers_the_engine_root_over_registry_state(tmp_pat
     state.mkdir()
 
     assert engine_storage_path(RootEngine(str(root)), state) == root  # type: ignore[arg-type]
+
+
+def test_network_bytes_are_known_zero_not_permanently_unmeasured() -> None:
+    """`system df -v` has no row shape for networks; that must read as measured-zero.
+
+    `gc.collect` refuses to declare byte pressure resolved while any resource is
+    unmeasured (`resource_bytes(...) is None`). If a network fell through to that
+    "unknown" path, every project with a Compose-created network would wedge byte
+    pressure resolution forever -- there is no inventory row that could ever fill it in.
+    """
+    engine = Engine()
+    network = Resource(
+        id="r1",
+        kind="network",
+        name="proj_default",
+        stack="s",
+        generation="g",
+        scope="spec",
+        workspace="/w",
+        created_at=0.0,
+        last_used=0.0,
+    )
+
+    size = resource_bytes(engine, network)  # type: ignore[arg-type]
+
+    assert size == 0
+    # No inventory lookup was needed to answer -- and none is possible for a network.
+    assert engine.calls == []
 
 
 def test_desktop_vhdx_finds_docker_data_disk_in_configured_directory(tmp_path) -> None:

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -33,3 +34,126 @@ def test_compose_overlay_has_the_complete_label_contract(tmp_path: Path) -> None
 def test_compose_subset_refuses_unknown_argument(tmp_path: Path) -> None:
     with pytest.raises(DockerFrontDoorError, match="--scale"):
         _run_compose("up", tmp_path / "compose.yaml", ["--scale"])
+
+
+# -- every Compose-created resource is governed (#48) ------------------------
+
+
+def _labelled(text: str) -> dict[str, dict[str, str]]:
+    """Map each overlay entry to its label dict, ignoring how scalars are quoted.
+
+    Deliberately quoting-agnostic: an assertion that pins `kind: "volume"` passes only
+    for one quoting style, so it would have enshrined the double-quoted emission that
+    made this very overlay unparseable on Windows.
+    """
+    entries: dict[str, dict[str, str]] = {}
+    current: str | None = None
+    for raw in text.splitlines():
+        if not raw.strip():
+            continue
+        entry = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", raw)
+        if entry:
+            current = entry.group(1)
+            entries.setdefault(entry.group(1), {})
+            continue
+        pair = re.match(r"^      com\.zackees\.bosn\.([a-z]+):\s*(.*)$", raw)
+        if pair and current:
+            entries[current][pair.group(1)] = pair.group(2).strip().strip("'\"")
+    return entries
+
+
+def _overlay_text(tmp_path: Path, body: str) -> str:
+    compose = tmp_path / "compose.yaml"
+    compose.write_text(body, encoding="utf-8")
+    with Registry(tmp_path / "registry.sqlite3") as registry:
+        overlay = _compose_overlay(registry, compose)
+        try:
+            return overlay.read_text(encoding="utf-8")
+        finally:
+            overlay.unlink()
+
+
+def test_top_level_volumes_and_networks_are_labeled_with_their_own_kind(tmp_path: Path) -> None:
+    """Compose volumes were the class of object the 452 GiB incident was made of."""
+    entries = _labelled(
+        _overlay_text(
+            tmp_path,
+            "services:\n  app:\n    image: alpine\n\nvolumes:\n  data:\n\nnetworks:\n  backend:\n",
+        )
+    )
+
+    assert entries["app"]["kind"] == "container"
+    assert entries["data"]["kind"] == "volume"
+    assert entries["backend"]["kind"] == "network"
+
+
+def test_a_services_nested_volumes_are_not_mistaken_for_declarations(tmp_path: Path) -> None:
+    """A service's `volumes:` lists what it *uses*; the top-level block *declares*.
+
+    Both sit at a two-space-ish indent, so a file-wide regex reads a service's mount
+    reference as a top-level declaration and labels it `kind="container"`.
+    """
+    entries = _labelled(
+        _overlay_text(
+            tmp_path,
+            "services:\n"
+            "  app:\n"
+            "    image: alpine\n"
+            "    volumes:\n"
+            "      - data:/data\n"
+            "    networks:\n"
+            "      - backend\n"
+            "\n"
+            "volumes:\n"
+            "  data:\n"
+            "\n"
+            "networks:\n"
+            "  backend:\n",
+        )
+    )
+
+    containers = [name for name, entry in entries.items() if entry.get("kind") == "container"]
+    assert containers == ["app"], f"a nested reference was labeled as a service: {containers}"
+    assert entries["data"]["kind"] == "volume"
+    assert entries["backend"]["kind"] == "network"
+
+
+def test_composes_implicit_default_network_is_labeled(tmp_path: Path) -> None:
+    """Compose creates `default` even when the file declares no networks at all.
+
+    Left unlabeled it is exactly the ungoverned resource #48 exists to prevent.
+    """
+    entries = _labelled(_overlay_text(tmp_path, "services:\n  app:\n    image: alpine\n"))
+
+    assert entries["default"]["kind"] == "network"
+
+
+def test_an_anonymous_service_volume_is_refused_before_compose_runs(tmp_path: Path) -> None:
+    """It has no top-level key an overlay can attach labels to, so it cannot be governed.
+
+    #48 requires such a resource be reported as ungovernable *before* execution rather
+    than silently created.
+    """
+    with pytest.raises(DockerFrontDoorError, match="anonymous|ungovernable|volume"):
+        _overlay_text(
+            tmp_path,
+            "services:\n  app:\n    image: alpine\n    volumes:\n      - /data\n",
+        )
+
+
+def test_label_values_survive_a_yaml_round_trip_on_windows(tmp_path: Path) -> None:
+    r"""The overlay must parse as YAML, and a Windows workspace is the hard case.
+
+    Label values were emitted double-quoted, where YAML processes escapes: a workspace of
+    `C:\Users\...` contains `\U`, read as the start of an 8-hex-digit unicode escape and
+    rejected outright. Compose could not parse its own generated overlay on the platform
+    bosn is developed on, so the front door was inert there.
+    """
+    workdir = tmp_path / "Users" / "new"
+    workdir.mkdir(parents=True)
+    text = _overlay_text(workdir, "services:\n  app:\n    image: alpine\n")
+
+    workspace = _labelled(text)["app"]["workspace"]
+    assert workspace == str(workdir.resolve()), "the path did not round-trip"
+    # Single-quoted YAML performs no escape processing; double-quoted does.
+    assert "workspace: '" in text, "values must be single-quoted to survive backslashes"

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -47,7 +47,7 @@ class FakeEngine:
             if name in self.fail_on:
                 return EngineResult(1, "", "stop failed")
             return EngineResult(0, name, "")
-        if args[0] in {"rm", "volume", "image"} and "rm" in args:
+        if args[0] in {"rm", "volume", "image", "network"} and "rm" in args:
             name = args[-1]
             if name in self.fail_on:
                 return EngineResult(1, "", "device or resource busy")
@@ -251,6 +251,56 @@ def test_there_is_no_force_flag_on_gc() -> None:
     assert "force" not in help_text
     with pytest.raises(SystemExit):
         build_parser().parse_args(["gc", "--force"])
+
+
+# -- network governance -----------------------------------------------------
+
+
+def test_network_removal_is_ordered_after_container_removal(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """Docker refuses to remove a network with an attached endpoint.
+
+    RED before this slice: `network` was not a governed kind at all -- absent from
+    `labels.KINDS`, `resources._LIST_COMMANDS`/`_INSPECT_COMMANDS`, and
+    `gc._REMOVE_COMMANDS` -- so a network resource could never be scanned, labeled, or
+    removed by GC in the first place. GREEN now: a network is fully governed, and the
+    dependency-ordered removal in `gc._REMOVAL_ORDER` places it after `container` (which
+    may hold an attached endpoint on it) and before `volume`/`image`.
+    """
+    add(registry, "proj_net", kind="network")
+    add(registry, "proj_ctr", kind="container")
+    engine = FakeEngine(
+        {
+            "proj_net": label_dict(registry=registry.registry_id, kind="network"),
+            "proj_ctr": label_dict(registry=registry.registry_id, kind="container"),
+        }
+    )
+    clock.advance(10 * DAY)
+
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    removal_order = [c[-1] for c in engine.commands if "rm" in c and c[0] != "container"]
+    assert removal_order == ["proj_ctr", "proj_net"], (
+        "container must be removed before the network that was attached to it"
+    )
+    assert set(result.removed) == {"proj_net", "proj_ctr"}
+
+
+def test_network_is_removable_via_gc_without_a_force_flag(
+    registry: Registry, clock: FakeClock
+) -> None:
+    add(registry, "proj_net", kind="network")
+    engine = FakeEngine({"proj_net": label_dict(registry=registry.registry_id, kind="network")})
+    clock.advance(10 * DAY)
+
+    result = Collector(registry, engine).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.removed == ["proj_net"]
+    assert ["network", "rm", "proj_net"] in engine.commands
+    assert not any("--force" in cmd for cmd in engine.commands if cmd[0] == "network")
+    assert registry.list_resources() == []
+    assert any(row["kind"] == "gc.removed" for row in registry.events())
 
 
 # -- dry run ---------------------------------------------------------------

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -63,6 +63,8 @@ class FakeEngine:
             if args[0] == "images"
             else "container"
             if args[0] == "ps"
+            else "network"
+            if args[0] == "network"
             else None
         )
         rows = self.listings.get(kind or "", [])
@@ -129,6 +131,29 @@ def test_image_discovery_requests_and_keeps_the_full_immutable_id() -> None:
 
     assert [resource.name for resource in scan.owned] == [image_id]
     assert ["images", "--no-trunc", "--format", "{{json .}}"] in engine.commands
+
+
+def test_network_discovery_classifies_owned_foreign_and_unlabeled() -> None:
+    """A Compose project's network must be scannable exactly like a container or volume."""
+    engine = FakeEngine(
+        {
+            "network": [
+                {"Name": "proj_default", "Labels": json.dumps(label_dict(kind="network"))},
+                {
+                    "Name": "someone-elses",
+                    "Labels": json.dumps(label_dict(kind="network", registry=THEIRS)),
+                },
+                {"Name": "bridge", "Labels": ""},
+            ]
+        }
+    )
+
+    scan = ResourceScanner(engine).scan(OURS, kinds=["network"])  # type: ignore[arg-type]
+
+    assert [r.name for r in scan.owned] == ["proj_default"]
+    assert [r.name for r in scan.foreign] == ["someone-elses"]
+    assert [r.name for r in scan.unlabeled] == ["bridge"]
+    assert ["network", "ls", "--format", "{{json .}}"] in engine.commands
 
 
 @pytest.mark.parametrize(

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -121,6 +121,30 @@ def test_warm_volumes_survive_far_longer_than_containers(
     assert evaluate(registry, volume, alive_probe=DEAD).reason == COLLECT_IDLE
 
 
+def test_networks_share_the_container_removal_clock_not_the_volume_warm_ttl(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """A network is cheap to recreate, like a container -- not a warm cache asset."""
+    network = make(registry, kind="network")
+
+    # Past the volume's 72h warm TTL would still be warm, but well past the container's
+    # 24h removal clock: a network should already be collectable here.
+    clock.advance(1 * DAY + 1)
+    verdict = evaluate(registry, network, alive_probe=DEAD)
+    assert verdict.collect
+    assert verdict.reason == COLLECT_IDLE
+
+
+def test_a_fresh_network_is_kept_warm_before_its_removal_clock_elapses(
+    registry: Registry, clock: FakeClock
+) -> None:
+    network = make(registry, kind="network")
+    clock.advance(1 * HOUR)
+    verdict = evaluate(registry, network, alive_probe=DEAD)
+    assert not verdict.collect
+    assert verdict.reason == KEPT_WARM
+
+
 # -- superseded generations ------------------------------------------------
 
 


### PR DESCRIPTION
First slice of #48. Leases for the full project graph and killed-run recovery are a deliberate follow-up slice — this one lands the guarantee that **no invocation may produce an ungoverned resource**.

## The gap

The Compose overlay labeled **service containers only**. Compose-declared volumes and networks were created unlabeled, never registered, never given a TTL, and counted as *unlabeled* forever — the exact class of object the 101 volumes / 273 GB in the README were made of. And `network` was not even a known kind, so bosn could not name one, let alone collect it.

## What lands

- **`network` is first-class** across `labels`, the scanner, retention, accounting, and GC.
- **Removal is dependency-ordered** — container → network → volume → image — because Docker refuses to remove a network that still has an attached endpoint. RED→GREEN test pins the ordering.
- **Networks report zero bytes, not unmeasured.** `docker system df -v` has no row shape for them, and `gc.py` refuses to declare byte pressure resolved while *any* resource is unmeasured. Left as `None`, a single Compose network would have wedged pressure resolution permanently. That one is easy to miss and would have looked like "GC stopped working" much later.
- **Top-level volumes and networks are labeled**, as is Compose's **implicit `default` network** — which exists whenever a service does not opt out, even with no `networks:` section in the file.
- **An anonymous service volume is refused up front**, by name. It has no top-level key an overlay can attach labels to, so it cannot be governed through this path, and #48 requires that be reported *before* execution rather than silently created.

## Two pre-existing bugs surfaced on the way

**The service parser had no section awareness.** It ran `re.findall` over the whole file, so any two-space-indented key anywhere — including entries under a top-level `volumes:` — was labeled `kind="container"`. A service's nested `volumes:` list what it *uses*; the top-level block *declares*. Parsing is now section-aware, with a test pinning that a reference is never mistaken for a declaration.

**The overlay did not parse as YAML on Windows.** Label values were double-quoted, and YAML processes escapes inside double quotes. A workspace of `C:\Users\...` contains `\U`, read as the start of an 8-hex-digit unicode escape:

```
YAML ERROR: expected escape sequence of 8 hexadecimal numbers, but found 's'
```

So Compose could not parse the overlay bosn generated for it — the front door was **inert on the platform bosn is developed on**. Confirmed present on `main` before this branch. Values are single-quoted now (no escape processing), and the test asserts the path *round-trips* rather than pinning a quoting style — the old assertions pinned the quoting, which is how the bug survived.

## Verification

441 tests pass, `ci/lint.py` clean. Overlay output now parses cleanly through a real YAML parser with every kind labeled:

```
workspace label : C:\Users\niteris\...\new
ROUND-TRIPS     : True
kinds emitted   : services→container, volumes→volume, networks→{frontend, default}→network
```

## Still open in #48

Deterministic project identity and ordered content digest, incremental registration so client death cannot strand resources, leases over the live project graph, and killed-run orphan recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)