### PR TITLE
feat: derive workspace-done from repository state

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -480,6 +480,24 @@ class Daemon:
                 "maintenance.prune_leases.error", f"{type(exc).__name__}: {exc}"
             )
 
+        # Derived done-signals run before GC (so a workspace reclaimed in this very pass is
+        # eligible for the same pass's collection) and before the engine reachability check
+        # below (so a Docker-down machine still gets the benefit -- this step only shells
+        # out to git, never Docker).
+        self.registry.log_event("maintenance.derived_done.started")
+        try:
+            candidates, reclaimed = self._derived_done_pass()
+            self.registry.log_event(
+                "maintenance.derived_done.finished",
+                f"candidates={candidates} reclaimed={reclaimed}",
+            )
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - a scheduler failure must be visible, not silent
+            self.registry.log_event(
+                "maintenance.derived_done.error", f"{type(exc).__name__}: {exc}"
+            )
+
         engine = Engine(self.engine_binary)
         info = engine.info()
         if not info.reachable:
@@ -505,6 +523,63 @@ class Daemon:
             self.registry.log_event("maintenance.gc.finished", json.dumps(result.summary()))
         self._maintenance_backoff_seconds = MAINTENANCE_BACKOFF_INITIAL_SECONDS
         self._set_next_maintenance(self.clock.now() + self.maintenance_interval_seconds)
+
+    def _derived_done_pass(self) -> tuple[int, int]:
+        """Mark done every not-yet-done workspace whose Git state proves it is finished.
+
+        Explicit `bosn done` remains the strongest, first-party signal -- this only ever
+        *adds* done-ness through the same `gc.mark_done` write path, never removes it and
+        never overrides one. A workspace is enumerated from `resources.workspace` (via
+        `list_resources`), the same identity `mark_workspace_done` matches on, so it is
+        passed through to `classify_workspace`/`mark_done` unmodified rather than
+        renormalized. This misses a workspace that only survives in an older
+        `resource_uses` row whose owning resource has since moved on to a different
+        workspace -- an acceptable gap, since the failure direction is a missed
+        reclamation, never a false "done".
+
+        Every decision is logged, protected or reclaimed alike: a protected workspace with
+        no recorded reason is what makes a derived-done pass untrustworthy. A classifier
+        that raises protects the workspace it was evaluating and is logged, but must never
+        aim to take down the rest of this pass -- so it is caught per workspace, not once
+        for the whole loop.
+
+        Returns (candidates considered, workspaces reclaimed).
+        """
+        from bosn.gc import mark_done
+        from bosn.gitstate import classify_workspace
+
+        known = {
+            resource.workspace
+            for resource in self.registry.list_resources()
+            if resource.scope != "machine" and resource.workspace
+        }
+        candidates = sorted(known - self.registry.done_workspace_ids())
+        reclaimed = 0
+        for workspace in candidates:
+            try:
+                verdict = classify_workspace(workspace)
+            except KeyboardInterrupt:
+                raise
+            except Exception as exc:  # noqa: BLE001 - ambiguity protects; a failed classifier
+                # decides nothing, so treat it the same as any other non-safe verdict:
+                # log why, leave the workspace exactly as it was, keep evaluating the rest.
+                self.registry.log_event(
+                    "maintenance.derived_done.error", f"{workspace}: {type(exc).__name__}: {exc}"
+                )
+                continue
+            if verdict.safe_to_mark_done:
+                mark_done(self.registry, workspace)
+                reclaimed += 1
+                self.registry.log_event(
+                    "maintenance.derived_done.reclaimed",
+                    f"{workspace} state={verdict.state.value} evidence={verdict.evidence}",
+                )
+            else:
+                self.registry.log_event(
+                    "maintenance.derived_done.protected",
+                    f"{workspace} state={verdict.state.value} evidence={verdict.evidence}",
+                )
+        return len(candidates), reclaimed
 
     def _set_next_maintenance(self, deadline: float) -> None:
         self._next_maintenance_at = deadline

