### PR TITLE
fix: give Compose a real generation and recover killed runs

### DIFF
--- a/src/bosn/compose.py
+++ b/src/bosn/compose.py
@@ -26,11 +26,16 @@ acceptance fixture -- those are tracked separately.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from bosn.manifest import ManifestError, docker_context_references
 
 
 class ComposeError(ValueError):
@@ -339,3 +344,195 @@ def load_compose(path_or_text: Path | str) -> ComposeFile:
     )
 
     return ComposeFile(services=services, volumes=volumes, networks=networks)
+
+
+# -- identity ---------------------------------------------------------------------
+#
+# The Compose front door (`docker_cli._compose_overlay`) used to label every resource
+# it creates with a *constant* `generation="compose"` -- every Compose project on the
+# machine shared one generation string, which defeats supersession entirely: editing
+# a compose file rolled nothing, because the generation never changed. The two
+# functions below give Compose the same identity contract `manifest.py` already gives
+# the native stack path: a stable per-project name (`project_identity`) and a content
+# digest that changes exactly when the resolved configuration changes
+# (`content_digest`). See `manifest.generation_digest`'s docstring for the parent
+# contract: two invocations are compatible iff their digests are byte-equal.
+
+
+def project_identity(compose_path: Path) -> str:
+    """A stable, collision-resistant project identity for a Compose file's directory.
+
+    Compose itself derives a project name from the containing directory's basename
+    alone, which collides whenever two different directories share a name -- an
+    ordinary shape for sibling clones or worktrees (`~/work/app` and
+    `~/scratch/app` would both compose to project `app`). This follows the same
+    precedent `converge.volume_name_for` already uses for workspace scoping: keep
+    the human-readable basename for debuggability, and disambiguate with a short
+    stable hash of the directory's *resolved absolute path* rather than inventing a
+    new scheme.
+
+    Deterministic and stable: the same directory (via any spelling -- relative,
+    symlinked, `.` segments) resolves to the same absolute path and therefore the
+    same identity on every call, on the same machine. It does not attempt to be
+    stable *across machines*, the way a content digest is -- an absolute path is
+    inherently local, and Compose project names have never claimed to be portable.
+
+    The basename component is lowercased and stripped to
+    `[a-z0-9]([a-z0-9_.-]*[a-z0-9])?`, matching the character set Compose itself
+    enforces on project names -- this identity is meant to be usable as a project
+    name (or a label value derived the same way), not just a debugging label, so
+    it must not carry characters Compose or a resource name would reject. The hash
+    suffix still carries all the collision resistance; the sanitized basename is
+    decoration.
+    """
+    directory = compose_path.resolve()
+    if directory.is_file():
+        directory = directory.parent
+    key = hashlib.sha256(directory.as_posix().encode("utf-8")).hexdigest()[:12]
+    slug = re.sub(r"[^a-z0-9_.-]+", "-", directory.name.lower()).strip("-._") or "project"
+    return f"bosn-compose-{slug}-{key}"
+
+
+def _hash_field(hasher: Any, value: bytes) -> None:
+    """Append one unambiguous binary field to a digest input.
+
+    Length-delimited rather than a plain separator-joined concatenation: a naive
+    `b"\\0".join([name, content])` lets two different (name, content) splits collide
+    on the same byte stream (see `manifest.test_file_records_are_length_delimited`).
+    Prefixing every field with its own byte length removes that ambiguity.
+    """
+    hasher.update(len(value).to_bytes(8, "big"))
+    hasher.update(value)
+
+
+def _service_build_context(raw_build: Any, compose_dir: Path) -> tuple[Path, Path] | None:
+    """Resolve a service's `build:` value to (context directory, Dockerfile path).
+
+    Mirrors Compose's own defaults: a bare string is the context, with an implicit
+    `Dockerfile` inside it; a mapping may override `context` and/or `dockerfile`.
+    Anything else (no `build:`, or a shape this slice doesn't recognize) yields
+    `None` and is simply not folded into the digest -- `load_compose` already
+    validated the service's key set before this runs, so an unrecognized `build:`
+    shape here means Compose's own schema allows something bosn hasn't modeled yet,
+    not that the file is malformed.
+    """
+    if isinstance(raw_build, str):
+        context = compose_dir / raw_build
+        dockerfile_name = "Dockerfile"
+    elif isinstance(raw_build, dict):
+        context = compose_dir / str(raw_build.get("context", "."))
+        dockerfile_name = str(raw_build.get("dockerfile", "Dockerfile"))
+    else:
+        return None
+    return context, context / dockerfile_name
+
+
+def content_digest(compose_path: Path | str) -> str:
+    """Ordered content-closure digest of a Compose file, for generation identity.
+
+    Same contract as `manifest.generation_digest`: two invocations are compatible
+    iff their digests are byte-equal. `sha256:`-prefixed, and every field folded in
+    is length-delimited (`_hash_field`) rather than concatenated, for the same
+    collision reason `manifest.py` documents.
+
+    **What rolls the digest.** The file is parsed with `yaml.safe_load` -- the same
+    step `load_compose` uses, so `&anchor`/`<<:` merge keys are already resolved --
+    and the *parsed structure* is hashed, not the source bytes. Concretely:
+
+    - Reformatting -- indentation, mapping key order, quoting style (`'x'` vs `"x"`
+      vs bare `x`), comments -- does NOT roll the digest, because none of that
+      survives `yaml.safe_load`; the digest is built from canonical JSON
+      (`sort_keys=True`) over the parsed value, so key order never matters either.
+    - Any semantic change to the parsed structure DOES roll the digest: an image
+      tag, a service's `volumes:`/`networks:`/`environment:`/`ports:`/`command:`,
+      adding or removing a top-level `volumes:` or `networks:` entry, all change
+      what got parsed and therefore the canonical JSON that gets hashed.
+    - List order is preserved, not sorted -- a `ports:` list or `command:` argv
+      reordered is a different digest, matching #48's "ordered ... digest".
+      Top-level key order is not preserved (canonical JSON sorts keys), so
+      reordering *services* in the file, or the keys within one service, does not
+      roll the digest -- only reordering matters *within* a list value.
+    - A null value and an empty mapping are NOT the same reformat, even though a
+      human skimming the file might read them that way: `back:` parses to `None`
+      and `back: {}` parses to `{}`, two different Python values, so switching
+      between them DOES roll the digest.
+
+    **Build contexts fold in.** For every service with a `build:` key, the local
+    build closure is resolved with `manifest.docker_context_references` -- the
+    same COPY/ADD-driven, `.dockerignore`-filtered walk stacks use -- and the byte
+    content of every file in that closure is folded in, in
+    `(service name, path)`-sorted order. Without this, editing application source
+    under a `build:` context would roll nothing for Compose-managed resources,
+    which is exactly the bug #48 exists to close. `build.args` is not resolved
+    against the Dockerfile's `ARG`/`FROM` the way `manifest.py` does for stacks
+    converted through `compose_to_manifest` -- that richer, build-arg-aware
+    resolution belongs to the manifest path once a service is converted. Here, an
+    unresolved `$VAR` in a COPY/ADD source falls back to the same conservative
+    "hash the whole context" behavior `docker_context_references` already
+    implements for stacks.
+
+    **Path handling** mirrors `load_compose`: a real `Path` is read from disk, and
+    its parent directory anchors `build:` context resolution; a `str` -- even one
+    that looks like a filesystem path -- is treated as literal YAML text, exactly
+    like `load_compose`, and cannot resolve `build:` contexts (there is no
+    directory to resolve a relative context against); build-context folding is
+    silently skipped for text input, since nothing on disk exists to hash.
+    """
+    load_compose(compose_path)  # validates first; fail closed on anything unsupported
+
+    if isinstance(compose_path, Path):
+        text = compose_path.read_text(encoding="utf-8")
+        compose_dir: Path | None = compose_path.resolve().parent
+    else:
+        text = compose_path
+        compose_dir = None
+
+    raw = yaml.safe_load(text)
+
+    hasher = hashlib.sha256()
+    # `default=str`: `yaml.safe_load` turns an unquoted ISO-looking scalar (a bare
+    # `2024-06-27` in a label value, say) into a `datetime.date`, which `load_compose`
+    # never rejects (it doesn't type-check leaf values) but which `json.dumps` cannot
+    # serialize on its own. `str()` on such a value is stable across calls, so digest
+    # determinism holds; this is a fallback for values JSON has no native type for, not
+    # an attempt to normalize their formatting.
+    canonical = json.dumps(raw, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    _hash_field(hasher, canonical)
+
+    if compose_dir is not None:
+        services_raw = raw.get("services") or {}
+        for name in sorted(services_raw):
+            service_raw = services_raw[name]
+            if not isinstance(service_raw, dict) or "build" not in service_raw:
+                continue
+            spec = _service_build_context(service_raw["build"], compose_dir)
+            if spec is None:
+                continue
+            context, dockerfile = spec
+            try:
+                files = docker_context_references(context, dockerfile)
+            except ManifestError as exc:
+                raise ComposeError(f"services.{name}.build: {exc}") from exc
+            for file_path in files:
+                relative = file_path.relative_to(context).as_posix()
+                try:
+                    if file_path.is_symlink():
+                        kind = b"link"
+                        content = file_path.readlink().as_posix().encode("utf-8")
+                    elif file_path.is_dir():
+                        kind = b"dir"
+                        content = b""
+                    else:
+                        kind = b"file"
+                        content = file_path.read_bytes()
+                except OSError as exc:
+                    raise ComposeError(
+                        f"cannot digest build context file {file_path}: {exc}"
+                    ) from exc
+                hasher.update(b"\0build-file-record\0")
+                _hash_field(hasher, name.encode("utf-8"))
+                _hash_field(hasher, kind)
+                _hash_field(hasher, relative.encode("utf-8"))
+                _hash_field(hasher, content)
+
+    return f"sha256:{hasher.hexdigest()}"

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from bosn import __version__, daemon, labels
-from bosn.compose import ComposeError, load_compose
+from bosn.compose import ComposeError, content_digest, load_compose
 from bosn.registry import Registry
 
 
@@ -103,6 +103,12 @@ def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
         )
     created = dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z")
     workspace = str(compose.parent.resolve())
