### PR TITLE
fix: lease the live Compose project graph

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -189,6 +189,8 @@ class _Handler(socketserver.StreamRequestHandler):
             "compose-adopt",
             "execution-acquire",
             "execution-release",
+            "compose-acquire",
+            "compose-release",
         }
         if (
             verb != "shutdown"
@@ -561,6 +563,8 @@ class Daemon:
             "compose-adopt": self._verb_compose_adopt,
             "execution-acquire": self._verb_execution_acquire,
             "execution-release": self._verb_execution_release,
+            "compose-acquire": self._verb_compose_acquire,
+            "compose-release": self._verb_compose_release,
             "shutdown": self._verb_shutdown,
         }.get(verb)
         if handler is None:
@@ -773,6 +777,87 @@ class Daemon:
         for lease_id in leases:
             self.registry.release_lease(lease_id)
         return {"ok": True}
+
+    def _verb_compose_acquire(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Lease every resource currently registered for a Compose project's workspace.
+
+        Diverges from `execution-acquire` on purpose: that path leases with
+        `pid=os.getpid()` -- the *daemon's* pid -- because the daemon is the one that holds
+        the lease open until an explicit release. Compose has no such holder inside the
+        daemon; `bosn-docker` runs the (possibly long, foreground) compose command itself,
+        so the lease is acquired here on behalf of *its* pid/proc_start, supplied by the
+        caller. If that client is SIGKILLed mid-run, no `finally` there ever fires and no
+        release ever arrives -- held under the daemon's identity that would pin the lease
+        until the daemon itself restarts, exactly the leak leases exist to prevent. Held
+        under the client's identity instead, `lease_is_expired` reclaims it after one TTL
+        once the pid (and start time, when available) stop matching a live process.
+        """
+        from bosn.paths import normalize_workspace_path
+
+        workspace = str(request.get("workspace") or "")
+        if not workspace:
+            return {"ok": False, "error": "compose-acquire requires workspace"}
+        # Same boundary gap as `done`/`execution-acquire`: an un-normalized spelling here
+        # would match zero resources and silently lease nothing.
+        workspace = normalize_workspace_path(workspace)
+        pid = request.get("pid")
+        if not isinstance(pid, int) or pid <= 0:
+            return {"ok": False, "error": "compose-acquire requires a client pid"}
+        proc_start_raw = request.get("proc_start")
+        proc_start = float(proc_start_raw) if proc_start_raw is not None else None
+        session = str(uuid.uuid4())
+        with self._execution_lock:
+            if self._stopping:
+                return {"ok": False, "error": "daemon is stopping; retry after it restarts"}
+            # Reserve before the lease loop below, same as execution-acquire: shutdown must
+            # see this session as active the instant it exists, not only once every
+            # dependency's lease has landed.
+            self._execution_sessions[session] = ()
+        try:
+            # Compare normalized against normalized rather than trusting a registered
+            # resource's stored `workspace` to already be canonical: the Compose overlay
+            # writes the raw `str(compose.parent.resolve())` into its labels (see
+            # `_compose_overlay`), not a normalized identity, so an un-normalized comparison
+            # here would silently match nothing on any platform where normalization is not
+            # a no-op (Windows case-folding, MSYS/cygdrive spellings, a trailing slash).
+            resources = [
+                resource
+                for resource in self.registry.list_resources()
+                if normalize_workspace_path(resource.workspace) == workspace
+            ]
+            leases = tuple(
+                self.registry.acquire_lease(resource.id, pid=pid, proc_start=proc_start)
+                for resource in resources
+            )
+        except KeyboardInterrupt:
+            # Same as execution-acquire: the reservation above must not outlive a failed
+            # acquire, or a session the client never received a session id for pins the
+            # daemon (`should_retire`/`request_stop` both key off `_execution_sessions`)
+            # forever -- nobody left holding it can ever call compose-release.
+            with self._execution_lock:
+                self._execution_sessions.pop(session, None)
+            raise
+        except Exception:
+            with self._execution_lock:
+                self._execution_sessions.pop(session, None)
+            raise
+        with self._execution_lock:
+            self._execution_sessions[session] = tuple(lease.id for lease in leases)
+        return {"ok": True, "session": session, "leased": len(leases)}
+
+    def _verb_compose_release(self, request: dict[str, Any]) -> dict[str, Any]:
+        session = str(request.get("session") or "")
+        with self._execution_lock:
+            leases = self._execution_sessions.pop(session, None)
+        if leases is None:
+            # A failed compose-acquire returns no session at all, so the client's own
+            # `finally` calls this with `None`/unknown; a double-release after a retried
+            # request lands here too. Neither is a caller error worth surfacing -- there is
+            # simply nothing left to release.
+            return {"ok": True, "released": 0}
+        for lease_id in leases:
+            self.registry.release_lease(lease_id)
+        return {"ok": True, "released": len(leases)}
 
     def _verb_converge(self, request: dict[str, Any]) -> Iterator[dict[str, Any]]:
         """Submit a converge under the coalescing policy, then stream the job it landed on.

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import os
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,7 @@ from pathlib import Path
 from bosn import __version__, daemon, labels
 from bosn.compose import ComposeError, content_digest, load_compose
 from bosn.registry import Registry
+from bosn.resources import process_start_time
 
 
 class DockerFrontDoorError(ValueError):
@@ -187,6 +189,66 @@ def _reconcile_after_compose(command: str) -> None:
         )
 
 
