### PR TITLE
fix: stop the Docker test suite leaking a volume per test

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -271,17 +271,60 @@ def cmd_doctor(opts: Options) -> int:
 
     scan = ResourceScanner(Engine(opts.engine)).scan(registry_id or "")
     if scan.foreign_registries:
-        state = f" --state-dir {opts.state_dir}" if opts.state_dir else ""
+        _report_foreign_registries(scan, opts)
+    return 0
+
+
+# A foreign label only proves "not this registry" -- it is not, and cannot be, proof of
+# death. The same machine can host another live bosn instance (a different user, a
+# different --state-dir, a CI runner) whose registry id will show up here forever, by
+# design: `resources.py` refuses to ever delete or downgrade a foreign resource on its
+# own say-so. So this report counts and points at the biggest holders; it never claims
+# orphaned/dead/safe-to-remove, because bosn has no signal that would make that claim true.
+#
+# Threshold: above this many distinct foreign ids, one command per id stops being
+# actionable (nobody reads, let alone runs, a 150-command line) and starts being noise
+# that buries the one thing doctor still owes the reader: how big the situation is. Below
+# it -- the case this feature was built for, recovering a single lost prior identity --
+# the exact `adopt --from-registry <id>` command is still printed because it is the whole
+# point of running doctor in the first place.
+_FOREIGN_REGISTRY_COMMAND_THRESHOLD = 5
+_FOREIGN_REGISTRY_TOP_N = 5
+
+
+def _report_foreign_registries(scan, opts: Options) -> None:
+    from collections import Counter
+
+    per_registry = Counter(resource.registry for resource in scan.foreign if resource.registry)
+    registry_ids = sorted(per_registry)
+    total_resources = sum(per_registry.values())
+    state = f" --state-dir {opts.state_dir}" if opts.state_dir else ""
+
+    if len(registry_ids) <= _FOREIGN_REGISTRY_COMMAND_THRESHOLD:
         commands = "; ".join(
-            f"bosn{state} adopt --from-registry {candidate}"
-            for candidate in sorted(scan.foreign_registries)
+            f"bosn{state} adopt --from-registry {candidate}" for candidate in registry_ids
         )
         print(
-            "complete resources from foreign registry ids found; "
-            f"choose recovery source: {commands}",
+            "resources labeled with a registry id other than this one were found "
+            "(bosn cannot tell whether that registry is gone or still in use elsewhere -- "
+            f"complete foreign resources are never touched automatically); recovery options "
+            f"if one of these was this machine's own prior identity: {commands}",
             file=sys.stderr,
         )
-    return 0
+        return
+
+    top = ", ".join(
+        f"{registry_id} ({count} resource{'' if count == 1 else 's'})"
+        for registry_id, count in per_registry.most_common(_FOREIGN_REGISTRY_TOP_N)
+    )
+    print(
+        f"{total_resources} resources belong to {len(registry_ids)} registry ids other than "
+        "this one (bosn cannot tell a prior identity of this machine from a registry still "
+        "in use elsewhere -- these are never touched automatically); "
+        f"largest by resource count: {top}; recover an id you recognize with "
+        f"bosn{state} adopt --from-registry <id>",
+        file=sys.stderr,
+    )
 
 
 def cmd_daemon(opts: Options) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import os
+import warnings
+from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
-from bosn.engine import Engine, engine_reachable
-from bosn.resources import process_start_time
+from bosn.engine import Engine, EngineError, engine_reachable
+from bosn.gc import _REMOVE_COMMANDS as GC_REMOVE_COMMANDS
+from bosn.registry import Registry
+from bosn.resources import ResourceScanner, process_start_time
 
 
 @pytest.fixture(autouse=True)
@@ -55,3 +60,103 @@ def engine() -> Engine:
 def pytest_runtest_setup(item: pytest.Item) -> None:
     if item.get_closest_marker("docker") and not _reachable():
         pytest.skip("no reachable Docker engine")
