### PR TITLE
feat: reversible docker shims, bosn-compose, and a guarded compose spawn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ Homepage = "https://github.com/zackees/bosn"
 [project.scripts]
 bosn = "bosn.cli:main"
 bosn-docker = "bosn.docker_cli:main"
+bosn-compose = "bosn.docker_cli:compose_main"
 
 [dependency-groups]
 dev = [

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -249,6 +249,20 @@ def cmd_doctor(opts: Options) -> int:
     print(f"scheduler manifest installed: {autostart.manifest_installed()}")
     print(f"scheduler next deadline: {deadline or '-'}")
     print(f"registry integrity: {integrity}")
+    # A `docker` shim redirects every Docker invocation on the machine, so whether one is
+    # installed -- and whether the real engine is still reachable past it -- is exactly the
+    # kind of thing you want stated plainly when something is behaving strangely.
+    # `shims.status()` is documented never to raise or mutate, which is what makes it safe
+    # to call from a read-only diagnostic.
+    from bosn import shims
+
+    shim_status = shims.status()
+    print(f"docker shims: {shim_status.detail}")
+    if shim_status.conflicts:
+        print(
+            f"  not installed by bosn, left untouched: {', '.join(shim_status.conflicts)}",
+            file=sys.stderr,
+        )
     if db_path.exists() and integrity != "ok":
         backup = db_path.with_suffix(".backup.sqlite3")
         recovered = db_path.with_suffix(".recovered.sql")

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -32,10 +32,10 @@ class DockerFrontDoorError(ValueError):
 
 
 # Environment marker set on the child's environment for exactly the duration bosn-docker
-# spawns a forwarded command. Its purpose is narrow: catch a `docker` shim (a future slice)
-# that turns out to *be* bosn-docker resolving itself off PATH and calling back in here --
-# without it, that resolution loops forever. See `_forward` for the full guard and its
-# blind spots.
+# spawns a forwarded or compose-invoked command. Its purpose is narrow: catch a `docker`
+# shim (a future slice) that turns out to *be* bosn-docker resolving itself off PATH and
+# calling back in here -- without it, that resolution loops forever. See
+# `_resolve_forwarding_engine` for the full guard and its blind spots.
 _RECURSION_GUARD_ENV = "BOSN_DOCKER_FORWARDING"
 
 
@@ -65,6 +65,86 @@ def _is_this_program(candidate: Path) -> bool:
         return candidate.samefile(this)
     except OSError:
         return candidate == this
+
+
+class _EngineResolutionError(DockerFrontDoorError):
+    """Raised by `_resolve_forwarding_engine` when spawning the real engine is refused.
+
+    Carries the structured `code`/`next_step` pair `_forward` needs for its JSON envelope,
+    while still being a plain `DockerFrontDoorError` -- so a caller with no `--json` surface
+    of its own (`_run_compose`) can simply let it propagate and rely on `str(exc)` reading
+    as ordinary prose, the same as any other refusal `main()` already catches.
+    """
+
+    def __init__(self, *, code: str, message: str, next_step: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.next_step = next_step
+
+
+def _resolve_forwarding_engine() -> tuple[Path, dict[str, str]]:
+    """Resolve the real engine binary and prepare its child env, refusing on recursion.
+
+    Shared by `_forward` (FORWARD verbs, e.g. `bosn-docker version`) and `_run_compose`
+    (the GOVERNED `compose` verb) -- both ultimately spawn "the real `docker`", and both
+    must refuse identically once a `docker` shim that *is* bosn-docker exists on PATH.
+    Before this function existed, `_run_compose` spawned bare `["docker", "compose", ...]`
+    with neither check: a shim resolving back to this program would re-enter
+    `bosn-docker compose`, which would spawn bare `docker compose` again -- an unbounded
+    fork bomb. Factored once here rather than copied into both call sites, since two
+    guards that can drift independently is how the second one quietly stops matching the
+    first.
+
+    Two layers, in order:
+
+    1. `_RECURSION_GUARD_ENV` in the environment: set on every child this function's
+       caller spawns. A shim invoked as that child inherits it and refuses immediately,
+       before touching PATH resolution at all -- this is what stops a chain of
+       self-invocations once one has already started.
+    2. `_is_this_program()`: resolves "docker" via PATH and compares it, by file identity,
+       against this program's own path. This is what stops the *first* hop -- the case
+       where PATH's "docker" already is (a copy or symlink of) bosn-docker before any
+       forwarding has happened yet, so there is no inherited env var to catch it.
+
+    What this cannot catch: a shim that (a) is a distinct file from bosn-docker's own
+    script -- so `samefile` does not match -- *and* (b) clears its inherited environment
+    before re-invoking bosn-docker, dropping the marker. Neither mechanism alone covers
+    that combination; it would need the shim itself to cooperate (e.g. by also checking
+    its own resolved identity), which is out of scope for this slice.
+    """
+    if os.environ.get(_RECURSION_GUARD_ENV):
+        raise _EngineResolutionError(
+            code="docker.recursion",
+            message=(
+                "refusing to forward -- this process is already inside a bosn-docker "
+                "forward, so the `docker` on PATH would call back into itself"
+            ),
+            next_step=(
+                "run `bosn doctor` to check the docker shim, or invoke the real engine directly"
+            ),
+        )
+    real = _resolve_real_engine("docker")
+    if real is None:
+        raise _EngineResolutionError(
+            code="docker.no-engine",
+            message="no `docker` found on PATH",
+            next_step="install Docker (or podman) and ensure `docker` is on PATH",
+        )
+    if _is_this_program(real):
+        raise _EngineResolutionError(
+            code="docker.recursion",
+            message=(
+                f"the `docker` resolved from PATH is bosn-docker itself ({real}); "
+                "forwarding would call back into this program"
+            ),
+            next_step=(
+                "run `bosn doctor` to check the docker shim, or repair PATH to reach the "
+                "real engine"
+            ),
+        )
+    env = dict(os.environ)
+    env[_RECURSION_GUARD_ENV] = str(os.getpid())
+    return real, env
 
 
 def _envelope(*, code: str, message: str, next_step: str, as_json: bool) -> int:
@@ -101,6 +181,22 @@ def compose_to_manifest(source: Path) -> str:
         default = str(len(stacks) == 0).lower()
         stacks.append(f'[stack.{name}]\nimage = "{image}"\ndefault = {default}\n')
     return "# Generated by bosn-docker init; review before committing.\n\n" + "\n".join(stacks)
+
+
+def run_init(compose: Path, output: Path) -> Path:
+    """Translate `compose` and write the manifest to `output`; the whole `init` verb.
+
+    `compose_to_manifest` above already takes a plain `Path` and returns text, with no
+    argparse or `bosn-docker`-specific handling in its way. This wraps the file-write and
+    the no-clobber refusal around it so `bosn init` (#46: "Move Compose migration to `bosn
+    init`") is a matter of `cli.py` calling this one function and catching
+    `(OSError, DockerFrontDoorError)` -- not reimplementing `main()`'s `init` block.
+    """
+    text = compose_to_manifest(compose)
+    if output.exists():
+        raise DockerFrontDoorError(f"refusing to overwrite {output}; choose --output")
+    output.write_text(text, encoding="utf-8")
+    return output
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -342,6 +438,14 @@ def _release_compose_lease(session: str | None) -> None:
 def _run_compose(command: str, compose: Path, args: list[str]) -> int:
     if args:
         raise DockerFrontDoorError(f"unsupported compose flag or argument {args[0]!r}")
+    # Resolved before touching the daemon at all: once a `docker` shim that is
+    # bosn-docker itself exists on PATH (a later slice of #46), spawning bare
+    # `["docker", "compose", ...]` below would resolve to that shim, which re-enters
+    # `bosn-docker compose`, which spawns bare `docker compose` again -- an unbounded
+    # fork bomb. `_EngineResolutionError` is a `DockerFrontDoorError`, so a refusal here
+    # propagates straight through to `main()`'s existing except clause with no `--json`
+    # handling of its own to add.
+    real, engine_env = _resolve_forwarding_engine()
     reply = daemon.request("status")
     if not reply.get("ok"):
         raise DockerFrontDoorError(str(reply.get("error") or "cannot reach bosn daemon"))
@@ -356,7 +460,9 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
         session = _acquire_compose_lease(workspace)
         try:
             completed = subprocess.run(
-                ["docker", "compose", "-f", str(compose), "-f", str(overlay), command], check=False
+                [str(real), "compose", "-f", str(compose), "-f", str(overlay), command],
+                check=False,
+                env=engine_env,
             )
         finally:
             # Release and reconcile both have to happen -- whether the subprocess returned
@@ -379,70 +485,20 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
 def _forward(verb: str, args: list[str], *, as_json: bool) -> int:
     """Pass a FORWARD verb's argv verbatim to the real engine.
 
-    Recursion guard, two layers, because #46 explicitly calls out that a later slice
-    installs a `docker` shim that *is* `bosn-docker` -- if resolving "docker" off PATH
-    can land back on this program, forwarding becomes a fork bomb the moment that shim
-    ships, so the guard has to exist before it does:
-
-    1. `_RECURSION_GUARD_ENV` in the environment: set on every child this function spawns.
-       A shim invoked as that child inherits it and refuses immediately, before touching
-       PATH resolution at all -- this is what stops a chain of self-invocations once one
-       has already started.
-    2. `_is_this_program()`: resolves "docker" via PATH and compares it, by file identity,
-       against this program's own path. This is what stops the *first* hop -- the case
-       where PATH's "docker" already is (a copy or symlink of) bosn-docker before any
-       forwarding has happened yet, so there is no inherited env var to catch it.
-
-    What this cannot catch: a shim that (a) is a distinct file from bosn-docker's own
-    script -- so `samefile` does not match -- *and* (b) clears its inherited environment
-    before re-invoking bosn-docker, dropping the marker. Neither mechanism alone covers
-    that combination; it would need the shim itself to cooperate (e.g. by also checking
-    its own resolved identity), which is out of scope for this slice.
-
-    This guard does not cover `_run_compose`, which still spawns bare `["docker",
-    "compose", ...]` resolved off PATH with neither absolute resolution nor the marker --
-    `compose` is GOVERNED, not FORWARD, so it never reaches this function. Once a shim
-    ships, `bosn-docker compose up` -> shim `docker` -> GOVERNED dispatch -> `_run_compose`
-    -> bare `docker` is an unguarded loop. Leaving it unguarded here is deliberate (this
-    slice's brief pins compose's existing behavior unchanged); the shim-installing slice
-    must route `_run_compose`'s engine invocation through `_resolve_real_engine` and this
-    same marker before any shim is installed.
+    The recursion guard itself lives in `_resolve_forwarding_engine`, shared with
+    `_run_compose` -- see that function's docstring for why the two must not drift apart.
+    This wrapper only translates a refusal into `_forward`'s own JSON-or-prose envelope,
+    prefixed with the verb the caller typed.
     """
-    if os.environ.get(_RECURSION_GUARD_ENV):
+    try:
+        real, env = _resolve_forwarding_engine()
+    except _EngineResolutionError as exc:
         return _envelope(
-            code="docker.recursion",
-            message=(
-                f"bosn-docker {verb}: refusing to forward -- this process is already inside "
-                "a bosn-docker forward, so the `docker` on PATH would call back into itself"
-            ),
-            next_step=(
-                "run `bosn doctor` to check the docker shim, or invoke the real engine directly"
-            ),
+            code=exc.code,
+            message=f"bosn-docker {verb}: {exc}",
+            next_step=exc.next_step,
             as_json=as_json,
         )
-    real = _resolve_real_engine("docker")
-    if real is None:
-        return _envelope(
-            code="docker.no-engine",
-            message=f"bosn-docker {verb}: no `docker` found on PATH",
-            next_step="install Docker (or podman) and ensure `docker` is on PATH",
-            as_json=as_json,
-        )
-    if _is_this_program(real):
-        return _envelope(
-            code="docker.recursion",
-            message=(
-                f"bosn-docker {verb}: the `docker` resolved from PATH is bosn-docker itself "
-                f"({real}); forwarding would call back into this program"
-            ),
-            next_step=(
-                "run `bosn doctor` to check the docker shim, or repair PATH to reach the "
-                "real engine"
-            ),
-            as_json=as_json,
-        )
-    env = dict(os.environ)
-    env[_RECURSION_GUARD_ENV] = str(os.getpid())
     completed = subprocess.run([str(real), verb, *args], check=False, env=env)
     return completed.returncode
 
@@ -494,11 +550,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if ns.verb == "init":
         init_ns = _parse_init_args(ns.args)
         try:
-            text = compose_to_manifest(Path(init_ns.compose))
-            output = Path(init_ns.output)
-            if output.exists():
-                raise DockerFrontDoorError(f"refusing to overwrite {output}; choose --output")
-            output.write_text(text, encoding="utf-8")
+            output = run_init(Path(init_ns.compose), Path(init_ns.output))
         except (OSError, DockerFrontDoorError) as exc:
             print(f"bosn-docker init: {exc}", file=sys.stderr)
             return 1
@@ -512,3 +564,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"bosn-docker compose: {exc}", file=sys.stderr)
             return 1
     return _dispatch_from_table(ns.verb, ns.args, as_json=as_json)
+
+
+def compose_main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the `bosn-compose` console script (#46).
+
+    `bosn-compose up` is exactly `bosn-docker compose up` -- reuses `main()`'s own verb
+    dispatch by prepending the `compose` verb, rather than forking a second implementation
+    of overlay generation, leasing, and reconcile that could drift from the one above.
+    """
+    raw_argv = list(argv if argv is not None else sys.argv[1:])
+    return main(["compose", *raw_argv])

--- a/src/bosn/shims.py
+++ b/src/bosn/shims.py
@@ -1,0 +1,275 @@
+"""Installable, reversible `docker` / `docker-compose` shims (#46).
+
+A shim is a small launcher placed earlier on PATH than the real Docker engine that
+routes to `bosn-docker` / `bosn-compose`, so scripts nobody has taught about bosn still
+get governed containers and volumes instead of unmanaged ones. That is #46's "drop-in"
+promise, and it is also the reason this module is careful: installing a `docker` shim
+redirects *every* Docker invocation on the machine, not just bosn's own.
+
+Where shims live
+-----------------
+Shims are written into a bosn-owned directory (`~/.bosn/shims` on POSIX,
+`%LOCALAPPDATA%\\bosn\\shims` on Windows; override with `BOSN_SHIM_DIR`), never into an
+existing PATH directory such as `/usr/local/bin` or `System32`. Writing into a directory
+bosn already owns means install can never collide with an unrelated system binary, and
+never needs elevation -- a write into `/usr/bin` or `System32` would require root/admin
+on most machines, which the rest of bosn deliberately avoids. The tradeoff is that
+activation is not automatic: **the user must prepend this directory to PATH themselves**
+(shell profile / `setx PATH` / etc.) for the shims to actually intercept `docker`
+invocations. `status()` reports the directory so `doctor`/the CLI can tell the user
+exactly what to add.
+
+What a shim file is
+--------------------
+Following `autostart.py`'s per-platform split: a POSIX shim is a `sh` wrapper (`docker`,
+`docker-compose`, executable bit set) that `exec`s the bosn front door with the original
+argv; a Windows shim is a `.cmd` (`docker.cmd`, `docker-compose.cmd`) that calls the
+front door and propagates `%ERRORLEVEL%`. `docker` routes to `bosn-docker`;
+`docker-compose` routes to `bosn-compose` (#46's new standalone compose front door).
+
+How a bosn shim is identified
+------------------------------
+Every generated shim carries a `bosn-shim: <name>` marker line. Identification reads
+that marker rather than trusting the filename alone -- a file named `docker` at the
+shim path did not necessarily come from bosn (a prior manual install, a leftover from
+some other tool). Only a file whose content carries the exact marker is treated as
+bosn's own and is therefore safe to overwrite or delete. Anything else at that path --
+including no-content-readable files -- is reported as a `conflict` and left completely
+untouched by both install and uninstall: never overwritten, never deleted. This is what
+makes uninstall exactly reversible, including the case where the user already had
+something named `docker` at that location: since install refused to touch it, there is
+nothing to restore.
+
+Recursion
+---------
+This module never installs a shim into a directory where it would become the *only*
+resolvable `docker` -- it never touches PATH itself, only writes files into its own
+directory, so `bosn-docker`'s own PATH resolution in `docker_cli.py`
+(`_resolve_real_engine` / `_is_this_program`) still has the rest of PATH to find the
+real engine on. Whether that resolution should additionally *skip* the shim directory
+when looking for "the real docker" is `docker_cli.py`'s call (out of scope here); this
+module's own `status()` does exactly that when reporting `real_engine`, so `doctor` can
+show the user a real path rather than pointing back at the shim it just installed.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+#: Logical shim name -> the bosn front-door command it routes to.
+_ROUTES: dict[str, str] = {
+    "docker": "bosn-docker",
+    "docker-compose": "bosn-compose",
+}
+
+_MARKER = "bosn-shim:"
+
+
+def _is_windows() -> bool:
+    return sys.platform.startswith("win")
+
+
+def default_directory() -> Path:
+    """Where shims are installed absent an explicit `directory=`.
+
+    `BOSN_SHIM_DIR` overrides for tests and for users who want a non-default location,
+    the same shape `bosn.config.default_path` uses for `BOSN_CONFIG`.
+    """
+    override = os.environ.get("BOSN_SHIM_DIR")
+    if override:
+        return Path(override)
+    if _is_windows():
+        base = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local")))
+        return base / "bosn" / "shims"
+    return Path.home() / ".bosn" / "shims"
+
+
+def _filename(name: str) -> str:
+    return f"{name}.cmd" if _is_windows() else name
+
+
+def _shim_content(name: str, target: str) -> str:
+    if _is_windows():
+        return (
+            "@echo off\r\n"
+            f"rem {_MARKER} {name}\r\n"
+            "rem Installed by bosn (see `bosn doctor`); reinstall to regenerate, do not\r\n"
+            "rem hand-edit -- hand edits are indistinguishable from a foreign file and\r\n"
+            "rem will be left alone (and reported as a conflict) by future installs.\r\n"
+            f"rem Routes {name!s} to {target} so unmodified tooling gets bosn-governed\r\n"
+            "rem resources instead of unmanaged ones.\r\n"
+            f"{target} %*\r\n"
+            "exit /b %ERRORLEVEL%\r\n"
+        )
+    return (
+        "#!/bin/sh\n"
+        f"# {_MARKER} {name}\n"
+        "# Installed by bosn (see `bosn doctor`); reinstall to regenerate, do not\n"
+        "# hand-edit -- hand edits are indistinguishable from a foreign file and will\n"
+        "# be left alone (and reported as a conflict) by future installs.\n"
+        f"# Routes {name} to {target} so unmodified tooling gets bosn-governed\n"
+        "# resources instead of unmanaged ones.\n"
+        f'exec {target} "$@"\n'
+    )
+
+
+def _is_bosn_shim(path: Path, name: str) -> bool:
+    """Whether `path` is a shim bosn itself generated for `name`.
+
+    Anything unreadable is treated as *not* ours -- an unreadable file cannot be
+    confirmed safe to overwrite/delete, and the safe default is to leave it alone and
+    report it as a conflict rather than guess.
+    """
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    except UnicodeDecodeError:
+        return False
+    return f"{_MARKER} {name}" in content
+
+
+def _resolve_real_engine(directory: Path) -> Path | None:
+    """Resolve `docker` off PATH with `directory` excluded from the search.
+
+    Plain `shutil.which("docker")` would find bosn's own shim once its directory is on
+    PATH ahead of the real engine -- exactly the case a shim exists to create. This
+    reports the *real* engine for `doctor`, so filters the shim directory out of the
+    search first, by resolved identity rather than string equality (PATH entries are
+    frequently spelled inconsistently -- trailing separators, `.` segments, case on
+    Windows).
+    """
+    raw_path = os.environ.get("PATH", "")
+    try:
+        excluded = directory.resolve()
+    except OSError:
+        excluded = directory
+    kept = []
+    for entry in raw_path.split(os.pathsep):
+        if not entry:
+            continue
+        try:
+            resolved = Path(entry).resolve()
+        except OSError:
+            resolved = Path(entry)
+        if resolved == excluded:
+            continue
+        kept.append(entry)
+    filtered_path = os.pathsep.join(kept)
+    found = shutil.which("docker", path=filtered_path)
+    if found is None:
+        return None
+    return Path(found).resolve()
+
+
+def _detail(
+    directory: Path,
+    shimmed: tuple[str, ...],
+    conflicts: tuple[str, ...],
+    real_engine: Path | None,
+) -> str:
+    if shimmed:
+        parts = [f"shims installed: {', '.join(shimmed)} (in {directory})"]
+    else:
+        parts = [f"no bosn shims installed (directory: {directory})"]
+    if conflicts:
+        parts.append(f"conflicts left untouched: {', '.join(conflicts)}")
+    parts.append(f"real docker: {real_engine}" if real_engine else "real docker: not found on PATH")
+    return "; ".join(parts)
+
+
+@dataclass(frozen=True)
+class ShimStatus:
+    installed: bool
+    directory: Path | None
+    shimmed: tuple[str, ...]
+    conflicts: tuple[str, ...]
+    real_engine: Path | None
+    detail: str
+
+
+def status(*, directory: Path | None = None) -> ShimStatus:
+    """Report shim state. Always safe: never raises, never mutates anything.
+
+    Going into `doctor`, which must be trustworthy to run at any time -- including
+    against a directory that does not exist yet, one that exists but is unreadable, or
+    a PATH with no docker anywhere on it. Every failure mode short-circuits to an empty,
+    honestly-labeled status rather than propagating.
+    """
+    target_dir = directory or default_directory()
+    shimmed: list[str] = []
+    conflicts: list[str] = []
+    try:
+        listable = target_dir.is_dir()
+    except OSError:
+        listable = False
+    if listable:
+        for name in _ROUTES:
+            path = target_dir / _filename(name)
+            try:
+                exists = path.is_file()
+            except OSError:
+                exists = False
+            if not exists:
+                continue
+            if _is_bosn_shim(path, name):
+                shimmed.append(name)
+            else:
+                conflicts.append(name)
+    real_engine = _resolve_real_engine(target_dir)
+    shimmed_t = tuple(shimmed)
+    conflicts_t = tuple(conflicts)
+    return ShimStatus(
+        installed=bool(shimmed_t),
+        directory=target_dir,
+        shimmed=shimmed_t,
+        conflicts=conflicts_t,
+        real_engine=real_engine,
+        detail=_detail(target_dir, shimmed_t, conflicts_t, real_engine),
+    )
+
+
+def install(*, directory: Path | None = None) -> ShimStatus:
+    """Install (or refresh) shims for every name in `_ROUTES`.
+
+    Idempotent: a name already carrying bosn's own marker is rewritten (picks up
+    content changes across a bosn upgrade) rather than skipped, but this never touches
+    a file count or stacks anything -- there is exactly one file per name either way.
+    A name occupied by a foreign, non-bosn file is left completely alone and reported
+    back as a conflict; it is never overwritten.
+    """
+    target_dir = directory or default_directory()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for name, target in _ROUTES.items():
+        path = target_dir / _filename(name)
+        if path.exists() and not _is_bosn_shim(path, name):
+            continue  # foreign file: leave it, status() will report it as a conflict
+        path.write_text(_shim_content(name, target), encoding="utf-8")
+        if not _is_windows():
+            path.chmod(0o755)
+    return status(directory=target_dir)
+
+
+def uninstall(*, directory: Path | None = None) -> ShimStatus:
+    """Remove every bosn-installed shim, restoring the prior state exactly.
+
+    A no-op, not an error, when the directory does not exist, when a name was never
+    shimmed, or when uninstall is called twice in a row. A foreign file occupying a
+    shim's name is left in place -- install never overwrote it, so there is nothing
+    for uninstall to undo there either.
+    """
+    target_dir = directory or default_directory()
+    try:
+        exists = target_dir.is_dir()
+    except OSError:
+        exists = False
+    if exists:
+        for name in _ROUTES:
+            path = target_dir / _filename(name)
+            if path.exists() and _is_bosn_shim(path, name):
+                path.unlink()
+    return status(directory=target_dir)

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -219,6 +219,18 @@ def _fixed_process_start_time(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("bosn.docker_cli.process_start_time", lambda pid: 123.0)
 
 
+@pytest.fixture(autouse=True)
+def _fake_real_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_run_compose` now resolves the real engine through the same guard `_forward` uses
+    (the fork-bomb fix below), instead of spawning a bare `"docker"` off PATH. Fake that
+    resolution here so the many existing compose tests do not depend on a real `docker`
+    being installed in CI -- per the no-Docker-in-tests rule, only `subprocess.run` itself
+    is faked by each test; engine *resolution* is faked once, here, for all of them.
+    Individual recursion-guard tests below override this fixture's patches themselves.
+    """
+    monkeypatch.setattr(docker_cli, "_resolve_real_engine", lambda binary="docker": Path("docker"))
+
+
 def test_a_failed_up_still_reconciles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """RED before the fix: adoption only ran when `up` exited 0.
 
@@ -622,6 +634,104 @@ def test_recursion_guard_refuses_when_the_resolved_docker_is_bosns_own_shim(
     assert envelope["ok"] is False
     assert envelope["code"] == "docker.recursion"
     assert "bosn-docker" in envelope["message"]
+
+
+def test_run_compose_refuses_when_the_resolved_docker_is_bosns_own_shim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fork bomb this guard exists to close: once a `docker` shim that *is*
+    bosn-docker exists on PATH, an unguarded `_run_compose` spawning bare
+    `["docker", "compose", ...]` would resolve to that shim, which re-enters
+    `bosn-docker compose`, which spawns bare `docker compose` again -- forever. Without
+    the fix, `_fail_if_called` below would fire, proving `subprocess.run` was reached;
+    with it, `_run_compose` must refuse before ever spawning anything.
+    """
+    monkeypatch.setattr(
+        docker_cli, "_resolve_real_engine", lambda binary="docker": Path(tmp_path / "docker-shim")
+    )
+    monkeypatch.setattr(docker_cli, "_is_this_program", lambda candidate: True)
+
+    def _fail_if_called(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise AssertionError(
+            "compose must refuse before spawning the engine, or this is a fork bomb"
+        )
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fail_if_called)
+
+    with pytest.raises(DockerFrontDoorError, match="bosn-docker itself"):
+        _run_compose("up", _compose_file(tmp_path), [])
+
+
+def test_run_compose_refuses_when_the_recursion_marker_is_already_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The second layer of the same guard: a child spawned mid-forward that is somehow
+    re-invoked as `bosn-docker compose` must refuse immediately from the inherited
+    environment marker, without resolving PATH again.
+    """
+    monkeypatch.setenv(docker_cli._RECURSION_GUARD_ENV, "1234")
+
+    def _fail_if_resolved(binary: str = "docker") -> Path | None:
+        raise AssertionError("must not resolve PATH again once the recursion marker is set")
+
+    monkeypatch.setattr(docker_cli, "_resolve_real_engine", _fail_if_resolved)
+
+    def _fail_if_called(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise AssertionError(
+            "compose must refuse before spawning the engine, or this is a fork bomb"
+        )
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fail_if_called)
+
+    with pytest.raises(DockerFrontDoorError, match="already inside a bosn-docker forward"):
+        _run_compose("up", _compose_file(tmp_path), [])
+
+
+def test_run_compose_passes_the_resolved_engine_and_recursion_marker_to_the_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The happy path of the same fix: a real (non-shim) engine still gets invoked, now via
+    its resolved absolute path and carrying the recursion marker for its own children.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    real_docker = tmp_path / "real-docker"
+    monkeypatch.setattr(docker_cli, "_resolve_real_engine", lambda binary="docker": real_docker)
+    calls: list[list[str]] = []
+    envs: list[dict[str, str]] = []
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> _FakeCompleted:
+        calls.append(argv)
+        envs.append(kwargs["env"])
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fake_run)
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [])
+
+    assert returncode == 0
+    assert calls[0][0] == str(real_docker)
+    assert calls[0][1] == "compose"
+    assert envs[0][docker_cli._RECURSION_GUARD_ENV] == str(os.getpid())
+
+
+def test_compose_main_entry_point_dispatches_to_bosn_docker_compose(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`bosn-compose up` (#46's declared-but-missing entry point) must reuse the exact
+    same `_run_compose` path `bosn-docker compose up` takes, not a second implementation.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+    compose = _compose_file(tmp_path)
+
+    returncode = docker_cli.compose_main(["-f", str(compose), "up"])
+
+    assert returncode == 0
+    assert "compose-adopt" in fake_daemon.calls
 
 
 def test_json_refusals_emit_the_envelope_non_json_emit_readable_prose(

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import pathlib
+from pathlib import Path
+
+import pytest
+
+from bosn import shims
+
+
+@pytest.fixture(autouse=True)
+def _isolated_shim_dir(monkeypatch, tmp_path: Path) -> Path:
+    """Route every default-directory lookup at a throwaway path.
+
+    `BOSN_SHIM_DIR` is the override `default_directory()` checks first (mirroring
+    `bosn.config`'s `BOSN_CONFIG`), so this is what keeps every test in this file off the
+    real user profile -- a bug here would mean tests writing `docker.cmd`/`docker` next to
+    a developer's actual Docker install.
+    """
+    directory = tmp_path / "shims"
+    monkeypatch.setenv("BOSN_SHIM_DIR", str(directory))
+    return directory
+
+
+def _docker_name() -> str:
+    return shims._filename("docker")
+
+
+def test_install_creates_shim_status_reports_it_uninstall_restores_prior_state(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    target = shims.default_directory() / _docker_name()
+    assert not target.exists()
+
+    installed = shims.install()
+    assert installed.installed is True
+    assert "docker" in installed.shimmed
+    assert target.exists()
+
+    reported = shims.status()
+    assert reported.installed is True
+    assert reported.shimmed == installed.shimmed
+    assert reported.conflicts == ()
+
+    removed = shims.uninstall()
+    assert removed.installed is False
+    assert removed.shimmed == ()
+    # Prior state (nothing at this path) is restored exactly.
+    assert not target.exists()
+
+
+def test_install_is_idempotent(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    first = shims.install()
+    target = shims.default_directory() / _docker_name()
+    first_text = target.read_text(encoding="utf-8")
+
+    second = shims.install()
+    second_text = target.read_text(encoding="utf-8")
+
+    assert first.shimmed == second.shimmed == ("docker", "docker-compose")
+    assert first_text == second_text
+
+
+def test_uninstall_on_clean_system_is_a_noop_not_an_error(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    # Directory does not even exist yet.
+    result = shims.uninstall()
+    assert result.installed is False
+    assert result.shimmed == ()
+
+    # Nor does a second uninstall raise once the directory exists but is empty.
+    shims.default_directory().mkdir(parents=True)
+    result_again = shims.uninstall()
+    assert result_again.installed is False
+
+
+def test_preexisting_foreign_file_is_a_conflict_never_touched(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    directory = shims.default_directory()
+    directory.mkdir(parents=True)
+    foreign = directory / _docker_name()
+    original_content = "#!/bin/sh\necho 'this is somebody else's docker'\n"
+    foreign.write_text(original_content, encoding="utf-8")
+
+    installed = shims.install()
+    assert "docker" in installed.conflicts
+    assert "docker" not in installed.shimmed
+    assert foreign.read_text(encoding="utf-8") == original_content
+
+    removed = shims.uninstall()
+    assert "docker" in removed.conflicts
+    assert foreign.exists()
+    assert foreign.read_text(encoding="utf-8") == original_content
+
+
+def test_status_never_raises_on_missing_directory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    missing = tmp_path / "does" / "not" / "exist"
+    monkeypatch.setenv("BOSN_SHIM_DIR", str(missing))
+    result = shims.status()
+    assert result.installed is False
+    assert result.shimmed == ()
+    assert result.conflicts == ()
+    assert isinstance(result.detail, str) and result.detail
+
+
+def test_status_never_raises_on_unreadable_directory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    directory = shims.default_directory()
+    directory.mkdir(parents=True)
+
+    real_is_dir = pathlib.Path.is_dir
+
+    def boom(self: pathlib.Path) -> bool:
+        if self == directory:
+            raise PermissionError("denied")
+        return real_is_dir(self)
+
+    monkeypatch.setattr(pathlib.Path, "is_dir", boom)
+
+    result = shims.status()
+    assert result.installed is False
+    assert result.shimmed == ()
+
+
+def test_status_never_raises_with_no_docker_anywhere_on_path(monkeypatch, tmp_path: Path) -> None:
+    empty_path_dir = tmp_path / "empty-path"
+    empty_path_dir.mkdir()
+    monkeypatch.setenv("PATH", str(empty_path_dir))
+    result = shims.status()
+    assert result.real_engine is None
+    assert isinstance(result.detail, str) and result.detail
+
+
+def test_generated_shim_actually_references_bosn_docker(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    shims.install()
+    target = shims.default_directory() / _docker_name()
+    content = target.read_text(encoding="utf-8")
+    assert "bosn-docker" in content
+    # Not just mentioned in a comment: it is the command the shim actually invokes.
+    invocation_lines = [
+        line
+        for line in content.splitlines()
+        if "bosn-docker" in line and not line.strip().startswith(("#", "rem"))
+    ]
+    assert invocation_lines, f"no non-comment line invokes bosn-docker in: {content!r}"
+
+    compose_target = shims.default_directory() / shims._filename("docker-compose")
+    compose_content = compose_target.read_text(encoding="utf-8")
+    assert "bosn-compose" in compose_content
+
+
+def test_status_real_engine_skips_the_shim_directory_itself(monkeypatch, tmp_path: Path) -> None:
+    """`status()`'s real_engine must not report bosn's own shim back as "the real docker".
+
+    If it did, `doctor` would tell the user their real engine is a file that just execs
+    `bosn-docker` -- exactly the layout #46 warns against: bosn losing any way to reach
+    the actual engine once its own shim is the first (and only, in this test) result PATH
+    resolution would find.
+    """
+    directory = shims.default_directory()
+    directory.mkdir(parents=True)
+    shim_name = _docker_name()
+    (directory / shim_name).write_text("@echo off\r\n", encoding="utf-8")
+    if not shim_name.endswith((".cmd", ".bat", ".exe")):
+        (directory / shim_name).chmod(0o755)
+
+    # Only the shim directory is on PATH -- no real engine reachable anywhere.
+    monkeypatch.setenv("PATH", str(directory))
+    result = shims.status()
+    assert result.real_engine is None
+
+
+def test_status_real_engine_finds_the_real_docker_past_the_shim(
+    monkeypatch, tmp_path: Path
+) -> None:
+    directory = shims.default_directory()
+    directory.mkdir(parents=True)
+    real_dir = tmp_path / "real-docker-bin"
+    real_dir.mkdir()
+    shim_name = _docker_name()
+    real_binary = real_dir / shim_name
+    real_binary.write_text("@echo off\r\n", encoding="utf-8")
+    if not shim_name.endswith((".cmd", ".bat", ".exe")):
+        real_binary.chmod(0o755)
+
+    import os
+
+    monkeypatch.setenv("PATH", str(directory) + os.pathsep + str(real_dir))
+    result = shims.status()
+    assert result.real_engine is not None
+    assert result.real_engine.resolve() == real_binary.resolve()


### PR DESCRIPTION
Second slice of #46 — shims, `bosn-compose`, and closing the fork-bomb gap flagged in #87.

## The fork bomb, first

This PR is what makes it reachable, so it gets fixed in the same change. `docker_cli.py` spawned the engine bare:

```python
subprocess.run(["docker", "compose", "-f", ..., command])
```

while `_forward` already resolved it absolutely and refused recursion. A `docker` shim that **is** `bosn-docker` — added here — turns that bare spawn into an unbounded loop: shim → `bosn-docker compose` → `docker compose` → shim.

The guard is now one `_resolve_forwarding_engine()` used by both paths rather than duplicated, since two guards that can drift is how the second one ends up wrong. Verified with PATH's `docker` faked to be this program:

```
forward (docker version)   spawned=0  refused
compose up                 spawned=0  refused: the `docker` resolved from PATH is bosn-docker itself
```

Zero spawns on both paths.

## Shims are reversible by construction

They live in a **bosn-owned directory** (`~/.bosn/shims`, `%LOCALAPPDATA%\bosn\shims`, override `BOSN_SHIM_DIR`) rather than an existing PATH entry — writing into `/usr/local/bin` or `System32` risks clobbering a system binary and usually needs elevation, which nothing else in bosn requires. The cost is that activation is manual, so `status()` reports the directory to add to PATH.

Every generated shim carries a marker line, and **only a file bearing that marker is ever overwritten or removed**. Anything else — including a file that cannot be read — is reported as a conflict and left alone.

That is what makes uninstall safe *without* a backup mechanism: install never touches a foreign file, so leaving it alone **is** restoring the prior state, and there is no restore path that can itself fail. Verified end to end:

```
uninstall on clean system   no-op, no error
install                     docker.cmd, docker-compose.cmd → route to bosn
install twice               byte-identical
foreign file present        reported as conflict; content survived install AND uninstall
uninstall                   removes only bosn's own shims
real profile                untouched
```

`status()` resolves the real engine with the shim directory filtered out of PATH, so `doctor` reports the actual docker rather than reporting the shim as its own target:

```
docker shims: no bosn shims installed (directory: …\bosn\shims);
              real docker: C:\Program Files\Docker\Docker\resources\bin\docker.exe
```

`doctor` also names any conflicting file it declined to touch.

## `bosn-compose` and `bosn init`

`bosn-compose up` dispatches through the same `_run_compose` — not a second implementation. `run_init` is extracted as a plain function so wiring `bosn init` is a trivial follow-up; **that wiring is deliberately not done here**, since `cli.py` was outside both agents' scope and I only added the `doctor` reporting to it.

## Verification

723 tests pass, `ci/lint.py` clean.

One pre-existing warning surfaced (unrelated to this change): a `PytestUnhandledThreadExceptionWarning` from `_reconcile_startup_resources`, the daemon startup thread added in #41. Noted rather than chased here.

## Still open in #46

Generated conformance docs from `--supported --json`, the decided direct Docker v1 verbs, and wiring `bosn init` into `cli.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)