### PR TITLE
feat: drive the Docker front door from an introspectable category table

### DIFF
--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -13,12 +15,71 @@ from pathlib import Path
 
 from bosn import __version__, daemon, labels
 from bosn.compose import ComposeError, content_digest, load_compose
+
+# The category table (#46): every verb bosn-docker knows about, and whether it is
+# implemented here (GOVERNED), passed verbatim to the real engine (FORWARD), or
+# explicitly refused with a remedy (REFUSE). `resolve()` is the fail-closed entry point --
+# it always returns a VerbSpec, turning a verb the table has never heard of into a REFUSE
+# with a generic remedy rather than a `None` a dispatcher could mistake for "safe to
+# forward". Dispatch below calls `resolve()`, never `spec_for()`, for that reason.
+from bosn.frontdoor import Category, resolve, supported
 from bosn.registry import Registry
 from bosn.resources import process_start_time
 
 
 class DockerFrontDoorError(ValueError):
     pass
+
+
+# Environment marker set on the child's environment for exactly the duration bosn-docker
+# spawns a forwarded command. Its purpose is narrow: catch a `docker` shim (a future slice)
+# that turns out to *be* bosn-docker resolving itself off PATH and calling back in here --
+# without it, that resolution loops forever. See `_forward` for the full guard and its
+# blind spots.
+_RECURSION_GUARD_ENV = "BOSN_DOCKER_FORWARDING"
+
+
+def _this_program() -> Path:
+    """Best-effort absolute path to the file backing the running `bosn-docker` process."""
+    return Path(sys.argv[0]).resolve()
+
+
+def _resolve_real_engine(binary: str = "docker") -> Path | None:
+    """Resolve `binary` to an absolute path via PATH, or None if nothing is found."""
+    found = shutil.which(binary)
+    if found is None:
+        return None
+    return Path(found).resolve()
+
+
+def _is_this_program(candidate: Path) -> bool:
+    """True when `candidate` is the same file as the running `bosn-docker` program.
+
+    `Path.samefile` is preferred (works across symlinks/hardlinks, the way a shim would
+    likely be installed) and falls back to a plain path comparison when the candidate
+    does not exist or the filesystem does not support the identity check (e.g. across
+    drives on Windows).
+    """
+    this = _this_program()
+    try:
+        return candidate.samefile(this)
+    except OSError:
+        return candidate == this
+
+
+def _envelope(*, code: str, message: str, next_step: str, as_json: bool) -> int:
+    """Emit the repo's stable refusal envelope, or readable prose when not asked for JSON.
+
+    Deliberately not imported from `bosn.cli`: `bosn-docker` is a separate console entry
+    point (see pyproject.toml), and reaching into another module's private helper would
+    couple two independently-invoked programs for a four-line dict. The shape is copied,
+    not the function.
+    """
+    if as_json:
+        print(json.dumps({"ok": False, "code": code, "message": message, "next": next_step}))
+    else:
+        print(message, file=sys.stderr)
+    return 1
 
 
 def compose_to_manifest(source: Path) -> str:
@@ -43,17 +104,46 @@ def compose_to_manifest(source: Path) -> str:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """The top-level parser deliberately does not hard-code the verb surface.
+
+    It used to: `sub.add_parser("init", ...)` / `sub.add_parser("compose", ...)` via
+    `add_subparsers`, which makes argparse itself reject anything it didn't register --
+    including verbs that should reach the REFUSE path with a structured remedy, and
+    unknown verbs, which must refuse rather than bounce off argparse with a bare exit 2.
+    So the verb is a plain optional positional and everything after it is REMAINDER;
+    `bosn.frontdoor.VERBS` is consulted in `main()`, and is the only place a verb is
+    declared. `init`/`compose` still get their own dedicated sub-parsing once the verb is
+    known (see `_parse_init_args`/`_parse_compose_args`), so their flag surfaces and error
+    messages are unchanged.
+    """
     parser = argparse.ArgumentParser(prog="bosn-docker", description=__doc__)
     parser.add_argument("--version", action="version", version=__version__)
-    sub = parser.add_subparsers(dest="verb")
-    init = sub.add_parser("init", help="generate bosn.toml from compose.yaml")
-    init.add_argument("--compose", default="compose.yaml")
-    init.add_argument("--output", default="bosn.toml")
-    compose = sub.add_parser("compose", help="managed Compose subset: up, down, logs, ps")
-    compose.add_argument("command", choices=["up", "down", "logs", "ps"])
-    compose.add_argument("args", nargs=argparse.REMAINDER)
-    compose.add_argument("-f", "--file", default="compose.yaml")
+    parser.add_argument(
+        "--supported",
+        action="store_true",
+        help="print the supported verb table (see bosn.frontdoor) and exit",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit structured machine-readable output"
+    )
+    parser.add_argument("verb", nargs="?", help="docker verb; see --supported")
+    parser.add_argument("args", nargs=argparse.REMAINDER, help="verb-specific arguments")
     return parser
+
+
+def _parse_init_args(args: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="bosn-docker init")
+    parser.add_argument("--compose", default="compose.yaml")
+    parser.add_argument("--output", default="bosn.toml")
+    return parser.parse_args(args)
+
+
+def _parse_compose_args(args: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="bosn-docker compose")
+    parser.add_argument("command", choices=["up", "down", "logs", "ps"])
+    parser.add_argument("args", nargs=argparse.REMAINDER)
+    parser.add_argument("-f", "--file", default="compose.yaml")
+    return parser.parse_args(args)
 
 
 def _yaml_scalar(value: str) -> str:
@@ -286,16 +376,126 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
         overlay.unlink(missing_ok=True)
 
 