+def _acquire_compose_lease(workspace: str) -> str | None:
+    """Lease every resource already registered for this Compose project before it runs.
+
+    Held under bosn-docker's own pid/start-time, sent explicitly in the request, rather
+    than the daemon acquiring with its own `os.getpid()` the way `execution-acquire` does.
+    `bosn-docker` runs the (possibly long, foreground) compose command itself; if it is
+    SIGKILLed mid-run, no `finally` here ever executes and no release request is ever sent.
+    A daemon-held lease would then sit pinned until the daemon itself restarts -- a
+    permanent leak, exactly what leases exist to prevent. Held under the client's identity
+    instead, the ordinary TTL-plus-liveness rule (`lease_is_expired`) reclaims it within one
+    TTL once this pid (and start time, when available) no longer match a live process.
+
+    Never fatal: a project with no resources registered yet (its first `up`, before this
+    invocation's own reconcile above has anything to find) leases nothing and that is fine
+    -- the orphan-recovery half of #48 is what protects a run's *own* newly created
+    resources; this lease only protects what a concurrent GC pass could otherwise already
+    see and evict out from under an in-progress run.
+    """
+    try:
+        acquired = daemon.request(
+            "compose-acquire",
+            workspace=workspace,
+            pid=os.getpid(),
+            proc_start=process_start_time(os.getpid()),
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # noqa: BLE001 - fail open, same posture as reconcile below
+        print(
+            f"bosn-docker compose: could not lease project resources: {exc}; "
+            "they are unprotected against pressure eviction for this run",
+            file=sys.stderr,
+        )
+        return None
+    if not acquired.get("ok"):
+        print(
+            f"bosn-docker compose: could not lease project resources: "
+            f"{acquired.get('error') or 'lease acquire failed'}; "
+            "they are unprotected against pressure eviction for this run",
+            file=sys.stderr,
+        )
+        return None
+    return str(acquired["session"])
+
+
+def _release_compose_lease(session: str | None) -> None:
+    """Release a lease acquired above. A `None` session (acquire failed or leased nothing
+    worth tracking) is a normal, silent no-op -- there is nothing on the daemon side to
+    release, and it must never be reported as a failure of the run itself.
+    """
+    if session is None:
+        return
+    try:
+        daemon.request("compose-release", session=session)
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # noqa: BLE001 - never mask compose's own exit status
+        print(f"bosn-docker compose: could not release project lease: {exc}", file=sys.stderr)
+
+
 def _run_compose(command: str, compose: Path, args: list[str]) -> int:
     if args:
         raise DockerFrontDoorError(f"unsupported compose flag or argument {args[0]!r}")
@@ -194,17 +256,31 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
     if not reply.get("ok"):
         raise DockerFrontDoorError(str(reply.get("error") or "cannot reach bosn daemon"))
     overlay = _compose_overlay(str(reply["registry_id"]), compose)
+    workspace = str(compose.parent.resolve())
     try:
-        # The inner try/finally is the load-bearing part: it reconciles whether the
-        # subprocess returns normally, raises, or is unwound by a KeyboardInterrupt from
-        # Ctrl-C -- the single most likely way a foreground `up` never reaches a clean
-        # exit. The outer finally still removes the overlay file in every case.
+        # Reconcile before acquiring: a lease can only protect a resource the registry
+        # already knows about, and a project that is already up -- this is a second
+        # `compose up`, or a `logs`/`ps` against a live stack -- has resources sitting on
+        # the engine from a prior invocation that this process never registered itself.
+        _reconcile_after_compose(command)
+        session = _acquire_compose_lease(workspace)
         try:
             completed = subprocess.run(
                 ["docker", "compose", "-f", str(compose), "-f", str(overlay), command], check=False
             )
         finally:
-            _reconcile_after_compose(command)
+            # Release and reconcile both have to happen -- whether the subprocess returned
+            # normally, raised, or is unwinding from a Ctrl-C KeyboardInterrupt -- and
+            # neither may swallow a failure in the other. Nesting the two `finally` blocks
+            # guarantees the inner one (reconcile) still runs even if releasing the lease
+            # raises, and the exception from whichever ran second is what actually
+            # propagates -- same ordering guarantee `try/finally` always gives, just applied
+            # twice. Release goes first only because it can't discover anything reconcile's
+            # scan doesn't need: releasing does not add or remove resource rows.
+            try:
+                _release_compose_lease(session)
+            finally:
+                _reconcile_after_compose(command)
         return completed.returncode
     finally:
         overlay.unlink(missing_ok=True)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -250,6 +250,260 @@ def test_active_execution_session_pins_daemon_and_refuses_shutdown(tmp_path: Pat
         daemon.registry.close()
 
 
+# -- Compose project leases (#48) -------------------------------------------
+
+
+def test_compose_acquire_leases_every_resource_registered_for_the_workspace(
+    tmp_path: Path,
+) -> None:
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        workspace = str(tmp_path / "proj")
+        container = daemon.registry.register_resource(
+            kind="container",
+            name="app",
+            stack="app",
+            generation="g",
+            scope="stack",
+            workspace=workspace,
+        )
+        volume = daemon.registry.register_resource(
+            kind="volume",
+            name="data",
+            stack="data",
+            generation="g",
+            scope="stack",
+            workspace=workspace,
+        )
+        # A resource from an unrelated workspace must not be swept up in the lease.
+        other = daemon.registry.register_resource(
+            kind="container",
+            name="other",
+            stack="other",
+            generation="g",
+            scope="stack",
+            workspace=str(tmp_path / "unrelated"),
+        )
+
+        reply = daemon.dispatch(
+            "compose-acquire", {"workspace": workspace, "pid": 4242, "proc_start": 100.0}
+        )
+
+        assert reply["ok"] is True
+        assert reply["leased"] == 2
+        leased_ids = {lease.resource_id for lease in daemon.registry.all_leases()}
+        assert leased_ids == {container.id, volume.id}
+        assert not daemon.registry.leases_for(other.id)
+    finally:
+        daemon.registry.close()
+
+
+def test_compose_acquire_holds_the_lease_under_the_callers_identity_not_the_daemons(
+    tmp_path: Path,
+) -> None:
+    """Diverges from `execution-acquire` on purpose: see the docstring on
+    `_verb_compose_acquire`. A daemon-held lease (`pid=os.getpid()` inside the daemon)
+    survives a SIGKILLed client forever; a client-held one expires within one TTL.
+    """
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        workspace = str(tmp_path / "proj")
+        resource = daemon.registry.register_resource(
+            kind="container",
+            name="app",
+            stack="app",
+            generation="g",
+            scope="stack",
+            workspace=workspace,
+        )
+        client_pid = 999999
+        assert client_pid != os.getpid()
+
+        reply = daemon.dispatch(
+            "compose-acquire",
+            {"workspace": workspace, "pid": client_pid, "proc_start": 55.5},
+        )
+
+        assert reply["ok"] is True
+        (lease,) = daemon.registry.leases_for(resource.id)
+        assert lease.pid == client_pid
+        assert lease.proc_start == 55.5
+    finally:
+        daemon.registry.close()
+
+
+def test_compose_acquire_normalizes_the_request_workspace_before_matching(
+    tmp_path: Path,
+) -> None:
+    from bosn.paths import normalize_workspace_path
+
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        canonical = normalize_workspace_path(r"C:\Users\Me\proj")
+        resource = daemon.registry.register_resource(
+            kind="container",
+            name="app",
+            stack="app",
+            generation="g",
+            scope="stack",
+            workspace=canonical,
+        )
+        differently_spelled = "/c/Users/Me/proj"
+        assert differently_spelled != canonical
+
+        reply = daemon.dispatch(
+            "compose-acquire",
+            {"workspace": differently_spelled, "pid": 111, "proc_start": None},
+        )
+
+        assert reply["ok"] is True
+        assert reply["leased"] == 1
+        assert daemon.registry.leases_for(resource.id)
+    finally:
+        daemon.registry.close()
+
+
+def test_compose_acquire_accepts_a_null_proc_start(tmp_path: Path) -> None:
+    """`process_start_time()` can return None; the schema must accept it rather than force
+    a wall-clock substitute (see the comment on `_own_process_start_time` in converge.py
+    about why that guess is dangerous).
+    """
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        workspace = str(tmp_path / "proj")
+        resource = daemon.registry.register_resource(
+            kind="container",
+            name="app",
+            stack="app",
+            generation="g",
+            scope="stack",
+            workspace=workspace,
+        )
+
+        reply = daemon.dispatch(
+            "compose-acquire", {"workspace": workspace, "pid": 111, "proc_start": None}
+        )
+
+        assert reply["ok"] is True
+        (lease,) = daemon.registry.leases_for(resource.id)
+        assert lease.proc_start is None
+    finally:
+        daemon.registry.close()
+
+
+def test_compose_release_frees_the_leases_and_the_session_no_longer_pins_the_daemon(
+    tmp_path: Path,
+) -> None:
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0)
+    try:
+        workspace = str(tmp_path / "proj")
+        resource = daemon.registry.register_resource(
+            kind="container",
+            name="app",
+            stack="app",
+            generation="g",
+            scope="stack",
+            workspace=workspace,
+        )
+        acquired = daemon.dispatch(
+            "compose-acquire", {"workspace": workspace, "pid": 111, "proc_start": None}
+        )
+        assert not daemon.should_retire()
+
+        released = daemon.dispatch("compose-release", {"session": acquired["session"]})
+
+        assert released == {"ok": True, "released": 1}
+        assert not daemon.registry.leases_for(resource.id)
+        assert daemon.should_retire()
+    finally:
+        daemon.registry.close()
+
+
+def test_compose_release_of_an_unknown_session_is_ok_not_an_error(tmp_path: Path) -> None:
+    """A failed `compose-acquire` never hands the client a session, so its own `finally`
+    calls release with nothing to release. That must not surface as a failure.
+    """
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        reply = daemon.dispatch("compose-release", {"session": "no-such-session"})
+        assert reply == {"ok": True, "released": 0}
+    finally:
+        daemon.registry.close()
+
+
+def test_a_leased_compose_resource_survives_pressure_eviction(tmp_path: Path) -> None:
+    """The whole reason this lease exists: pressure eviction ignores age for non-machine
+    resources, so a volume `compose up` just created is otherwise eligible immediately.
+    """
+    from bosn.retention import Pressure, evaluate
+
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        workspace = str(tmp_path / "proj")
+        volume = daemon.registry.register_resource(
+            kind="volume",
+            name="data",
+            stack="data",
+            generation="g",
+            scope="stack",
+            workspace=workspace,
+        )
+        # Freshly created: far younger than any age-based tier, so only pressure -- not
+        # age -- could possibly explain a collect verdict here.
+        under_pressure = Pressure(under_pressure=True, bytes_exceeded=True)
+        unleased_verdict = evaluate(daemon.registry, volume, pressure=under_pressure)
+        assert unleased_verdict.collect is True, "sanity: pressure alone collects this"
+
+        acquired = daemon.dispatch(
+            "compose-acquire", {"workspace": workspace, "pid": 111, "proc_start": None}
+        )
+        assert acquired["ok"] is True
+
+        leased_verdict = evaluate(daemon.registry, volume, pressure=under_pressure)
+
+        assert leased_verdict.collect is False
+        assert leased_verdict.reason == "leased"
+    finally:
+        daemon.registry.close()
+
+
+def test_a_failed_acquire_does_not_leave_a_session_pinning_the_daemon_forever(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The session is reserved before the lease loop runs (so shutdown sees it immediately),
+    but if `acquire_lease` then raises -- e.g. a locked registry under concurrent writers --
+    the caller never receives a session id back and can never call compose-release. Leaving
+    the reservation behind would pin the daemon (`should_retire`/`request_stop` both key off
+    `_execution_sessions`) exactly as permanently as the leak leases exist to prevent.
+    """
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0)
+    try:
+        workspace = str(tmp_path / "proj")
+        daemon.registry.register_resource(
+            kind="container",
+            name="app",
+            stack="app",
+            generation="g",
+            scope="stack",
+            workspace=workspace,
+        )
+
+        def _boom(*_a: object, **_k: object) -> None:
+            raise RuntimeError("database is locked")
+
+        monkeypatch.setattr(daemon.registry, "acquire_lease", _boom)
+
+        with pytest.raises(RuntimeError, match="database is locked"):
+            daemon.dispatch(
+                "compose-acquire", {"workspace": workspace, "pid": 111, "proc_start": None}
+            )
+
+        assert daemon._execution_sessions == {}
+        assert daemon.should_retire()
+    finally:
+        daemon.registry.close()
+
+
 # -- unattended maintenance ------------------------------------------------
 
 

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -1,3 +1,4 @@
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -172,16 +173,29 @@ class _FakeCompleted:
 class _FakeDaemon:
     """Records every verb sent to the daemon and answers with canned replies."""
 
-    def __init__(self, adopt_reply: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        adopt_reply: dict[str, Any] | None = None,
+        acquire_reply: dict[str, Any] | None = None,
+    ) -> None:
         self.calls: list[str] = []
+        self.requests: list[dict[str, Any]] = []
         self.adopt_reply = adopt_reply if adopt_reply is not None else {"ok": True, "adopted": []}
+        self.acquire_reply = (
+            acquire_reply if acquire_reply is not None else {"ok": True, "session": "sess-1"}
+        )
 
-    def request(self, verb: str, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+    def request(self, verb: str, *_args: Any, **kwargs: Any) -> dict[str, Any]:
         self.calls.append(verb)
+        self.requests.append(kwargs)
         if verb == "status":
             return {"ok": True, "registry_id": "reg-1"}
         if verb == "compose-adopt":
             return self.adopt_reply
+        if verb == "compose-acquire":
+            return self.acquire_reply
+        if verb == "compose-release":
+            return {"ok": True, "released": 0}
         raise AssertionError(f"unexpected verb {verb!r}")
 
 
@@ -189,6 +203,17 @@ def _compose_file(tmp_path: Path) -> Path:
     compose = tmp_path / "compose.yaml"
     compose.write_text("services:\n  app:\n    image: alpine\n", encoding="utf-8")
     return compose
+
+
+@pytest.fixture(autouse=True)
+def _fixed_process_start_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test below fakes `subprocess.run` for the compose command itself, and that
+    monkeypatch replaces the one process-wide `subprocess` module object -- there is no
+    separate copy to leave alone. `process_start_time()` also shells out (`tasklist`/`ps`)
+    to probe the client's own liveness, so without this fixture it would silently receive
+    the compose-command fake instead and blow up on a missing `.stdout` attribute.
+    """
+    monkeypatch.setattr("bosn.docker_cli.process_start_time", lambda pid: 123.0)
 
 
 def test_a_failed_up_still_reconciles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -266,6 +291,108 @@ def test_a_reconcile_failure_is_reported_but_does_not_mask_composes_exit_code(
     assert "may be unregistered" in err
 
 
+# -- Compose project leases (#48) --------------------------------------------
+
+
+def test_compose_acquire_is_sent_before_compose_runs_and_released_after(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    calls_at_compose_run: list[str] = []
+
+    def _record_and_run(*_a: Any, **_k: Any) -> _FakeCompleted:
+        calls_at_compose_run.extend(fake_daemon.calls)
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr("bosn.docker_cli.subprocess.run", _record_and_run)
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [])
+
+    assert returncode == 0
+    assert calls_at_compose_run == ["status", "compose-adopt", "compose-acquire"]
+    assert fake_daemon.calls[-2:] == ["compose-release", "compose-adopt"]
+
+
+def test_the_acquire_request_carries_the_clients_own_pid_and_proc_start_not_the_daemons(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`bosn-docker` must send its own identity: the daemon has no long-lived holder for a
+    Compose lease the way it does for `execution-acquire`, so a daemon-side pid would pin
+    the lease forever if this client were killed before it could release explicitly.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    _run_compose("up", _compose_file(tmp_path), [])
+
+    acquire_request = next(
+        req
+        for call, req in zip(fake_daemon.calls, fake_daemon.requests, strict=True)
+        if call == "compose-acquire"
+    )
+    assert acquire_request["pid"] == os.getpid()
+    assert acquire_request["proc_start"] == 123.0  # from the _fixed_process_start_time fixture
+
+
+def test_release_happens_even_when_compose_exits_non_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=1)
+    )
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [])
+
+    assert returncode == 1
+    assert "compose-release" in fake_daemon.calls
+
+
+def test_release_happens_on_keyboard_interrupt_and_the_interrupt_still_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+
+    def _interrupted(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("bosn.docker_cli.subprocess.run", _interrupted)
+
+    with pytest.raises(KeyboardInterrupt):
+        _run_compose("up", _compose_file(tmp_path), [])
+
+    assert "compose-release" in fake_daemon.calls
+
+
+def test_a_failed_acquire_still_lets_compose_run_and_releases_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Leasing is a protection, not a precondition: a project with nothing registered yet
+    (or an unreachable daemon) must not block the compose command itself, and the release
+    that follows a session-less acquire must not raise or be reported as a run failure.
+    """
+    fake_daemon = _FakeDaemon(acquire_reply={"ok": False, "error": "no such workspace"})
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [])
+
+    assert returncode == 0
+    assert "compose-acquire" in fake_daemon.calls
+    assert "compose-release" not in fake_daemon.calls, "nothing to release without a session"
+    err = capsys.readouterr().err
+    assert "no such workspace" in err
+    assert "unprotected against pressure eviction" in err
+
+
 def test_a_clean_up_reconciles_exactly_as_before(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -278,4 +405,13 @@ def test_a_clean_up_reconciles_exactly_as_before(
     returncode = _run_compose("up", _compose_file(tmp_path), [])
 
     assert returncode == 0
-    assert fake_daemon.calls == ["status", "compose-adopt"]
+    # An initial reconcile registers whatever the project already has, then the lease is
+    # acquired and released around the compose command itself, then a closing reconcile
+    # adopts anything newly labeled during this run.
+    assert fake_daemon.calls == [
+        "status",
+        "compose-adopt",
+        "compose-acquire",
+        "compose-release",
+        "compose-adopt",
+    ]


### PR DESCRIPTION
Closes #48 — the last open bullet.

## Why a lease, specifically

A running Compose project's resources were registered but unprotected. The age tiers alone would not touch them (a fresh container has an hour before idle-stop). The real exposure is **pressure eviction**, which ignores age for non-machine scopes — so a volume created seconds ago by a running `compose up` could be collected out from under it. A lease is the only thing that outranks that.

Verified directly rather than assumed:

```
unleased : collect=True  reason='pressure'
leased   : collect=False reason='leased'
released : collect=True  reason='pressure'
```

## The verbs

`compose-acquire {workspace, pid, proc_start}` and `compose-release {session}` mirror the existing `execution-acquire`/`execution-release` machinery: a session uuid maps to lease ids under the execution lock, and `should_retire()` consults it so the daemon cannot idle-retire while a project is live.

## One deliberate divergence from that precedent

The manifest path leases under **the daemon's** pid. The liveness probe therefore always reports alive, and only an explicit release ever frees the lease. That is fine there.

It is not fine here. If `bosn-docker` is SIGKILLed, no `finally` runs and no release is ever sent — a daemon-held lease would pin those resources until the daemon restarts, which is the permanent pin this project exists to prevent. So the client sends **its own** `pid` and `process_start_time`, and the existing TTL-plus-liveness rule (`lease_is_expired` requires TTL elapsed **and** `process_alive` false) reclaims it within one TTL. This is the first use of the #45 PID/start-time work outside the manifest path.

`proc_start=None` is accepted end to end and falls back to PID-only liveness — deliberately not substituting a wall-clock value, which is the dangerous fallback removed in #70.

## Ordering

`reconcile → acquire → run → finally: release → reconcile`. A lease can only protect what is already registered, so reconcile must precede acquire; the nested `finally`s mean neither the release nor the closing reconcile can mask the other. No `except` sits on that path, so Ctrl-C still propagates.

## Two details worth noting

- **Workspace matching normalizes both sides.** `_compose_overlay` writes a raw `str(compose.parent.resolve())` into its labels rather than a canonical identity, so a naive equality check would silently lease nothing on Windows — the same boundary bug class as #67.
- **A failed acquire cleans up its session.** The agent caught this on review: an exception mid-lease-loop would otherwise leave a phantom session pinning the daemon forever, since the client never receives a session id it could release.

## Verification

489 tests pass, `ci/lint.py` clean. Two daemon-lifecycle timing tests flaked under parallel load and pass in isolation; a `git stash` check confirmed one fails identically without this diff — pre-existing Windows flake, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)