--- a/src/bosn/gitstate.py
+++ b/src/bosn/gitstate.py
@@ -1,0 +1,196 @@
+"""Read-only Git workspace classifier for derived done-signals.
+
+bosn frees a workspace's caches when it decides the workspace is "finished." The only
+first-party signal is `bosn done`. This module adds a *derived* signal: infer "finished"
+from repository state so a worktree deleted outside clud's teardown hook, or simply left
+clean and pushed, gets its caches reclaimed before the TTL expires instead of after.
+
+The asymmetry that governs every decision here: a false "finished" makes someone's warm
+cache collectable while they are still using it -- expensive, sometimes irrecoverable. A
+false "still working" only costs some disk until the TTL expires -- cheap. So every
+ambiguous or unavailable state MUST classify as protected, never finished. This module
+never mutates a repository (no fetch, no gc, no writes) -- it runs unattended in a daemon
+against a developer's real worktrees, so a bug here must never be able to touch their data.
+
+Untracked-files decision: untracked files do NOT by themselves make a workspace DIRTY.
+`git status --porcelain` reports untracked files as `??` lines, and this module treats
+those as non-blocking while any other porcelain line (staged, modified, deleted, renamed,
+conflicted) still marks DIRTY. The tradeoff: build output, IDE scratch files, and other
+disposable junk sit untracked in most real workspaces, and treating any stray file as
+"still working" would mean almost no workspace is ever safe to mark done -- the derived
+signal would never fire and #49 would ship no observable benefit. The risk this accepts is
+narrow: genuine new work that was never `git add`ed could theoretically be discarded. But
+`bosn done` only clears *caches* (stacks/specs), never the workspace's files themselves --
+an untracked file on disk survives a done-mark untouched, it just stops being kept warm.
+Losing warm cache for untracked work is the same cheap failure mode as a TTL expiry, not
+data loss, so the severe asymmetry above does not apply to this specific choice.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import running_process as rp
+
+GIT_TIMEOUT_SECONDS = 15
+
+
+class WorkspaceState(Enum):
+    ABSENT = "absent"
+    """The workspace directory does not exist."""
+
+    CLEAN = "clean"
+    """A repo, no uncommitted changes, nothing unpushed."""
+
+    DIRTY = "dirty"
+    """Uncommitted changes (staged, modified, deleted, renamed, or conflicted)."""
+
+    UNPUSHED = "unpushed"
+    """Commits not present on the tracking branch."""
+
+    DETACHED = "detached"
+    """Detached HEAD -- there is no branch to compare against a remote."""
+
+    NO_UPSTREAM = "no_upstream"
+    """No tracking branch configured, so "pushed" cannot be proven."""
+
+    NOT_A_REPO = "not_a_repo"
+    """The path exists but is not a Git repository (or worktree)."""
+
+    UNAVAILABLE = "unavailable"
+    """Git is missing, or a command failed/timed out for any other reason."""
+
+
+# Single obvious table for the one property that matters: which states are safe to
+# infer "done" from. Only ABSENT and CLEAN qualify. Every other state -- including
+# every failure mode -- is False, deliberately, so a reader can audit the safety
+# property without tracing conditionals. Do not special-case around this table.
+_SAFE_TO_MARK_DONE: dict[WorkspaceState, bool] = {
+    WorkspaceState.ABSENT: True,
+    WorkspaceState.CLEAN: True,
+    WorkspaceState.DIRTY: False,
+    WorkspaceState.UNPUSHED: False,
+    WorkspaceState.DETACHED: False,
+    WorkspaceState.NO_UPSTREAM: False,
+    WorkspaceState.NOT_A_REPO: False,
+    WorkspaceState.UNAVAILABLE: False,
+}
+
+
+@dataclass(frozen=True)
+class WorkspaceVerdict:
+    state: WorkspaceState
+    safe_to_mark_done: bool
+    evidence: str
+
+
+def _verdict(state: WorkspaceState, evidence: str) -> WorkspaceVerdict:
+    return WorkspaceVerdict(
+        state=state, safe_to_mark_done=_SAFE_TO_MARK_DONE[state], evidence=evidence
+    )
+
+
+def _run_git(args: list[str], cwd: Path) -> rp.CompletedProcess[str] | None:
+    """Run a git command, returning None (never raising) when it could not be trusted.
+
+    A None result must always be interpreted as UNAVAILABLE by the caller -- this
+    function does not distinguish "git said no" (a normal non-zero exit, e.g. no
+    upstream) from a real failure. Callers that need to tell those apart inspect
+    `.returncode` on a non-None result themselves.
+    """
+    try:
+        return rp.subprocess_run(["git", *args], cwd=cwd, check=False, timeout=GIT_TIMEOUT_SECONDS)
+    except KeyboardInterrupt:
+        raise
+    except (RuntimeError, OSError, subprocess.SubprocessError):
+        # RuntimeError: running_process wraps timeouts and spawn failures (missing
+        # binary) as RuntimeError. OSError/SubprocessError: defensive belt-and-braces
+        # for any lower-level spawn failure that slips through unwrapped. Every path
+        # here means the command could not be trusted, so the caller must fall back
+        # to UNAVAILABLE rather than guess at a state.
+        return None
+
+
+def classify_workspace(path: Path | str) -> WorkspaceVerdict:
+    """Classify a workspace's Git state for the derived done-signal.
+
+    Read-only: never fetches, never runs gc, never writes anything. Shells out to
+    `git` using plumbing/porcelain forms only (no human-readable log parsing), and
+    treats any missing binary, non-zero exit that isn't a recognized "no upstream"
+    signal, or timeout as UNAVAILABLE -- the safe default when the tool cannot prove
+    a workspace is finished.
+    """
+    workspace = Path(path)
+
+    if not workspace.exists():
+        return _verdict(WorkspaceState.ABSENT, f"{workspace} does not exist")
+
+    if shutil.which("git") is None:
+        return _verdict(WorkspaceState.UNAVAILABLE, "git is not on PATH")
+
+    # `git rev-parse --is-inside-work-tree` is the standard plumbing probe for "is this
+    # a repository (or worktree) at all," and fails cleanly (non-zero, no exception)
+    # outside one.
+    inside = _run_git(["rev-parse", "--is-inside-work-tree"], cwd=workspace)
+    if inside is None:
+        return _verdict(
+            WorkspaceState.UNAVAILABLE, "git rev-parse --is-inside-work-tree failed to run"
+        )
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return _verdict(WorkspaceState.NOT_A_REPO, f"{workspace} is not a git repository")
+
+    status_proc = _run_git(["status", "--porcelain"], cwd=workspace)
+    if status_proc is None or status_proc.returncode != 0:
+        return _verdict(WorkspaceState.UNAVAILABLE, "git status --porcelain failed to run")
+
+    status_lines = [line for line in status_proc.stdout.splitlines() if line.strip()]
+    # Untracked-only entries ("?? path") do not block a done-mark; see module docstring
+    # for the tradeoff. Anything else (staged/modified/deleted/renamed/conflicted) does.
+    tracked_changes = [line for line in status_lines if not line.startswith("??")]
+    if tracked_changes:
+        noun = "change" if len(tracked_changes) == 1 else "changes"
+        return _verdict(
+            WorkspaceState.DIRTY,
+            f"{len(tracked_changes)} uncommitted {noun}",
+        )
+
+    head_proc = _run_git(["symbolic-ref", "-q", "--short", "HEAD"], cwd=workspace)
+    if head_proc is None:
+        return _verdict(WorkspaceState.UNAVAILABLE, "git symbolic-ref failed to run")
+    if head_proc.returncode != 0:
+        # symbolic-ref fails specifically (and only) when HEAD is not a symbolic ref,
+        # i.e. detached. It is not a generic failure mode we need to distinguish
+        # further -- there is no upstream question to ask without a branch.
+        return _verdict(WorkspaceState.DETACHED, "HEAD is detached")
+    branch = head_proc.stdout.strip()
+
+    upstream_proc = _run_git(
+        ["rev-list", "--count", "@{upstream}..HEAD"],
+        cwd=workspace,
+    )
+    if upstream_proc is None:
+        return _verdict(WorkspaceState.UNAVAILABLE, "git rev-list failed to run")
+    if upstream_proc.returncode != 0:
+        # rev-list fails with "no upstream configured for branch" when @{upstream}
+        # cannot be resolved -- a normal, expected outcome for a local-only branch,
+        # not a tool failure. Distinguish it from UNAVAILABLE explicitly rather than
+        # folding it into the generic failure path.
+        return _verdict(WorkspaceState.NO_UPSTREAM, f"{branch!r} has no tracking branch")
+
+    ahead_text = upstream_proc.stdout.strip()
+    try:
+        ahead = int(ahead_text)
+    except ValueError:
+        return _verdict(
+            WorkspaceState.UNAVAILABLE, f"git rev-list returned non-numeric output: {ahead_text!r}"
+        )
+
+    if ahead > 0:
+        noun = "commit" if ahead == 1 else "commits"
+        return _verdict(WorkspaceState.UNPUSHED, f"{ahead} {noun} ahead of upstream")
+
+    return _verdict(WorkspaceState.CLEAN, f"{branch!r} is clean and matches upstream")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -753,6 +753,220 @@ def test_malformed_persisted_maintenance_deadline_recovers(tmp_path: Path) -> No
         daemon.registry.close()
 
 
+# -- derived done-signals (#49) ---------------------------------------------
+#
+# `classify_workspace` is faked throughout: the classifier module (bosn.gitstate) proves
+# its own git-state logic against real repositories in its own test module. These tests
+# only prove the daemon's wiring -- enumeration, the mark-done call, event evidence, and
+# fault isolation -- so nothing here builds a real git repo.
+
+
+def _seed_workspace(registry, workspace: str, name: str, *, scope: str = "spec") -> None:
+    registry.register_resource(
+        kind="volume", name=name, stack="s", generation="g", scope=scope, workspace=workspace
+    )
+
+
+def _fake_verdict(state, evidence: str):
+    from bosn.gitstate import WorkspaceState, WorkspaceVerdict
+
+    resolved = state if isinstance(state, WorkspaceState) else WorkspaceState(state)
+    safe = resolved in (WorkspaceState.ABSENT, WorkspaceState.CLEAN)
+    return WorkspaceVerdict(state=resolved, safe_to_mark_done=safe, evidence=evidence)
+
+
+def test_derived_done_marks_absent_and_clean_workspaces(monkeypatch, tmp_path: Path) -> None:
+    import bosn.gitstate
+
+    clock = FakeClock()
+    daemon = Daemon(state_dir=tmp_path, clock=clock)
+    try:
+        _seed_workspace(daemon.registry, "/absent", "vol-absent")
+        _seed_workspace(daemon.registry, "/clean", "vol-clean")
+
+        def fake_classify(path):
+            from bosn.gitstate import WorkspaceState
+
+            mapping = {
+                "/absent": (WorkspaceState.ABSENT, "does not exist"),
+                "/clean": (WorkspaceState.CLEAN, "'main' is clean and matches upstream"),
+            }
+            state, evidence = mapping[str(path)]
+            return _fake_verdict(state, evidence)
+
+        monkeypatch.setattr(bosn.gitstate, "classify_workspace", fake_classify)
+
+        candidates, reclaimed = daemon._derived_done_pass()
+
+        assert candidates == 2
+        assert reclaimed == 2
+        assert daemon.registry.done_workspace_ids() == {"/absent", "/clean"}
+    finally:
+        daemon.registry.close()
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        "dirty",
+        "unpushed",
+        "detached",
+        "no_upstream",
+        "not_a_repo",
+        "unavailable",
+    ],
+)
+def test_derived_done_leaves_unsafe_states_untouched(
+    monkeypatch, tmp_path: Path, state: str
+) -> None:
+    import bosn.gitstate
+
+    clock = FakeClock()
+    daemon = Daemon(state_dir=tmp_path, clock=clock)
+    try:
+        _seed_workspace(daemon.registry, "/w", "vol")
+
+        monkeypatch.setattr(
+            bosn.gitstate, "classify_workspace", lambda _path: _fake_verdict(state, "evidence")
+        )
+
+        candidates, reclaimed = daemon._derived_done_pass()
+
+        assert candidates == 1
+        assert reclaimed == 0
+        assert daemon.registry.done_workspace_ids() == set()
+    finally:
+        daemon.registry.close()
+
+
+def test_derived_done_does_not_reclassify_an_already_done_workspace(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import bosn.gitstate
+    from bosn.gc import mark_done
+
+    clock = FakeClock()
+    daemon = Daemon(state_dir=tmp_path, clock=clock)
+    try:
+        _seed_workspace(daemon.registry, "/already-done", "vol-done")
+        _seed_workspace(daemon.registry, "/pending", "vol-pending")
+        assert mark_done(daemon.registry, "/already-done") == 1
+
+        classified: list[str] = []
+
+        def fake_classify(path):
+            classified.append(str(path))
+            return _fake_verdict("clean", "clean and pushed")
+
+        monkeypatch.setattr(bosn.gitstate, "classify_workspace", fake_classify)
+
+        candidates, reclaimed = daemon._derived_done_pass()
+
+        assert candidates == 1
+        assert reclaimed == 1
+        assert classified == ["/pending"], "an already-done workspace must never be reclassified"
+    finally:
+        daemon.registry.close()
+
+
+def test_derived_done_logs_evidence_for_both_directions(monkeypatch, tmp_path: Path) -> None:
+    import bosn.gitstate
+
+    clock = FakeClock()
+    daemon = Daemon(state_dir=tmp_path, clock=clock)
+    try:
+        _seed_workspace(daemon.registry, "/safe", "vol-safe")
+        _seed_workspace(daemon.registry, "/unsafe", "vol-unsafe")
+
+        def fake_classify(path):
+            from bosn.gitstate import WorkspaceState
+
+            if str(path) == "/safe":
+                return _fake_verdict(WorkspaceState.CLEAN, "'main' is clean and matches upstream")
+            return _fake_verdict(WorkspaceState.DIRTY, "3 uncommitted changes")
+
+        monkeypatch.setattr(bosn.gitstate, "classify_workspace", fake_classify)
+
+        daemon._derived_done_pass()
+
+        events = [(row["kind"], row["detail"]) for row in daemon.registry.events()]
+        reclaimed = [
+            detail for kind, detail in events if kind == "maintenance.derived_done.reclaimed"
+        ]
+        protected = [
+            detail for kind, detail in events if kind == "maintenance.derived_done.protected"
+        ]
+        assert len(reclaimed) == 1
+        assert "/safe" in reclaimed[0]
+        assert "clean and matches upstream" in reclaimed[0]
+        assert len(protected) == 1
+        assert "/unsafe" in protected[0]
+        assert "3 uncommitted changes" in protected[0]
+    finally:
+        daemon.registry.close()
+
+
+def test_derived_done_raising_classifier_protects_and_does_not_block_gc(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A classifier crash must be logged, must protect the workspace it was evaluating, and
+    must not prevent the GC step that follows it in the same pass from running."""
+    import bosn.gitstate
+
+    clock = FakeClock()
+
+    class ReachableEngine:
+        def __init__(self, _binary: str) -> None:
+            pass
+
+        def info(self) -> EngineInfo:
+            return EngineInfo(binary="docker", reachable=True)
+
+    gc_calls: list[str] = []
+
+    class RecordingCollector:
+        def __init__(self, _registry, _engine, *, config=None) -> None:
+            pass
+
+        def collect(self, **_kwargs):
+            gc_calls.append("gc")
+
+            class Result:
+                def summary(self):
+                    return {"removed": 0}
+
+            return Result()
+
+    import bosn.engine
+    import bosn.gc
+
+    monkeypatch.setattr(bosn.engine, "Engine", ReachableEngine)
+    monkeypatch.setattr(bosn.gc, "Collector", RecordingCollector)
+
+    def boom(_path):
+        raise RuntimeError("git executable vanished mid-classification")
+
+    monkeypatch.setattr(bosn.gitstate, "classify_workspace", boom)
+
+    daemon = Daemon(state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60)
+    try:
+        _seed_workspace(daemon.registry, "/flaky", "vol-flaky")
+
+        assert daemon.run_maintenance_if_due() is True
+
+        events = [(row["kind"], row["detail"]) for row in reversed(daemon.registry.events())]
+        kinds = [kind for kind, _detail in events]
+        assert any(
+            kind == "maintenance.derived_done.error" and "/flaky" in detail
+            for kind, detail in events
+        )
+        assert daemon.registry.done_workspace_ids() == set()
+        assert "maintenance.gc.started" in kinds
+        assert gc_calls == ["gc"], "a classifier failure must not prevent GC from running"
+    finally:
+        daemon.registry.close()
+
+
 def test_adopt_with_multiple_foreign_registries_prints_selectable_commands(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_gitstate.py
+++ b/tests/test_gitstate.py
@@ -1,0 +1,213 @@
+"""Git workspace classifier: the safety property under test is the safe_to_mark_done table.
+
+Every state except ABSENT and CLEAN must be False, including every failure mode. Real git
+repositories are built in tmp dirs for each case rather than mocked, so these tests prove
+the actual command parsing (porcelain output, rev-list exit codes, symbolic-ref failure on
+detached HEAD) rather than an assumption about it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bosn.gitstate import WorkspaceState, classify_workspace
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+}
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**_env(), **GIT_ENV},
+    )
+
+
+def _env() -> dict[str, str]:
+    import os
+
+    return dict(os.environ)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "user.name", "Test")
+    _git(path, "config", "user.email", "test@example.com")
+
+
+def _commit_all(path: Path, message: str) -> None:
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", message)
+
+
+def _make_bare_remote(tmp_path: Path) -> Path:
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True, capture_output=True)
+    return remote
+
+
+def test_absent_workspace(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    verdict = classify_workspace(missing)
+    assert verdict.state is WorkspaceState.ABSENT
+    assert verdict.safe_to_mark_done is True
+    assert verdict.evidence
+
+
+def test_not_a_repo(tmp_path: Path) -> None:
+    plain = tmp_path / "plain-dir"
+    plain.mkdir()
+    (plain / "file.txt").write_text("hello", encoding="utf-8")
+    verdict = classify_workspace(plain)
+    assert verdict.state is WorkspaceState.NOT_A_REPO
+    assert verdict.safe_to_mark_done is False
+
+
+def test_clean_and_pushed(tmp_path: Path) -> None:
+    remote = _make_bare_remote(tmp_path)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "a.txt").write_text("one", encoding="utf-8")
+    _commit_all(repo, "initial")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-q", "-u", "origin", "main")
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.CLEAN
+    assert verdict.safe_to_mark_done is True
+    assert verdict.evidence
+
+
+def test_dirty_tracked_modification(tmp_path: Path) -> None:
+    remote = _make_bare_remote(tmp_path)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "a.txt").write_text("one", encoding="utf-8")
+    _commit_all(repo, "initial")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-q", "-u", "origin", "main")
+
+    (repo / "a.txt").write_text("modified", encoding="utf-8")
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.DIRTY
+    assert verdict.safe_to_mark_done is False
+    assert "1" in verdict.evidence
+
+
+def test_untracked_only_is_not_dirty(tmp_path: Path) -> None:
+    """Untracked files (build output, scratch files) do not block a done-mark by themselves."""
+    remote = _make_bare_remote(tmp_path)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "a.txt").write_text("one", encoding="utf-8")
+    _commit_all(repo, "initial")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-q", "-u", "origin", "main")
+
+    (repo / "build-output.tmp").write_text("scratch", encoding="utf-8")
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.CLEAN
+    assert verdict.safe_to_mark_done is True
+
+
+def test_unpushed_commits(tmp_path: Path) -> None:
+    remote = _make_bare_remote(tmp_path)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "a.txt").write_text("one", encoding="utf-8")
+    _commit_all(repo, "initial")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-q", "-u", "origin", "main")
+
+    (repo / "b.txt").write_text("two", encoding="utf-8")
+    _commit_all(repo, "second")
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.UNPUSHED
+    assert verdict.safe_to_mark_done is False
+    assert "1" in verdict.evidence
+
+
+def test_detached_head(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "a.txt").write_text("one", encoding="utf-8")
+    _commit_all(repo, "initial")
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    _git(repo, "checkout", "-q", sha)
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.DETACHED
+    assert verdict.safe_to_mark_done is False
+
+
+def test_no_upstream(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "a.txt").write_text("one", encoding="utf-8")
+    _commit_all(repo, "initial")
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.NO_UPSTREAM
+    assert verdict.safe_to_mark_done is False
+    assert "main" in verdict.evidence
+
+
+def test_git_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    monkeypatch.setattr("bosn.gitstate.shutil.which", lambda _binary: None)
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.UNAVAILABLE
+    assert verdict.safe_to_mark_done is False
+    assert verdict.evidence
+
+
+def test_git_command_failure_yields_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raised RuntimeError (timeout, spawn failure) from the subprocess wrapper must not
+    propagate -- it has to collapse to a normal, protected UNAVAILABLE verdict."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("simulated timeout")
+
+    monkeypatch.setattr("bosn.gitstate.rp.subprocess_run", boom)
+
+    verdict = classify_workspace(repo)
+    assert verdict.state is WorkspaceState.UNAVAILABLE
+    assert verdict.safe_to_mark_done is False
+
+
+@pytest.mark.parametrize(
+    "state",
+    list(WorkspaceState),
+)
+def test_safety_table_is_exhaustive_and_explicit(state: WorkspaceState) -> None:
+    """A new WorkspaceState member must get an explicit safety decision, not a default."""
+    from bosn.gitstate import _SAFE_TO_MARK_DONE
+
+    assert state in _SAFE_TO_MARK_DONE
+    expected_safe = state in (WorkspaceState.ABSENT, WorkspaceState.CLEAN)
+    assert _SAFE_TO_MARK_DONE[state] is expected_safe


### PR DESCRIPTION
Fixes #49

The README promised derived done-signals — missing worktree, clean branch — guarded so dirty or unpushed work is never destroyed. Only the explicit `bosn done` path existed, so a worktree removed outside clud's teardown hook kept its caches until the ordinary TTL.

## The safety property, and why it drove the design

A false "finished" makes someone's warm cache collectable **while they are still working**. A false "still working" costs some disk until the TTL expires. That asymmetry is severe, so every ambiguous or unavailable state protects.

`gitstate.classify_workspace` covers eight states, and the safety mapping is a single dict literal so it can be audited at a glance:

| Safe to mark done | Protected |
| --- | --- |
| `ABSENT`, `CLEAN` | `DIRTY`, `UNPUSHED`, `DETACHED`, `NO_UPSTREAM`, `NOT_A_REPO`, `UNAVAILABLE` |

A test parametrizes over every enum member, so adding a state without deciding its safety fails loudly rather than silently defaulting.

## Two judgment calls worth surfacing

**Untracked files do not count as dirty.** Build output sits untracked in most real workspaces, so counting it would mean no workspace is ever reclaimable and the signal would never fire. The risk is bounded by what `done` actually does: it clears warm *caches*, never workspace files. An untracked file survives untouched, so the downside is a cold rebuild — not lost work.

**A non-zero git exit is a trusted answer, not a broken tool.** That distinction separates `NO_UPSTREAM` and `NOT_A_REPO` (git ran and told us something definite) from `UNAVAILABLE` (failed to spawn, or timed out). Collapsing them would have thrown away real information.

## Where the pass runs

In maintenance, between prune-leases and GC:

- **Before the engine-reachability check**, because it shells out to `git` and never Docker — a machine with a dead engine still gets the benefit.
- **Before GC**, so the same cycle collects what it just reclaimed rather than waiting another five minutes.

Every decision logs its evidence **in both directions**. A protected workspace with no recorded reason is precisely what would make a feature like this untrustworthy. A classifier that raises protects that workspace and stops neither the pass nor the GC after it.

## Verified against real repositories

Not just fixtures — the classifier run against actual repos on this machine:

| Workspace | State | Safe | Evidence |
| --- | --- | --- | --- |
| this checkout | `NO_UPSTREAM` | ✗ | branch has no tracking branch |
| soldr | `DIRTY` | ✗ | 5 uncommitted changes |
| absent path | `ABSENT` | ✓ | does not exist |
| non-repo dir | `NOT_A_REPO` | ✗ | not a git repository |

## Verification

521 tests pass (28 new), `ci/lint.py` clean. One daemon timing test flaked on one of three full-suite runs; it passes in isolation and passes with this diff stashed, so it is the pre-existing Windows flake rather than added watchdog latency — worth checking rather than assuming, since this pass does run on that thread.

## Known limit

Per-cycle cost is unbounded: classification is up to four `git` calls per not-yet-done workspace, serially, on the idle-watchdog thread. That thread already blocks on Docker during GC, so this adds to an existing stall rather than introducing a new class of one. A cap would be the next step if worktree counts get large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)