+    # Every Compose resource used to carry the constant generation "compose", so every
+    # project on the machine shared one generation string and nothing could ever be
+    # superseded: editing the compose file rolled nothing, and the old resources stayed
+    # current forever. A content digest gives Compose the same identity the manifest path
+    # already has -- two invocations are compatible iff their digests are byte-equal.
+    generation = content_digest(compose)
 
     def label_block(resource_names: list[str], kind: str) -> list[str]:
         block: list[str] = []
@@ -111,7 +117,7 @@ def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
                 registry=registry_id,
                 kind=kind,
                 stack=name,
-                generation="compose",
+                generation=generation,
                 scope="stack",
                 workspace=workspace,
                 created=created,
@@ -141,6 +147,46 @@ def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
         handle.close()
 
 
+def _reconcile_after_compose(command: str) -> None:
+    """Adopt any labeled-but-unregistered resource left behind by a Compose invocation.
+
+    Runs unconditionally -- on a clean exit, a non-zero exit, and on the way out of a
+    KeyboardInterrupt -- because Compose labels (and creates) containers, networks, and
+    volumes incrementally as it works through the file. A run that fails partway through
+    pulling images, or is killed by Ctrl-C during a foreground `up`, can still leave fully
+    labeled resources on the engine that the registry has never heard of: exactly the
+    ungoverned accumulation bosn exists to prevent. Gating this on `command == "up" and
+    returncode == 0` is precisely how those resources went unregistered.
+
+    Paying for the scan on `down`/`logs`/`ps` too is a non-issue: those commands don't
+    label new resources, adoption only registers what is not already known, so the scan
+    finds nothing to do and returns immediately.
+
+    A failure here is reported to stderr but never raised. Raising would surface as a
+    `DockerFrontDoorError` in `main()`, which maps to exit code 1 regardless of what the
+    compose command itself returned -- masking `up`'s real exit status behind a
+    bookkeeping error the caller didn't ask about.
+    """
+    try:
+        adopted = daemon.request("compose-adopt")
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # daemon unreachable, IPC failure, etc.
+        print(
+            f"bosn-docker compose: reconcile after {command} failed: {exc}; "
+            "resources created by this run may be unregistered",
+            file=sys.stderr,
+        )
+        return
+    if not adopted.get("ok"):
+        print(
+            f"bosn-docker compose: reconcile after {command} failed: "
+            f"{adopted.get('error') or 'compose adoption failed'}; "
+            "resources created by this run may be unregistered",
+            file=sys.stderr,
+        )
+
+
 def _run_compose(command: str, compose: Path, args: list[str]) -> int:
     if args:
         raise DockerFrontDoorError(f"unsupported compose flag or argument {args[0]!r}")