+
+
+# -- Docker-marked test teardown (#84) --------------------------------------
+#
+# Each Docker-marked test builds a `Registry` inside pytest's `tmp_path`, converges a real
+# stack, and creates real engine resources labeled with that registry's UUID. `tmp_path`
+# is deleted at teardown, taking the sqlite registry with it -- and every live daemon then
+# classifies the surviving engine resources as *foreign*, because `gc.py` refuses to delete
+# anything it cannot re-prove ownership of from a *live* registry's own database. That
+# refusal is correct and is exactly what makes the leak permanent: the one registry that
+# could ever collect these resources is the one pytest just deleted.
+#
+# Removed in dependency order -- containers hold volume mounts and network endpoints, so
+# they must go first; images are least constrained and go last. Mirrors
+# `bosn.gc._REMOVAL_ORDER`.
+_SWEEP_KINDS: tuple[str, ...] = ("container", "network", "volume", "image")
+
+
+def _sweep_minted_registries(engine: Engine, registry_ids: set[str]) -> list[str]:
+    """Remove every engine resource whose OWN labels name one of `registry_ids`.
+
+    This is deliberately not `bosn.gc.Collector`: `Collector.collect()` is retention-gated
+    -- a volume created seconds ago is `KEPT_WARM` for 72h, a machine-scoped cache only
+    moves under storage pressure, a leased resource is protected indefinitely -- so it
+    cannot honestly answer "delete every resource this test just created" without faking a
+    clock or pressure state to defeat its own policy. What *is* reused from the real
+    collection path is the ownership proof itself: `resource.complete` plus a registry-id
+    match is the identical check `gc.Collector._ownership_proven` re-runs from the engine's
+    labels before every delete, and the removal commands below are `gc.py`'s own
+    `_REMOVE_COMMANDS`, not a bespoke `docker ... rm` invented for tests.
+
+    Why this can never touch a live registry's resources: nothing is removed because of a
+    name, a path, or a workspace label -- only because the resource's *own* label, freshly
+    re-read from the engine, names an id present in `registry_ids`. That set is populated
+    exclusively by wrapping `Registry.__init__` for the lifetime of one test (see the
+    `_cleanup_docker_test_resources` fixture below), so it can only ever contain ids this
+    test itself minted. A registry id nobody constructed in this process -- including this
+    developer's real, live registry, which was never touched by the wrapped constructor --
+    can never appear in `registry_ids`, and is therefore structurally unreachable by this
+    sweep no matter what its resources are labeled or named.
+    """
+    if not registry_ids:
+        return []
+    scanner = ResourceScanner(engine)
+    errors: list[str] = []
+    for kind in _SWEEP_KINDS:
+        args = GC_REMOVE_COMMANDS.get(kind)
+        if args is None:
+            continue
+        for resource in scanner.discover(kind):
+            if not resource.complete or resource.registry not in registry_ids:
+                continue
+            result = engine.run([*args, resource.name])
+            if not result.ok:
+                errors.append(f"{kind}:{resource.name}: {result.stderr or result.stdout}")
+    return errors
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_docker_test_resources(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    """Autouse safety net: a Docker-marked test leaves no new engine resource behind.
+
+    Only active for `@pytest.mark.docker` tests -- every other test never touches a real
+    engine, so wrapping `Registry.__init__` for them would be pure overhead for no benefit.
+    """
+    if request.node.get_closest_marker("docker") is None:
+        yield
+        return
+
+    minted_registry_ids: set[str] = set()
+    real_init = Registry.__init__
+
+    def _tracking_init(self: Registry, *args: Any, **kwargs: Any) -> None:
+        real_init(self, *args, **kwargs)
+        # Read-only opens never create resources, and every resource-creating flow already
+        # has a writable `Registry` with the same id -- so a read-only open is excluded
+        # from the minted set on purpose. This is what keeps a test that merely *reads* an
+        # existing (possibly the developer's real) registry from ever poisoning the set
+        # this sweep is allowed to delete against.
+        if not self.read_only:
+            minted_registry_ids.add(self.registry_id)
+
+    monkeypatch.setattr(Registry, "__init__", _tracking_init)
+    try:
+        yield
+    finally:
+        try:
+            errors = _sweep_minted_registries(Engine(), minted_registry_ids)
+        except EngineError as exc:
+            errors = [str(exc)]
+        if errors:
+            # Surfaced, never raised: a teardown failure must not turn a passing test red,
+            # but it must not vanish silently either -- that is how "storage is bounded"
+            # stops being true.
+            warnings.warn(
+                "docker test teardown could not remove some engine resources: " + "; ".join(errors),
+                stacklevel=2,
+            )

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -184,6 +184,120 @@ def test_doctor_reports_unreachable_engine_and_scheduler_state_without_crashing(
     assert "not on PATH" in captured.err
 
 
+def _stub_reachable_engine(monkeypatch) -> None:
+    """Doctor only reaches the foreign-registry report once the engine is reachable."""
+    from bosn.engine import EngineInfo
+
+    class FakeEngine:
+        def __init__(self, binary: str = "docker") -> None:
+            self.binary = binary
+
+        def info(self):
+            return EngineInfo(binary=self.binary, reachable=True, client_version="1.0")
+
+    monkeypatch.setattr(cli, "Engine", FakeEngine)
+
+
+def _stub_scan(monkeypatch, foreign_by_registry: dict[str, int]) -> None:
+    """Fake a scan whose foreign bucket holds ``count`` resources per registry id."""
+    import bosn.resources
+    from bosn import labels
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    def _raw(registry: str) -> dict[str, str]:
+        return labels.ResourceLabels(
+            registry=registry,
+            kind="volume",
+            stack="dev",
+            generation="digest",
+            scope="spec",
+            workspace="workspace",
+            created="2026-01-01T00:00:00Z",
+        ).to_dict()
+
+    foreign = [
+        DiscoveredResource("volume", f"{registry_id}-{i}", _raw(registry_id))
+        for registry_id, count in foreign_by_registry.items()
+        for i in range(count)
+    ]
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, _registry_id, **_kwargs):
+            return ScanResult(foreign=foreign)
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+
+
+def test_doctor_reports_few_foreign_registries_as_exact_adopt_commands(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """The case doctor's foreign-registry report was built for: one lost identity."""
+    _stub_reachable_engine(monkeypatch)
+    _stub_scan(monkeypatch, {"lost-registry-1": 2, "lost-registry-2": 1})
+
+    code = cli.main(["--state-dir", str(tmp_path), "doctor"])
+    assert code == 0
+    err = capsys.readouterr().err
+    assert f"bosn --state-dir {tmp_path} adopt --from-registry lost-registry-1" in err
+    assert f"bosn --state-dir {tmp_path} adopt --from-registry lost-registry-2" in err
+
+
+def test_doctor_aggregates_many_foreign_registries_instead_of_listing_each(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """150 foreign ids must not become 150 semicolon-joined commands on one line."""
+    _stub_reachable_engine(monkeypatch)
+    foreign_by_registry = {f"leaked-registry-{i}": 1 for i in range(150)}
+    _stub_scan(monkeypatch, foreign_by_registry)
+
+    code = cli.main(["--state-dir", str(tmp_path), "doctor"])
+    assert code == 0
+    err = capsys.readouterr().err
+
+    # The aggregate counts are reported...
+    assert "150" in err
+    assert "150 registry ids" in err or "registry ids" in err
+    # ...but no per-id adopt command is emitted for the bulk of them.
+    assert err.count("adopt --from-registry leaked-registry-") == 0
+    assert "adopt --from-registry <id>" in err
+
+
+def test_doctor_reports_total_resource_count_not_just_id_count(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """150 ids holding 151 resources and a few ids holding thousands read very differently."""
+    _stub_reachable_engine(monkeypatch)
+    heavy = {"heavy-registry-a": 3000, "heavy-registry-b": 2000}
+    padding = {f"leaked-registry-{i}": 1 for i in range(10)}
+    _stub_scan(monkeypatch, {**heavy, **padding})
+
+    code = cli.main(["--state-dir", str(tmp_path), "doctor"])
+    assert code == 0
+    err = capsys.readouterr().err
+    assert "5010" in err  # total resource count, not just the 12 distinct ids
+    assert "heavy-registry-a" in err
+    assert "heavy-registry-b" in err
+
+
+def test_doctor_foreign_registry_wording_never_claims_dead_or_safe_to_delete(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """bosn cannot distinguish a stale registry from one owned by a live user elsewhere."""
+    _stub_reachable_engine(monkeypatch)
+    foreign_by_registry = {f"leaked-registry-{i}": 1 for i in range(150)}
+    _stub_scan(monkeypatch, foreign_by_registry)
+
+    code = cli.main(["--state-dir", str(tmp_path), "doctor"])
+    assert code == 0
+    err = capsys.readouterr().err.lower()
+
+    for forbidden in ("orphan", "dead", "stale", "safe to delete", "safe to remove"):
+        assert forbidden not in err, f"doctor must not claim foreign resources are {forbidden!r}"
+
+
 def test_gc_reports_invalid_policy_without_a_traceback(monkeypatch, tmp_path, capsys) -> None:
     monkeypatch.setenv("BOSN_WARM_VOLUME_TTL", "not-a-number")
     assert cli.main(["--state-dir", str(tmp_path), "gc"]) == 1

--- a/tests/test_jobs_docker.py
+++ b/tests/test_jobs_docker.py
@@ -22,6 +22,7 @@ from bosn import daemon as daemon_mod
 from bosn import ipc, labels
 from bosn.daemon import Daemon
 from bosn.engine import Engine
+from bosn.registry import Registry
 
 pytestmark = pytest.mark.docker
 
@@ -76,14 +77,25 @@ def served(tmp_path: Path) -> Iterator[Daemon]:
     try:
         yield daemon
     finally:
+        registry_id = daemon.registry.registry_id
         daemon.request_stop()
         thread.join(timeout=30)
         daemon.shutdown()
-        _remove_built_images(Engine())
+        _remove_built_images(Engine(), registry_id)
 
 
-def _remove_built_images(engine: Engine) -> None:
-    listed = engine.run(["image", "ls", "--filter", f"label={labels.REGISTRY}", "--quiet"])
+def _remove_built_images(engine: Engine, registry_id: str) -> None:
+    """Remove only images this daemon's own registry built.
+
+    Filtering on the label's *value*, not merely its presence, matters: an unscoped
+    `label=com.zackees.bosn.registry` filter would match every bosn-built image on the
+    engine, including a live registry's (e.g. this developer's real one), and force-remove
+    them too. Scoping to the exact id this test's own daemon minted is the same ownership
+    proof the rest of the suite's teardown uses.
+    """
+    listed = engine.run(
+        ["image", "ls", "--filter", f"label={labels.REGISTRY}={registry_id}", "--quiet"]
+    )
     for image_id in {line.strip() for line in listed.stdout.splitlines() if line.strip()}:
         engine.run(["image", "rm", "--force", image_id])
 
@@ -234,5 +246,16 @@ def test_bosn_run_converges_through_the_daemon_then_runs_locally(
         assert listed, "the converge really did go through the daemon"
         assert all(row["state"] == "succeeded" for row in listed), listed
     finally:
+        # The daemon here is a genuinely separate OS process (`daemon_mod.spawn`), so the
+        # in-process `Registry.__init__` tracking in conftest never sees it construct its
+        # registry. Reading its id back from its own database -- known-safe because
+        # `state_dir` is this test's own `tmp_path`, never the developer's real state dir
+        # -- is the only way this test's cleanup can scope image removal to what it built.
+        db_path = state_dir / "registry.sqlite3"
+        registry_id = None
+        if db_path.exists():
+            with Registry(db_path, read_only=True) as registry:
+                registry_id = registry.registry_id
         daemon_mod.stop(state_dir, timeout=60)
-        _remove_built_images(Engine())
+        if registry_id is not None:
+            _remove_built_images(Engine(), registry_id)

--- a/tests/test_teardown_docker.py
+++ b/tests/test_teardown_docker.py
@@ -1,0 +1,159 @@
+"""#84: the Docker suite's own autouse teardown must not leak, and must not overreach.
+
+Three things are proved against a real engine:
+
+- precision: the sweep in `conftest._cleanup_docker_test_resources` removes a resource
+  carrying a minted registry id and leaves everything else -- including a resource
+  labeled with a registry id nobody in this process ever constructed -- untouched. This
+  is the same convention `test_resources_docker.py` and `test_scenario_docker.py` use for
+  a "foreign" registry: a bare uuid string, never a real `Registry()`.
+- a removal failure is surfaced (visible), not swallowed and not raised (never fails the
+  test being torn down).
+- end to end: a Docker-marked test that creates a real labeled volume and does nothing
+  else leaves no volume behind once its own teardown has run.
+
+Docker-marked: Linux CI only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from bosn import labels
+from bosn.engine import Engine, EngineResult
+from bosn.registry import Registry
+from conftest import _sweep_minted_registries
+
+pytestmark = pytest.mark.docker
+
+
+def _labels(registry: str) -> labels.ResourceLabels:
+    return labels.ResourceLabels(
+        registry=registry,
+        kind="volume",
+        stack="test",
+        generation="sha256:deadbeef",
+        scope="spec",
+        workspace="/w/teardown",
+        created="2026-08-14T00:00:00Z",
+    )
+
+
+def _volume_names(engine: Engine) -> set[str]:
+    listed = engine.run(["volume", "ls", "--quiet"])
+    return {line.strip() for line in listed.stdout.splitlines() if line.strip()}
+
+
+# -- precision: only the named registry id is ever touched -------------------
+
+
+def test_sweep_removes_only_the_named_registry_id(engine: Engine) -> None:
+    swept_id = f"sweep-target-{uuid.uuid4()}"
+    other_id = f"sweep-bystander-{uuid.uuid4()}"
+    swept_name = f"bosn-sweep-target-{uuid.uuid4().hex[:8]}"
+    other_name = f"bosn-sweep-bystander-{uuid.uuid4().hex[:8]}"
+    engine.run(["volume", "create", *_labels(swept_id).to_docker_args(), swept_name], check=True)
+    engine.run(["volume", "create", *_labels(other_id).to_docker_args(), other_name], check=True)
+    try:
+        errors = _sweep_minted_registries(engine, {swept_id})
+        assert errors == []
+
+        names = _volume_names(engine)
+        assert swept_name not in names, "the named registry's volume must be removed"
+        assert other_name in names, "a registry id not in the set must never be touched"
+    finally:
+        engine.run(["volume", "rm", "--force", other_name])
+
+
+def test_sweep_with_no_minted_ids_is_a_no_op(engine: Engine) -> None:
+    """An empty minted set (a test that never constructed a writable Registry) removes nothing."""
+    untouched_id = f"sweep-untouched-{uuid.uuid4()}"
+    untouched_name = f"bosn-sweep-untouched-{uuid.uuid4().hex[:8]}"
+    engine.run(
+        ["volume", "create", *_labels(untouched_id).to_docker_args(), untouched_name],
+        check=True,
+    )
+    try:
+        errors = _sweep_minted_registries(engine, set())
+        assert errors == []
+        assert untouched_name in _volume_names(engine)
+    finally:
+        engine.run(["volume", "rm", "--force", untouched_name])
+
+
+# -- a removal failure is surfaced, never raised ------------------------------
+
+
+def test_sweep_reports_a_removal_failure_without_raising(
+    engine: Engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    failing_id = f"sweep-failing-{uuid.uuid4()}"
+    failing_name = f"bosn-sweep-failing-{uuid.uuid4().hex[:8]}"
+    engine.run(
+        ["volume", "create", *_labels(failing_id).to_docker_args(), failing_name], check=True
+    )
+    real_run = Engine.run
+
+    def _failing_run(self: Engine, args: list[str], **kwargs: object) -> EngineResult:
+        if args[:2] == ["volume", "rm"]:
+            return EngineResult(returncode=1, stdout="", stderr="simulated removal failure")
+        return real_run(self, args, **kwargs)  # type: ignore[arg-type]
+
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(Engine, "run", _failing_run)
+            errors = _sweep_minted_registries(engine, {failing_id})
+        assert errors, "a failed removal must be reported, not silently dropped"
+        assert "simulated removal failure" in errors[0]
+        assert failing_name in _volume_names(engine), "a failed removal must not be pretended"
+    finally:
+        engine.run(["volume", "rm", "--force", failing_name])
+
+
+# -- end to end: RED -> GREEN --------------------------------------------------
+#
+# A Docker-marked test that constructs a registry and creates one labeled volume, and does
+# nothing else, must leave no volume behind once ITS OWN autouse teardown has run. That
+# teardown runs after this test function returns, so the follow-up assertion has to live in
+# a second test ordered after it in the same module -- pytest collects a file's tests in
+# source order, so `_b` genuinely runs once `_a`'s teardown has already fired.
+
+_minted_volume: str | None = None
+_live_volume: str | None = None
+_live_registry_id: str | None = None
+
+
+def test_a_a_docker_marked_test_creates_one_labeled_volume(tmp_path, engine: Engine) -> None:
+    global _minted_volume, _live_volume, _live_registry_id
+    with Registry(tmp_path / "state" / "r.sqlite3") as registry:
+        _minted_volume = f"bosn-teardown-e2e-{uuid.uuid4().hex[:8]}"
+        engine.run(
+            ["volume", "create", *_labels(registry.registry_id).to_docker_args(), _minted_volume],
+            check=True,
+        )
+        assert engine.run(["volume", "inspect", _minted_volume]).ok
+
+    # A "different, live" registry, simulated the same way the rest of the docker suite
+    # simulates a foreign registry: a bare id, never passed through `Registry()`, so it can
+    # never land in this test's minted set no matter what this test does.
+    _live_registry_id = f"live-{uuid.uuid4()}"
+    _live_volume = f"bosn-teardown-e2e-live-{uuid.uuid4().hex[:8]}"
+    engine.run(
+        ["volume", "create", *_labels(_live_registry_id).to_docker_args(), _live_volume],
+        check=True,
+    )
+
+
+def test_b_that_volume_is_gone_and_the_live_one_survived(engine: Engine) -> None:
+    if _minted_volume is None or _live_volume is None:
+        pytest.skip("must run after test_a_a_docker_marked_test_creates_one_labeled_volume")
+    try:
+        names = _volume_names(engine)
+        assert _minted_volume not in names, (
+            "the autouse teardown must have removed the previous test's own volume"
+        )
+        assert _live_volume in names, "a live registry's volume must never be swept"
+    finally:
+        engine.run(["volume", "rm", "--force", _live_volume])


### PR DESCRIPTION
Fixes #84

bosn's own Docker-marked tests leaked a real Docker volume per test, permanently. Measured on this machine before the fix:

```
149 bosn-g-test-* volumes
151 carrying a com.zackees.bosn.registry label
150 distinct registry ids   →  ~one dead registry per volume
```

Each test built a `Registry` inside a pytest `tmp_path`, created real volumes labeled with that registry's UUID, then pytest deleted the tmpdir — sqlite file and all. The volumes survived, labeled with an owner that no longer existed.

**They could never be collected.** Every live daemon buckets them as *foreign*, and `gc.py` re-proves ownership from engine labels before any delete precisely so it never touches another registry's resources. That protection is correct — and it is exactly what made these immortal.

The README opens with a machine that died at 452.6 GiB from "268 Docker invocations and zero cleanup calls." The test suite for the tool that prevents that was reproducing it. CI never surfaced it: Linux runners are fresh containers, so it only accumulated on developer machines.

## The fix

Teardown tracks the registry ids a Docker-marked test **mints**, and sweeps only those.

Precision is by construction rather than by path convention — a sweep can only ever remove ids the test itself created, so it cannot reach a live registry's resources. Read-only opens are excluded from the minted set, so a test that merely *reads* an existing registry (possibly the developer's real one) can never poison it.

A teardown failure warns rather than raises: it must not turn a passing test red, but swallowing it silently is how "storage is bounded" quietly stops being true.

## Evidence, on a real engine

```
BEFORE: 189 volumes, 149 bosn-g-test
31 passed in 354s
AFTER:  189 volumes, 149 bosn-g-test
```

Zero net growth. The pre-existing 149 orphans are deliberately untouched — recovering those is a separate decision, not a side effect of running tests.

## `doctor` also stops flooding

It emitted one `adopt --from-registry <id>` command per foreign id, semicolon-joined — a 150-command line on this machine. It now reports total resource count and distinct id count with the largest few:

```
151 resources belong to 150 registry ids other than this one (bosn cannot tell a prior
identity of this machine from a registry still in use elsewhere -- these are never touched
automatically); largest by resource count: 1fda5c5d… (2 resources), …
```

Below a threshold of 5 ids it still prints the exact command, since that is the case the reporting was built for.

**The wording is deliberately non-committal.** bosn cannot distinguish "dead registry" from "another live registry on this machine" — it only sees an id that is not its own, which is why foreign resources are protected in the first place. No signal separates them from labels alone, so the report claims neither, and a test asserts the words *orphan*, *dead*, *stale*, and *safe to delete* never appear.

## Verification

493 non-Docker tests pass, 31 Docker tests pass against a real engine, `ci/lint.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)