+def _forward(verb: str, args: list[str], *, as_json: bool) -> int:
+    """Pass a FORWARD verb's argv verbatim to the real engine.
+
+    Recursion guard, two layers, because #46 explicitly calls out that a later slice
+    installs a `docker` shim that *is* `bosn-docker` -- if resolving "docker" off PATH
+    can land back on this program, forwarding becomes a fork bomb the moment that shim
+    ships, so the guard has to exist before it does:
+
+    1. `_RECURSION_GUARD_ENV` in the environment: set on every child this function spawns.
+       A shim invoked as that child inherits it and refuses immediately, before touching
+       PATH resolution at all -- this is what stops a chain of self-invocations once one
+       has already started.
+    2. `_is_this_program()`: resolves "docker" via PATH and compares it, by file identity,
+       against this program's own path. This is what stops the *first* hop -- the case
+       where PATH's "docker" already is (a copy or symlink of) bosn-docker before any
+       forwarding has happened yet, so there is no inherited env var to catch it.
+
+    What this cannot catch: a shim that (a) is a distinct file from bosn-docker's own
+    script -- so `samefile` does not match -- *and* (b) clears its inherited environment
+    before re-invoking bosn-docker, dropping the marker. Neither mechanism alone covers
+    that combination; it would need the shim itself to cooperate (e.g. by also checking
+    its own resolved identity), which is out of scope for this slice.
+
+    This guard does not cover `_run_compose`, which still spawns bare `["docker",
+    "compose", ...]` resolved off PATH with neither absolute resolution nor the marker --
+    `compose` is GOVERNED, not FORWARD, so it never reaches this function. Once a shim
+    ships, `bosn-docker compose up` -> shim `docker` -> GOVERNED dispatch -> `_run_compose`
+    -> bare `docker` is an unguarded loop. Leaving it unguarded here is deliberate (this
+    slice's brief pins compose's existing behavior unchanged); the shim-installing slice
+    must route `_run_compose`'s engine invocation through `_resolve_real_engine` and this
+    same marker before any shim is installed.
+    """
+    if os.environ.get(_RECURSION_GUARD_ENV):
+        return _envelope(
+            code="docker.recursion",
+            message=(
+                f"bosn-docker {verb}: refusing to forward -- this process is already inside "
+                "a bosn-docker forward, so the `docker` on PATH would call back into itself"
+            ),
+            next_step=(
+                "run `bosn doctor` to check the docker shim, or invoke the real engine directly"
+            ),
+            as_json=as_json,
+        )
+    real = _resolve_real_engine("docker")
+    if real is None:
+        return _envelope(
+            code="docker.no-engine",
+            message=f"bosn-docker {verb}: no `docker` found on PATH",
+            next_step="install Docker (or podman) and ensure `docker` is on PATH",
+            as_json=as_json,
+        )
+    if _is_this_program(real):
+        return _envelope(
+            code="docker.recursion",
+            message=(
+                f"bosn-docker {verb}: the `docker` resolved from PATH is bosn-docker itself "
+                f"({real}); forwarding would call back into this program"
+            ),
+            next_step=(
+                "run `bosn doctor` to check the docker shim, or repair PATH to reach the "
+                "real engine"
+            ),
+            as_json=as_json,
+        )
+    env = dict(os.environ)
+    env[_RECURSION_GUARD_ENV] = str(os.getpid())
+    completed = subprocess.run([str(real), verb, *args], check=False, env=env)
+    return completed.returncode
+
+
+def _dispatch_from_table(verb: str, args: list[str], *, as_json: bool) -> int:
+    """Route every verb that is not one of the two GOVERNED verbs implemented directly
+    in `main()`. Uses `frontdoor.resolve()`, not `spec_for()`: `resolve()` is the
+    fail-closed wrapper that turns a verb the table has never heard of into an explicit
+    REFUSE row with a generic remedy, so there is no `None` case here to get wrong --
+    unknown never means forward.
+    """
+    spec = resolve(verb)
+    if spec.category is Category.FORWARD:
+        return _forward(verb, args, as_json=as_json)
+    if spec.category is Category.REFUSE:
+        return _envelope(
+            code="docker.refused",
+            message=f"bosn-docker {verb}: {spec.summary}",
+            next_step=spec.remedy or "run `bosn-docker --supported --json` for supported verbs",
+            as_json=as_json,
+        )
+    # spec.category is Category.GOVERNED here: declared in the table but not one of the
+    # verbs main() implements directly (init/compose). Refuse rather than silently no-op.
+    return _envelope(
+        code="docker.not-implemented",
+        message=f"bosn-docker {verb}: declared governed but not yet wired in this build",
+        next_step=spec.remedy or "see the project tracker for this verb's landing phase",
+        as_json=as_json,
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
+    raw_argv = list(argv if argv is not None else sys.argv[1:])
+    # Scanned from the raw tokens, the same way `bosn.cli` decides `json_errors` -- not
+    # read off the parsed namespace. `args` is `argparse.REMAINDER`, so a `--json` typed
+    # after the verb (`bosn-docker rm --json`, the natural place to put it) is swallowed
+    # into the verb's own argv rather than bound to the top-level flag; forwarded verbs
+    # need that swallowing intact so the flag reaches the real engine verbatim, but
+    # refusals still need to know the caller asked for JSON however it was spelled.
+    as_json = "--json" in raw_argv
     parser = build_parser()
-    ns = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    ns = parser.parse_args(raw_argv)
+    if ns.supported:
+        print(json.dumps(supported()))
+        return 0
     if ns.verb is None:
         parser.print_help()
         return 0
     if ns.verb == "init":
+        init_ns = _parse_init_args(ns.args)
         try:
-            text = compose_to_manifest(Path(ns.compose))
-            output = Path(ns.output)
+            text = compose_to_manifest(Path(init_ns.compose))
+            output = Path(init_ns.output)
             if output.exists():
                 raise DockerFrontDoorError(f"refusing to overwrite {output}; choose --output")
             output.write_text(text, encoding="utf-8")
@@ -305,9 +505,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"wrote {output}")
         return 0
     if ns.verb == "compose":