@@ -149,13 +195,16 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
         raise DockerFrontDoorError(str(reply.get("error") or "cannot reach bosn daemon"))
     overlay = _compose_overlay(str(reply["registry_id"]), compose)
     try:
-        completed = subprocess.run(
-            ["docker", "compose", "-f", str(compose), "-f", str(overlay), command], check=False
-        )
-        if command == "up" and completed.returncode == 0:
-            adopted = daemon.request("compose-adopt")
-            if not adopted.get("ok"):
-                raise DockerFrontDoorError(str(adopted.get("error") or "compose adoption failed"))
+        # The inner try/finally is the load-bearing part: it reconciles whether the
+        # subprocess returns normally, raises, or is unwound by a KeyboardInterrupt from
+        # Ctrl-C -- the single most likely way a foreground `up` never reaches a clean
+        # exit. The outer finally still removes the overlay file in every case.
+        try:
+            completed = subprocess.run(
+                ["docker", "compose", "-f", str(compose), "-f", str(overlay), command], check=False
+            )
+        finally:
+            _reconcile_after_compose(command)
         return completed.returncode
     finally:
         overlay.unlink(missing_ok=True)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,8 +1,9 @@
+import re
 from pathlib import Path
 
 import pytest
 
-from bosn.compose import ComposeError, load_compose
+from bosn.compose import ComposeError, content_digest, load_compose, project_identity
 
 
 def test_anchors_and_merge_keys_resolve() -> None:
@@ -204,3 +205,183 @@ def test_extension_fields_are_accepted_wherever_compose_allows_them() -> None:
 
     assert doc.services["app"].image == "alpine:3.20"
     assert doc.volumes == ("data",)
+
+
+# -- project_identity ---------------------------------------------------------------
+
+
+def test_project_identity_is_stable_across_repeated_calls(tmp_path: Path) -> None:
+    compose_path = tmp_path / "compose.yaml"
+    compose_path.write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+
+    assert project_identity(compose_path) == project_identity(compose_path)
+
+
+def test_project_identity_differs_for_same_basename_different_directory(tmp_path: Path) -> None:
+    """Compose itself would give both of these the same project name (the directory
+    basename); bosn's identity must not collide the way Compose's own does."""
+    first = tmp_path / "one" / "myapp"
+    second = tmp_path / "two" / "myapp"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "compose.yaml").write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+    (second / "compose.yaml").write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+
+    assert project_identity(first / "compose.yaml") != project_identity(second / "compose.yaml")
+
+
+def test_project_identity_same_for_same_directory_regardless_of_spelling(tmp_path: Path) -> None:
+    directory = tmp_path / "proj"
+    directory.mkdir()
+    compose_path = directory / "compose.yaml"
+    compose_path.write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+
+    indirect = tmp_path / "proj" / ".." / "proj" / "compose.yaml"
+
+    assert project_identity(compose_path) == project_identity(indirect)
+
+
+def test_project_identity_sanitizes_an_uppercase_basename(tmp_path: Path) -> None:
+    """The identity is meant to double as a project name/label value, so it must stay
+    inside the character set Compose itself enforces on project names."""
+    directory = tmp_path / "MyApp"
+    directory.mkdir()
+    compose_path = directory / "compose.yaml"
+    compose_path.write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+
+    identity = project_identity(compose_path)
+
+    assert identity == identity.lower()
+    assert re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", identity)
+
+
+# -- content_digest -------------------------------------------------------------------
+
+
+def test_content_digest_is_stable_for_the_same_file(tmp_path: Path) -> None:
+    compose_path = tmp_path / "compose.yaml"
+    compose_path.write_text("services:\n  app:\n    image: alpine:3.20\n", encoding="utf-8")
+
+    assert content_digest(compose_path) == content_digest(compose_path)
+
+
+def test_content_digest_handles_an_unquoted_date_like_scalar(tmp_path: Path) -> None:
+    """`yaml.safe_load` turns an unquoted `2024-06-27` into a `datetime.date`, which
+    `load_compose` never rejects (it doesn't type-check leaf values) but which
+    `json.dumps` cannot serialize without a `default=` fallback -- must not raise."""
+    compose_path = tmp_path / "compose.yaml"
+    compose_path.write_text(
+        "services:\n  app:\n    image: alpine\n    labels:\n      build-date: 2024-06-27\n",
+        encoding="utf-8",
+    )
+
+    assert content_digest(compose_path) == content_digest(compose_path)
+
+
+def test_content_digest_ignores_reformatting(tmp_path: Path) -> None:
+    original = tmp_path / "a.yaml"
+    original.write_text(
+        "services:\n  app:\n    image: alpine:3.20\n    networks:\n      - back\n"
+        "networks:\n  back:\n",
+        encoding="utf-8",
+    )
+    reformatted = tmp_path / "b.yaml"
+    reformatted.write_text(
+        "networks:\n  back:\nservices:\n  app:\n"
+        '    networks: ["back"]\n'
+        "    image: 'alpine:3.20'\n",
+        encoding="utf-8",
+    )
+
+    assert content_digest(original) == content_digest(reformatted)
+
+
+def test_content_digest_changes_with_image_tag(tmp_path: Path) -> None:
+    original = tmp_path / "compose.yaml"
+    original.write_text("services:\n  app:\n    image: alpine:3.20\n", encoding="utf-8")
+    changed = tmp_path / "compose2.yaml"
+    changed.write_text("services:\n  app:\n    image: alpine:3.21\n", encoding="utf-8")
+
+    assert content_digest(original) != content_digest(changed)
+
+
+def test_content_digest_changes_when_top_level_volume_added(tmp_path: Path) -> None:
+    without = tmp_path / "without.yaml"
+    without.write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+    with_volume = tmp_path / "with.yaml"
+    with_volume.write_text(
+        "services:\n  app:\n    image: alpine\n    volumes:\n      - data:/data\n"
+        "volumes:\n  data:\n",
+        encoding="utf-8",
+    )
+
+    assert content_digest(without) != content_digest(with_volume)
+
+
+def test_content_digest_changes_when_top_level_network_removed(tmp_path: Path) -> None:
+    with_network = tmp_path / "with.yaml"
+    with_network.write_text(
+        "services:\n  app:\n    image: alpine\n    networks:\n      - back\nnetworks:\n  back:\n",
+        encoding="utf-8",
+    )
+    without_network = tmp_path / "without.yaml"
+    without_network.write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+
+    assert content_digest(with_network) != content_digest(without_network)
+
+
+def test_content_digest_reorders_top_level_services_without_rolling(tmp_path: Path) -> None:
+    """Canonical JSON sorts mapping keys, so reordering *service declarations* -- a pure
+    reformat -- must not roll the digest, even though it does change list-valued fields."""
+    first = tmp_path / "first.yaml"
+    first.write_text(
+        "services:\n  web:\n    image: nginx\n  api:\n    image: alpine\n", encoding="utf-8"
+    )
+    second = tmp_path / "second.yaml"
+    second.write_text(
+        "services:\n  api:\n    image: alpine\n  web:\n    image: nginx\n", encoding="utf-8"
+    )
+
+    assert content_digest(first) == content_digest(second)
+
+
+def test_content_digest_rolls_when_list_order_changes(tmp_path: Path) -> None:
+    """Unlike mapping-key reordering, list order is part of identity (#48: "ordered ...
+    digest")."""
+    first = tmp_path / "first.yaml"
+    first.write_text(
+        'services:\n  app:\n    image: alpine\n    command: ["a", "b"]\n', encoding="utf-8"
+    )
+    second = tmp_path / "second.yaml"
+    second.write_text(
+        'services:\n  app:\n    image: alpine\n    command: ["b", "a"]\n', encoding="utf-8"
+    )
+
+    assert content_digest(first) != content_digest(second)
+
+
+def test_content_digest_folds_in_build_context_file_content(tmp_path: Path) -> None:
+    """Editing application source under a service's `build:` context must roll the
+    generation -- otherwise a Compose-managed build silently never supersedes (#48)."""
+    (tmp_path / "worker").mkdir()
+    dockerfile = tmp_path / "worker" / "Dockerfile"
+    dockerfile.write_text("FROM alpine\nCOPY app.py /app.py\n", encoding="utf-8")
+    source = tmp_path / "worker" / "app.py"
+    source.write_text("print('v1')\n", encoding="utf-8")
+    compose_path = tmp_path / "compose.yaml"
+    compose_path.write_text("services:\n  worker:\n    build: ./worker\n", encoding="utf-8")
+
+    before = content_digest(compose_path)
+    source.write_text("print('v2')\n", encoding="utf-8")
+    after = content_digest(compose_path)
+
+    assert before != after
+
+
+def test_content_digest_build_context_folding_is_skipped_for_literal_text() -> None:
+    """A `str` is treated as literal YAML text (matching `load_compose`'s own contract),
+    so there is no directory to resolve a relative `build:` context against; this must not
+    raise, and must simply omit build-context content from the digest."""
+    text = "services:\n  worker:\n    build: ./worker\n"
+
+    assert content_digest(text) == content_digest(text)

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -1,8 +1,10 @@
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from bosn import daemon
 from bosn.docker_cli import (
     DockerFrontDoorError,
     _compose_overlay,
@@ -157,3 +159,123 @@ def test_label_values_survive_a_yaml_round_trip_on_windows(tmp_path: Path) -> No
     assert workspace == str(workdir.resolve()), "the path did not round-trip"
     # Single-quoted YAML performs no escape processing; double-quoted does.
     assert "workspace: '" in text, "values must be single-quoted to survive backslashes"
+
+
+# -- reconcile after every Compose invocation, not just a clean `up` (#48) ---
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+
+
+class _FakeDaemon:
+    """Records every verb sent to the daemon and answers with canned replies."""
+
+    def __init__(self, adopt_reply: dict[str, Any] | None = None) -> None:
+        self.calls: list[str] = []
+        self.adopt_reply = adopt_reply if adopt_reply is not None else {"ok": True, "adopted": []}
+
+    def request(self, verb: str, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls.append(verb)
+        if verb == "status":
+            return {"ok": True, "registry_id": "reg-1"}
+        if verb == "compose-adopt":
+            return self.adopt_reply
+        raise AssertionError(f"unexpected verb {verb!r}")
+
+
+def _compose_file(tmp_path: Path) -> Path:
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
+    return compose
+
+
+def test_a_failed_up_still_reconciles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RED before the fix: adoption only ran when `up` exited 0.
+
+    A service image that fails to pull leaves Compose's earlier containers, plus the
+    network and volumes it already created, fully labeled and unregistered -- this is
+    the exact failure #48 describes.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=1)
+    )
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [])
+
+    assert returncode == 1
+    assert "compose-adopt" in fake_daemon.calls
+
+
+def test_an_interrupted_up_still_reconciles_and_the_interrupt_still_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ctrl-C during a foreground `up` is the common way a run never reaches a clean exit."""
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+
+    def _interrupted(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("bosn.docker_cli.subprocess.run", _interrupted)
+
+    with pytest.raises(KeyboardInterrupt):
+        _run_compose("up", _compose_file(tmp_path), [])
+
+    assert "compose-adopt" in fake_daemon.calls
+
+
+@pytest.mark.parametrize("command", ["down", "logs", "ps"])
+def test_non_up_commands_also_reconcile(
+    command: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reconcile is unconditional: it is cheap and idempotent, so paying for it on
+    `down`/`logs`/`ps` too is harmless -- those commands don't label new resources, so
+    adoption simply finds nothing to do.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    returncode = _run_compose(command, _compose_file(tmp_path), [])
+
+    assert returncode == 0
+    assert "compose-adopt" in fake_daemon.calls
+
+
+def test_a_reconcile_failure_is_reported_but_does_not_mask_composes_exit_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The user asked whether `up` succeeded, not whether bookkeeping succeeded."""
+    fake_daemon = _FakeDaemon(adopt_reply={"ok": False, "error": "engine unreachable"})
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [])
+
+    assert returncode == 0, "a reconcile failure must not override compose's own exit code"
+    err = capsys.readouterr().err
+    assert "engine unreachable" in err
+    assert "may be unregistered" in err
+
+
+def test_a_clean_up_reconciles_exactly_as_before(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [])
+
+    assert returncode == 0
+    assert fake_daemon.calls == ["status", "compose-adopt"]


### PR DESCRIPTION
Closes the remaining #48 bullets — deterministic project identity, an ordered content-closure digest, and incremental reconciliation so client death cannot strand resources. Leases over the live project graph remain open as the last bullet.

## Compose had no identity

Every Compose-created resource carried the constant `generation="compose"`. So every project on the machine shared one generation string, and **nothing could ever be superseded**: edit your compose file and nothing rolls, the old resources stay current forever.

`compose.content_digest` gives the front door the same property the manifest path already had — two invocations are compatible iff their digests are byte-equal:

```
stable across runs : True
reformat no-roll   : True
tag change rolls   : True
sample             : sha256:5419b9c79fc61a3d3f3b4...
```

A service's `build:` context folds in through the same `COPY`/`ADD` closure walk stacks use, so editing app source under a build context is not invisible.

**Deliberate deviation, worth ratifying:** `content_digest` re-parses the YAML rather than accepting the `ComposeFile` model. The model deliberately drops `environment`, `command`, and `ports` — digesting the reduced model would let exactly the edits this exists to catch pass with an unchanged digest.

## Killed runs stranded resources

```python
if command == "up" and completed.returncode == 0:
    adopted = daemon.request("compose-adopt")
```

Registration ran **only** on a clean `up`. A run that failed partway through pulling images, or was killed by Ctrl-C during a foreground `up` — the common case, since `up` blocks — left containers, networks, and volumes carrying complete bosn labels that the registry had never heard of. No TTL, no owner. The ungoverned accumulation this project exists to prevent, produced by its own front door.

Reconciliation now runs in a `finally`, so it happens on clean exit, non-zero exit, and on the way out of a `KeyboardInterrupt`. Verified directly rather than assumed:

```
interrupted up  -> reconciled: True | Ctrl-C propagated: True
failed up       -> reconciled: True | exit code preserved: True
```

Two design points:

- **A reconcile failure is reported, not raised.** Raising would surface as a `DockerFrontDoorError` in `main()` and map to exit 1 regardless of what compose returned — masking the status the caller actually wanted. It prints to stderr instead and the compose exit code survives.
- **Reconcile runs after `down`/`logs`/`ps` too.** Adoption only registers what is not already known and those commands label nothing new, so the scan finds nothing — a uniform rule beats a per-command special case.

`_verb_compose_adopt` needed no change: it already scopes its scan to this daemon's own registry id, and `adopt()` is idempotent, which is what makes the unconditional call safe.

## Verification

476 tests pass, `ci/lint.py` clean.

## Still open in #48

Leases held over the full active project graph, so a live Compose project cannot be collected mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)