+        compose_ns = _parse_compose_args(ns.args)
         try:
-            return _run_compose(ns.command, Path(ns.file), list(ns.args))
+            return _run_compose(compose_ns.command, Path(compose_ns.file), list(compose_ns.args))
         except (OSError, DockerFrontDoorError) as exc:
             print(f"bosn-docker compose: {exc}", file=sys.stderr)
             return 1
-    return 2
+    return _dispatch_from_table(ns.verb, ns.args, as_json=as_json)

--- a/src/bosn/frontdoor.py
+++ b/src/bosn/frontdoor.py
@@ -1,0 +1,463 @@
+"""The `bosn-docker` front-door category table.
+
+`bosn-docker` advertises a drop-in Docker/Compose surface. Every verb a caller might type
+against it falls into exactly one of three categories, and this module is the single place
+that decides which:
+
+- ``GOVERNED`` -- bosn implements the verb itself. It creates or manages resources (a
+  container, a volume, a network, an image), and every one of those resources is labeled,
+  registered, and leased the same way anything else bosn creates is (see ``labels.py`` /
+  ``registry.py``). ``init`` and ``compose`` are the current members.
+
+- ``FORWARD`` -- the verb is passed verbatim to the real Docker binary because it is
+  provably incapable of creating or mutating an engine-managed resource. This is a narrow
+  allowlist by design: the bar is not "read-only in the common case", it is "cannot create
+  a resource in *any* case". A verb only earns this category when its manual page is read
+  end to end and the reasoning is written down next to it below.
+
+- ``REFUSE`` -- everything else, including every verb this table has never heard of.
+  Refusing carries a ``remedy``: the governed bosn equivalent, or the documented escape
+  hatch to the real engine, so the caller has somewhere to go next instead of a dead end.
+
+The load-bearing property is the *default*. A verb that is absent from ``VERBS`` is not
+"probably fine to pass through" -- it is unknown, and unknown means refuse. Getting this
+backwards would let an unrecognized verb like ``docker run`` fall through to the real
+engine and silently create an unlabeled, unregistered, unleasable resource: precisely the
+ungoverned accumulation bosn exists to prevent (see the project's #1 label contract).
+``resolve()`` below makes that default an explicit branch in code -- never an implicit
+`dict.get(verb)` that happens to return `None` and gets treated as "okay to forward" by an
+inattentive caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+# Bumped only if the shape of supported()'s payload changes in a way a consumer parsing it
+# would need to branch on (a field renamed or removed; a field's meaning changed). Adding a
+# new verb to VERBS, or a new optional field, is not a breaking change and does not bump
+# this. A consuming agent that pins to a schema_version it has validated against can detect
+# drift instead of silently misreading a reshaped payload.
+SCHEMA_VERSION = 1
+
+
+class Category(Enum):
+    """Where a `bosn-docker` verb's implementation lives.
+
+    Values are lowercase strings, not auto() ints, because they round-trip through
+    supported()'s JSON payload -- an agent parsing that JSON reads "governed", not "1".
+    """
+
+    GOVERNED = "governed"
+    FORWARD = "forward"
+    REFUSE = "refuse"
+
+
+@dataclass(frozen=True)
+class VerbSpec:
+    """One row of the category table.
+
+    `remedy` is required for REFUSE (there is always something else to do or say) and
+    left `None` for GOVERNED/FORWARD, where "run the verb" already is the remedy.
+    """
+
+    verb: str
+    category: Category
+    summary: str
+    remedy: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.category is Category.REFUSE and not self.remedy:
+            raise ValueError(f"REFUSE entry {self.verb!r} must carry a remedy")
+
+
+# ---------------------------------------------------------------------------------------
+# GOVERNED -- bosn implements these. Every resource they create is labeled and registered.
+# ---------------------------------------------------------------------------------------
+_GOVERNED: tuple[VerbSpec, ...] = (
+    VerbSpec(
+        verb="init",
+        category=Category.GOVERNED,
+        summary="translate compose.yaml into a starting bosn.toml manifest",
+    ),
+    VerbSpec(
+        verb="compose",
+        category=Category.GOVERNED,
+        summary="managed Compose subset (up/down/logs/ps); every resource labeled and leased",
+    ),
+)
+
+# ---------------------------------------------------------------------------------------
+# FORWARD -- passed verbatim to the real docker binary. Kept deliberately small: each entry
+# below only exists because it is provably incapable of creating or mutating an
+# engine-managed resource, not merely because it "usually" is. See the module docstring.
+# ---------------------------------------------------------------------------------------
+_FORWARD: tuple[VerbSpec, ...] = (
+    # `docker version` prints client/server version metadata. It contacts the engine but
+    # neither reads nor writes any container, image, volume, or network -- there is no
+    # target argument for it to act on even if it wanted to.
+    VerbSpec(
+        verb="version",
+        category=Category.FORWARD,
+        summary="print client and engine version info (forwarded, read-only)",
+    ),
+    # `docker info` prints engine-wide diagnostics (driver, root dir, resource counts). It
+    # is a global read with no resource-scoped target and no side effect on the engine.
+    VerbSpec(
+        verb="info",
+        category=Category.FORWARD,
+        summary="print engine-wide diagnostic info (forwarded, read-only)",
+    ),
+    # `docker login` writes a credential to the *local* Docker config file
+    # (~/.docker/config.json). That file is not part of bosn's resource model -- it is not
+    # a container, image, volume, or network, and nothing about it is labeled, leased, or
+    # collected. It cannot create or mutate anything the registry tracks.
+    VerbSpec(
+        verb="login",
+        category=Category.FORWARD,
+        summary="authenticate to a registry (forwarded; touches local credential store only)",
+    ),
+    # `docker logout` is login's exact inverse: it deletes an entry from the same local
+    # credential file and touches nothing else. Same reasoning, same conclusion.
+    VerbSpec(
+        verb="logout",
+        category=Category.FORWARD,
+        summary="clear registry credentials (forwarded; touches local credential store only)",
+    ),
+)
+
+# The explicit safety allowlist tests assert FORWARD against: nothing here may be a verb
+# that docker documents as creating, starting, stopping, or removing a container, image,
+# volume, or network. Kept separate from _FORWARD (rather than derived from it) so that
+# adding a dangerous verb to _FORWARD without updating this list is exactly the mistake
+# the test is designed to catch, not something the list would quietly absorb.
+FORWARD_SAFE_ALLOWLIST: frozenset[str] = frozenset({"version", "info", "login", "logout"})
+
+# ---------------------------------------------------------------------------------------
+# REFUSE -- explicitly refused, each with a remedy pointing at the governed bosn equivalent
+# or the documented real-engine escape hatch. This list exists for verbs common enough that
+# a specific, named refusal is more useful than falling through to the generic "unknown
+# verb" refusal in resolve() -- it is not, and does not need to be, exhaustive: anything
+# missing from this list and from GOVERNED/FORWARD is still refused, generically, by
+# resolve()'s fail-closed default.
+# ---------------------------------------------------------------------------------------
+_ESCAPE_HATCH = (
+    "not part of the managed subset; use the real `docker` binary directly if you "
+    "accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn "
+    "can create it tracked"
+)
+
+_REFUSE: tuple[VerbSpec, ...] = (
+    VerbSpec(
+        "run",
+        Category.REFUSE,
+        "create and start an ad-hoc container",
+        "resource-creating; use `bosn run` for a manifest-declared stack, or "
+        "`bosn-docker compose up` for a multi-service project",
+    ),
+    VerbSpec(
+        "create",
+        Category.REFUSE,
+        "create a container without starting it",
+        "resource-creating; use `bosn ensure` to pre-warm a manifest-declared stack",
+    ),
+    VerbSpec(
+        "build",
+        Category.REFUSE,
+        "build an image from a Dockerfile",
+        "resource-creating; declare the build in bosn.toml and use `bosn ensure`/`bosn run`, "
+        "which key the built image to a spec digest and track it",
+    ),
+    VerbSpec(
+        "exec",
+        Category.REFUSE,
+        "run a command in a running container",
+        "targets a raw container name outside bosn's registry; use `bosn shell` or "
+        "`bosn run` against a manifest-declared stack",
+    ),
+    VerbSpec(
+        "start",
+        Category.REFUSE,
+        "start a stopped container",
+        "mutates container lifecycle state outside the registry; use `bosn run` or "
+        "`bosn ensure` to bring up a managed stack",
+    ),
+    VerbSpec(
+        "stop",
+        Category.REFUSE,
+        "stop a running container",
+        "mutates container lifecycle state outside lease/GC bookkeeping; use `bosn done` "
+        "to mark a workspace finished, or `bosn gc` to reclaim collectable resources",
+    ),
+    VerbSpec(
+        "restart",
+        Category.REFUSE,
+        "restart a container",
+        "mutates container lifecycle state outside the registry; use `bosn run` or "
+        "`bosn ensure` to bring up a managed stack fresh",
+    ),
+    VerbSpec(
+        "kill",
+        Category.REFUSE,
+        "send a signal to a running container",
+        "mutates container lifecycle state outside the registry; use `bosn cancel` for a "
+        "daemon-owned job, or `bosn gc` to reclaim collectable resources",
+    ),
+    VerbSpec(
+        "rm",
+        Category.REFUSE,
+        "remove a container",
+        "deletes outside lease/GC bookkeeping; use `bosn gc` to reclaim managed resources safely",
+    ),
+    VerbSpec(
+        "rmi",
+        Category.REFUSE,
+        "remove an image",
+        "deletes outside lease/GC bookkeeping; use `bosn gc` to reclaim managed resources safely",
+    ),
+    VerbSpec(
+        "pull",
+        Category.REFUSE,
+        "download an image from a registry",
+        "creates a local image copy outside the registry; declare the image in bosn.toml "
+        "and let `bosn ensure` pull it tracked",
+    ),
+    VerbSpec(
+        "push",
+        Category.REFUSE,
+        "upload an image to a registry",
+        _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "tag",
+        Category.REFUSE,
+        "create a new tag pointing at an existing image",
+        "creates a new local image reference outside the registry; " + _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "cp",
+        Category.REFUSE,
+        "copy files into or out of a container",
+        "targets a raw container name outside bosn's registry; use `bosn shell` to reach "
+        "a managed container's filesystem",
+    ),
+    VerbSpec(
+        "network",
+        Category.REFUSE,
+        "manage networks (create/rm/connect/...)",
+        "networks are declared implicitly by a stack and labeled by bosn; use "
+        "`bosn status` to inspect them, `bosn gc` to reclaim them",
+    ),
+    VerbSpec(
+        "volume",
+        Category.REFUSE,
+        "manage volumes (create/rm/prune/...)",
+        "volumes are declared in bosn.toml and labeled by bosn; use `bosn status` to "
+        "inspect them, `bosn gc` to reclaim them",
+    ),
+    VerbSpec(
+        "image",
+        Category.REFUSE,
+        "manage images (build/rm/prune/...)",
+        "images are generation-keyed and managed by bosn; use `bosn status`/`bosn gc` "
+        "instead of the raw image subcommands",
+    ),
+    VerbSpec(
+        "container",
+        Category.REFUSE,
+        "manage containers (create/rm/prune/...)",
+        "containers are declared in bosn.toml and labeled by bosn; use "
+        "`bosn status`/`bosn gc` instead of the raw container subcommands",
+    ),
+    VerbSpec(
+        "system",
+        Category.REFUSE,
+        "manage or inspect the engine (df/prune/events/...)",
+        "`system prune` in particular deletes resources bosn did not choose to reclaim; "
+        "use `bosn gc` for a governed equivalent",
+    ),
+    VerbSpec(
+        "save",
+        Category.REFUSE,
+        "export an image to a tar archive",
+        _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "load",
+        Category.REFUSE,
+        "import an image from a tar archive",
+        "creates a local image outside the registry; " + _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "export",
+        Category.REFUSE,
+        "export a container's filesystem to a tar archive",
+        _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "import",
+        Category.REFUSE,
+        "create an image from a tarball",
+        "creates a local image outside the registry; " + _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "commit",
+        Category.REFUSE,
+        "create a new image from a container's changes",
+        "creates a local image outside the registry; " + _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "rename",
+        Category.REFUSE,
+        "rename a container",
+        "mutates a container's identity outside the registry's naming; " + _ESCAPE_HATCH,
+    ),
+    VerbSpec(
+        "attach",
+        Category.REFUSE,
+        "attach local streams to a running container",
+        "targets a raw container name outside bosn's registry; use `bosn attach` for a "
+        "daemon-owned job",
+    ),
+    VerbSpec(
+        "ps",
+        Category.REFUSE,
+        "list containers",
+        "lists raw engine state instead of bosn's managed view; use `bosn status` or "
+        "`bosn tasks` for governed introspection",
+    ),
+    VerbSpec(
+        "logs",
+        Category.REFUSE,
+        "fetch a container's logs",
+        "targets a raw container name outside bosn's registry; use `bosn-docker compose "
+        "logs` for a managed stack, or `bosn attach` for a daemon-owned job",
+    ),
+    VerbSpec(
+        "inspect",
+        Category.REFUSE,
+        "show low-level details of an object",
+        "targets a raw object name outside bosn's registry; use `bosn status` for "
+        "governed introspection",
+    ),
+    VerbSpec(
+        "top",
+        Category.REFUSE,
+        "list processes running in a container",
+        "targets a raw container name outside bosn's registry; use `bosn jobs` for "
+        "governed introspection",
+    ),
+    VerbSpec(
+        "stats",
+        Category.REFUSE,
+        "stream resource usage statistics",
+        "targets raw container names outside bosn's registry; use `bosn status` for "
+        "governed introspection",
+    ),
+    VerbSpec(
+        "events",
+        Category.REFUSE,
+        "stream real-time engine events",
+        "surfaces raw engine activity outside bosn's registry; use `bosn status` for "
+        "governed introspection",
+    ),
+    VerbSpec(
+        "port",
+        Category.REFUSE,
+        "list a container's published ports",
+        "targets a raw container name outside bosn's registry; use `bosn status` for "
+        "governed introspection",
+    ),
+    VerbSpec(
+        "diff",
+        Category.REFUSE,
+        "list changed files in a container's filesystem",
+        "targets a raw container name outside bosn's registry; use `bosn shell` to "
+        "inspect a managed container directly",
+    ),
+    VerbSpec(
+        "wait",
+        Category.REFUSE,
+        "block until a container stops, then print its exit code",
+        "targets a raw container name outside bosn's registry; use `bosn jobs`/`bosn "
+        "attach` to wait on a daemon-owned job",
+    ),
+    VerbSpec(
+        "search",
+        Category.REFUSE,
+        "search Docker Hub for images",
+        _ESCAPE_HATCH,
+    ),
+)
+
+VERBS: tuple[VerbSpec, ...] = _GOVERNED + _FORWARD + _REFUSE
+
+
+def _index_by_verb(verbs: tuple[VerbSpec, ...]) -> dict[str, VerbSpec]:
+    index: dict[str, VerbSpec] = {}
+    for spec in verbs:
+        if spec.verb in index:
+            raise ValueError(f"duplicate verb in VERBS: {spec.verb!r}")
+        index[spec.verb] = spec
+    return index
+
+
+_BY_VERB: dict[str, VerbSpec] = _index_by_verb(VERBS)
+
+
+def spec_for(verb: str) -> VerbSpec | None:
+    """Look up `verb`'s table row. `None` means the table has no opinion -- callers must
+    not treat that as "safe to forward"; see `resolve()` for the fail-closed wrapper.
+    """
+    return _BY_VERB.get(verb)
+
+
+# The remedy attached to a verb resolve() has never heard of. Generic on purpose: there is
+# no specific governed equivalent to point at for a verb this table doesn't recognize.
+_UNKNOWN_VERB_REMEDY = (
+    "not part of the introspectable bosn-docker subset; run `bosn-docker --supported "
+    "--json` to see every governed, forwarded, and refused verb, or use the real `docker` "
+    "binary directly if you accept the resources it creates will be unmanaged"
+)
+
+
+def resolve(verb: str) -> VerbSpec:
+    """The fail-closed caller-facing entry point: always returns a decision, never `None`.
+
+    A verb present in `VERBS` returns its row. A verb absent from `VERBS` is unknown, and
+    this function's whole job is to make "unknown" resolve to REFUSE as an explicit branch
+    here rather than as a side effect of some other function's lookup miss. Dispatch code
+    should call this, not `spec_for`, for exactly that reason.
+    """
+    spec = spec_for(verb)
+    if spec is not None:
+        return spec
+    return VerbSpec(
+        verb=verb,
+        category=Category.REFUSE,
+        summary="unrecognized docker verb",
+        remedy=_UNKNOWN_VERB_REMEDY,
+    )
+
+
+def supported() -> dict:
+    """The payload behind `bosn-docker --supported --json`.
+
+    `VERBS` is the only source for it -- there is no second, hand-maintained list for
+    parser help text, generated docs, or this JSON to drift out of sync with. Every field
+    here is JSON-primitive (str/None), so `json.dumps(supported())` always round-trips for
+    the agent this is written for.
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "verbs": [
+            {
+                "verb": spec.verb,
+                "category": spec.category.value,
+                "summary": spec.summary,
+                "remedy": spec.remedy,
+            }
+            for spec in VERBS
+        ],
+    }

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from pathlib import Path
@@ -5,13 +6,15 @@ from typing import Any
 
 import pytest
 
-from bosn import daemon
+from bosn import daemon, docker_cli
 from bosn.docker_cli import (
     DockerFrontDoorError,
     _compose_overlay,
     _run_compose,
     compose_to_manifest,
+    main,
 )
+from bosn.frontdoor import Category, VerbSpec
 from bosn.registry import Registry
 
 
@@ -415,3 +418,229 @@ def test_a_clean_up_reconciles_exactly_as_before(
         "compose-release",
         "compose-adopt",
     ]
+
+
+# -- category-table dispatch (#46) --------------------------------------------
+#
+# `bosn.frontdoor` supplies the category table itself (a separate agent's slice of #46,
+# landed alongside this one). `bosn.docker_cli` dispatches through its `resolve()` -- the
+# fail-closed wrapper that always returns a `VerbSpec`, so an unknown verb is just another
+# REFUSE row rather than a `None` a caller could mistake for "safe to forward". These tests
+# do not depend on the real table's contents -- every test below monkeypatches
+# `docker_cli.resolve` (and, where relevant, `docker_cli.supported`) with a small fake of
+# its own, per the brief, so they do not break when the real table gains entries.
+
+
+def _fake_spec(verb: str, category: Category, summary: str, remedy: str | None) -> VerbSpec:
+    return VerbSpec(verb=verb, category=category, summary=summary, remedy=remedy)
+
+
+def test_a_governed_verb_still_runs_its_implementation_through_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`compose` is GOVERNED and implemented directly in `main()`, not through the table
+    dispatch -- this exercises the new `main()` -> `_parse_compose_args` -> `_run_compose`
+    path end to end, proving the table rewiring didn't disturb it.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr("bosn.docker_cli.process_start_time", lambda pid: 123.0)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+    compose = _compose_file(tmp_path)
+
+    returncode = main(["compose", "-f", str(compose), "up"])
+
+    assert returncode == 0
+    assert "compose-adopt" in fake_daemon.calls
+
+
+def test_a_forward_verb_invokes_the_real_engine_with_argv_passed_verbatim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_docker = tmp_path / "real-docker"
+    real_docker.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        docker_cli, "resolve", lambda verb: _fake_spec("version", Category.FORWARD, "v", None)
+    )
+    monkeypatch.setattr(docker_cli, "_resolve_real_engine", lambda binary="docker": real_docker)
+    calls: list[list[str]] = []
+    envs: list[dict[str, str]] = []
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> _FakeCompleted:
+        calls.append(argv)
+        envs.append(kwargs["env"])
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fake_run)
+
+    returncode = main(["version", "--format", "{{.Server.Version}}"])
+
+    assert returncode == 0
+    assert calls == [[str(real_docker), "version", "--format", "{{.Server.Version}}"]]
+    # The recursion guard's first layer: every forwarded child must carry the marker, or a
+    # future `docker` shim resolving back to this program would never see it and loop.
+    assert envs[0][docker_cli._RECURSION_GUARD_ENV] == str(os.getpid())
+
+
+def test_a_refuse_verb_emits_the_envelope_with_the_specs_remedy_and_exits_non_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        docker_cli,
+        "resolve",
+        lambda verb: _fake_spec(
+            "rm", Category.REFUSE, "forcibly removes containers bosn tracks", "use `bosn done`"
+        ),
+    )
+
+    returncode = main(["rm", "--json", "some-container"])
+
+    assert returncode != 0
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["ok"] is False
+    assert envelope["next"] == "use `bosn done`"
+    assert "rm" in envelope["message"]
+
+
+def test_an_unknown_verb_refuses_and_never_forwards(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The safety property: a verb absent from the table must never reach the engine.
+
+    Mirrors what the real `frontdoor.resolve()` does for a verb it has never heard of:
+    return an explicit REFUSE row rather than `None` -- this is the fail-closed contract
+    dispatch relies on, exercised here with a fake so the test does not depend on the
+    real table's contents.
+    """
+    monkeypatch.setattr(
+        docker_cli,
+        "resolve",
+        lambda verb: _fake_spec(
+            verb, Category.REFUSE, "unrecognized docker verb", "see --supported"
+        ),
+    )
+
+    def _fail_if_called(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise AssertionError("an unknown verb must never invoke the real engine")
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fail_if_called)
+
+    returncode = main(["totally-made-up-verb"])
+
+    assert returncode != 0
+    err = capsys.readouterr().err
+    assert "totally-made-up-verb" in err
+    assert "unrecognized" in err.lower()
+
+
+def test_an_unknown_verb_refuses_and_never_forwards_against_the_real_table(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same safety property, exercised against the real `bosn.frontdoor` table this time
+    (no monkeypatch of `resolve`) -- proves the wiring, not just a fake standing in for it.
+    """
+
+    def _fail_if_called(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise AssertionError("an unknown verb must never invoke the real engine")
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fail_if_called)
+
+    returncode = main(["totally-made-up-verb"])
+
+    assert returncode != 0
+    assert "totally-made-up-verb" in capsys.readouterr().err
+
+
+def test_supported_json_emits_parseable_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_table = {"verbs": [{"verb": "init", "category": "governed"}]}
+    monkeypatch.setattr(docker_cli, "supported", lambda: fake_table)
+
+    returncode = main(["--supported", "--json"])
+
+    assert returncode == 0
+    assert json.loads(capsys.readouterr().out) == fake_table
+
+
+# -- recursion guard: absolute real-engine resolution (#46) -------------------
+
+
+def test_recursion_guard_refuses_when_the_environment_marker_is_already_set(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A child of a bosn-docker forward that is itself asked to forward -- because the
+    resolved `docker` turned out to be a shim calling back into bosn-docker -- must refuse
+    immediately, before even resolving PATH again.
+    """
+    monkeypatch.setattr(
+        docker_cli, "resolve", lambda verb: _fake_spec("version", Category.FORWARD, "v", None)
+    )
+    monkeypatch.setenv(docker_cli._RECURSION_GUARD_ENV, "1234")
+
+    def _fail_if_called(*_a: Any, **_k: Any) -> Path | None:
+        raise AssertionError("must not resolve PATH again once the recursion marker is set")
+
+    monkeypatch.setattr(docker_cli, "_resolve_real_engine", _fail_if_called)
+
+    def _fail_if_run(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise AssertionError("must not execute the resolved engine")
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fail_if_run)
+
+    returncode = main(["version", "--json"])
+
+    assert returncode != 0
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["ok"] is False
+    assert envelope["code"] == "docker.recursion"
+
+
+def test_recursion_guard_refuses_when_the_resolved_docker_is_bosns_own_shim(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The first-hop case: PATH's `docker` already is bosn-docker (a future shim), before
+    any forwarding -- and therefore any inherited environment marker -- has happened.
+    """
+    monkeypatch.setattr(
+        docker_cli, "resolve", lambda verb: _fake_spec("version", Category.FORWARD, "v", None)
+    )
+    monkeypatch.setattr(docker_cli, "_resolve_real_engine", lambda binary="docker": Path("shim"))
+    monkeypatch.setattr(docker_cli, "_is_this_program", lambda candidate: True)
+
+    def _fail_if_run(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise AssertionError("must not execute a `docker` that resolves to bosn-docker itself")
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fail_if_run)
+
+    returncode = main(["version", "--json"])
+
+    assert returncode != 0
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["ok"] is False
+    assert envelope["code"] == "docker.recursion"
+    assert "bosn-docker" in envelope["message"]
+
+
+def test_json_refusals_emit_the_envelope_non_json_emit_readable_prose(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        docker_cli,
+        "resolve",
+        lambda verb: _fake_spec("kill", Category.REFUSE, "kills containers bosn tracks", "x"),
+    )
+
+    prose_returncode = main(["kill"])
+    prose_err = capsys.readouterr().err
+    assert prose_returncode != 0
+    assert "kill" in prose_err
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(prose_err)
+
+    json_returncode = main(["kill", "--json"])
+    envelope = json.loads(capsys.readouterr().out)
+    assert json_returncode != 0
+    assert envelope["ok"] is False

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -1,0 +1,162 @@
+import json
+
+import pytest
+
+from bosn.frontdoor import (
+    FORWARD_SAFE_ALLOWLIST,
+    VERBS,
+    Category,
+    VerbSpec,
+    resolve,
+    spec_for,
+    supported,
+)
+
+# Verbs that create, start, stop, remove, or otherwise mutate an engine-managed resource
+# (container/image/volume/network). If a future edit ever adds one of these to
+# FORWARD_SAFE_ALLOWLIST, the assertion below must fail -- that is the whole point of the
+# allowlist.
+_RESOURCE_MUTATING_VERBS = frozenset(
+    {
+        "run",
+        "create",
+        "build",
+        "exec",
+        "start",
+        "stop",
+        "restart",
+        "kill",
+        "rm",
+        "rmi",
+        "pull",
+        "push",
+        "tag",
+        "cp",
+        "network",
+        "volume",
+        "image",
+        "container",
+        "system",
+        "save",
+        "load",
+        "export",
+        "import",
+        "commit",
+        "rename",
+        "attach",
+    }
+)
+
+
+@pytest.mark.parametrize("spec", VERBS, ids=lambda spec: spec.verb)
+def test_every_spec_is_internally_consistent(spec: VerbSpec) -> None:
+    if spec.category is Category.REFUSE:
+        assert spec.remedy, f"{spec.verb!r} is REFUSE but carries no remedy"
+    assert isinstance(spec.verb, str) and spec.verb
+    assert isinstance(spec.summary, str) and spec.summary
+
+
+def test_no_duplicate_verbs() -> None:
+    verbs = [spec.verb for spec in VERBS]
+    assert len(verbs) == len(set(verbs)), "VERBS contains a duplicate verb"
+
+
+@pytest.mark.parametrize("spec", VERBS, ids=lambda spec: spec.verb)
+def test_spec_for_round_trips_every_table_entry(spec: VerbSpec) -> None:
+    assert spec_for(spec.verb) is spec
+
+
+def test_spec_for_unknown_verb_returns_none() -> None:
+    """`spec_for` is a raw lookup: a miss is `None`, not an opinion."""
+    assert spec_for("docker-compose-plugin-that-does-not-exist") is None
+
+
+def test_resolve_treats_unknown_verb_as_refused() -> None:
+    """This is the safety property: an unrecognized verb must never be forwarded.
+
+    A verb absent from VERBS -- e.g. a not-yet-cataloged docker subcommand, or a typo --
+    must resolve to REFUSE with a usable remedy, not silently pass through to the real
+    engine and create an unlabeled, unregistered resource.
+    """
+    spec = resolve("some-verb-nobody-registered")
+    assert spec.category is Category.REFUSE
+    assert spec.remedy
+
+
+@pytest.mark.parametrize("spec", VERBS, ids=lambda spec: spec.verb)
+def test_resolve_agrees_with_the_table_for_known_verbs(spec: VerbSpec) -> None:
+    assert resolve(spec.verb) is spec
+
+
+def test_forward_set_contains_only_the_declared_safe_allowlist() -> None:
+    """Table-driven guard against scope creep in FORWARD.
+
+    Every FORWARD verb must be named in FORWARD_SAFE_ALLOWLIST, and nothing else may be
+    in that allowlist. Adding a new FORWARD verb without also justifying it in the
+    allowlist (or vice versa) fails this test.
+    """
+    forward_verbs = {spec.verb for spec in VERBS if spec.category is Category.FORWARD}
+    assert forward_verbs == FORWARD_SAFE_ALLOWLIST
+
+
+def test_forward_set_never_contains_a_resource_mutating_verb() -> None:
+    """The load-bearing allowlist assertion: if a future edit ever forwards `run`, `rm`,
+    `build`, or any other verb that can create/mutate a resource, this must fail.
+    """
+    forward_verbs = {spec.verb for spec in VERBS if spec.category is Category.FORWARD}
+    assert forward_verbs.isdisjoint(_RESOURCE_MUTATING_VERBS)
+
+
+@pytest.mark.parametrize("spec", VERBS, ids=lambda spec: spec.verb)
+def test_refuse_entries_are_not_in_the_resource_mutating_allowlist_by_accident(
+    spec: VerbSpec,
+) -> None:
+    """Sanity check the other direction: every verb this module already knows is
+    resource-mutating must actually be categorized REFUSE (or GOVERNED, where bosn takes
+    responsibility for the resource itself), never FORWARD.
+    """
+    if spec.verb in _RESOURCE_MUTATING_VERBS:
+        assert spec.category is not Category.FORWARD
+
+
+def test_supported_round_trips_through_json() -> None:
+    payload = supported()
+    text = json.dumps(payload)
+    parsed = json.loads(text)
+    assert parsed == payload
+
+
+def test_supported_has_schema_version() -> None:
+    payload = supported()
+    assert isinstance(payload["schema_version"], int)
+    assert payload["schema_version"] >= 1
+
+
+def test_supported_lists_every_verb_with_category_and_summary() -> None:
+    payload = supported()
+    by_verb = {entry["verb"]: entry for entry in payload["verbs"]}
+    assert set(by_verb) == {spec.verb for spec in VERBS}
+    for spec in VERBS:
+        entry = by_verb[spec.verb]
+        assert entry["category"] == spec.category.value
+        assert entry["summary"] == spec.summary
+        assert entry["remedy"] == spec.remedy
+
+
+def test_supported_refusals_carry_their_remedy() -> None:
+    payload = supported()
+    for entry in payload["verbs"]:
+        if entry["category"] == Category.REFUSE.value:
+            assert entry["remedy"]
+
+
+def test_verbspec_refuse_without_remedy_is_rejected() -> None:
+    with pytest.raises(ValueError, match="remedy"):
+        VerbSpec(verb="bogus", category=Category.REFUSE, summary="no remedy given")
+
+
+def test_governed_and_forward_categories_are_both_represented() -> None:
+    categories = {spec.category for spec in VERBS}
+    assert Category.GOVERNED in categories
+    assert Category.FORWARD in categories
+    assert Category.REFUSE in categories


### PR DESCRIPTION
First slice of #46 — the category table and its introspection surface. Shims, `bosn-compose`, and relocating `bosn init` are later slices.

## The problem

`bosn-docker` advertises a drop-in Docker surface but implemented `init` and `compose {up,down,logs,ps}`, refusing everything else with argparse prose. The advertised surface and the implemented one shared no source of truth, so they could drift silently.

## What lands

`frontdoor.VERBS` is now that source — **42 verbs, 2 governed / 4 forwarded / 36 refused** — and the parser, the refusals, and `bosn-docker --supported --json` all read from it. argparse no longer rejects unregistered verbs, so every verb reaches dispatch and gets a structured answer instead of a parser error.

```
--- unknown verb must never reach the engine ---
  run                    exit=1 engine_spawned=0
  totally-made-up-verb   exit=1 engine_spawned=0
  rm                     exit=1 engine_spawned=0

--- forwarded verb reaches the engine verbatim ---
  version                exit=0 argv=['version', '--format', '{{.Server.Version}}']

--- --supported --json is parseable ---
  schema_version=1 verbs=42
```

## Unknown means refuse, never forward

This is the load-bearing property. Forwarding an unrecognized verb would let `docker run` create unlabeled containers — the accumulation this project exists to prevent. `resolve()` makes it an **explicit REFUSE branch** rather than an implicit lookup miss, and a test asserts the FORWARD set is disjoint from a named set of resource-mutating verbs, so widening it later fails loudly.

Only `version`, `info`, `login`, `logout` forward. `ps`, `logs`, `inspect`, `stats` were considered and **refused instead** — they take raw object names and would quietly encourage bypassing bosn's naming and registry. A missing capability is recoverable; an unmanaged container is not.

Every refusal carries a real remedy rather than the word "unsupported":

```json
{"code": "docker.refused",
 "message": "bosn-docker rm: remove a container",
 "next": "deletes outside lease/GC bookkeeping; use `bosn gc` to reclaim managed resources safely"}
```

## Recursion protection, built before the shim exists

A later slice installs a `docker` shim that **is** `bosn-docker`. If forwarding resolves `docker` off `PATH`, the shim calls itself forever — so adding this guard after the shim ships means shipping a fork bomb.

Two layers: an environment marker set on every forwarded child (catches any hop after the first), and a file-identity comparison of PATH's `docker` against this program (catches the first hop, before any marker exists).

**Stated blind spot:** a shim that is a *distinct file* and also clears its inherited environment defeats both — that requires the shim itself to cooperate.

**Landmine flagged for the shim slice**, documented in `_forward`: `_run_compose` still spawns bare `docker compose` with no guard. It must be routed through the same resolution before any shim ships, or `compose up` becomes an unguarded loop.

## Verification

709 tests pass (179 new in `test_frontdoor.py`, parametrized over the table so a new verb is automatically covered), `ci/lint.py` clean. `compose`/`init` behavior is byte-identical — their mini-parsers were moved verbatim, and their pre-existing tests pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)