### PR TITLE
feat: accept the decided compose flag subset

### DIFF
--- a/ci/gen_docker_support.py
+++ b/ci/gen_docker_support.py
@@ -89,7 +89,68 @@ def render() -> str:
                 lines.append(f"| `{entry['verb']}` | {entry['summary']} |")
         lines.append("")
 
+    lines += _render_compose_flags(payload["compose"])
+
     return "\n".join(lines) + "\n"
+
+
+def _render_flag_table(flags: list[dict]) -> list[str]:
+    """One flag table, accepted and refused rows together -- `Status`/`Remedy` columns
+    make the refused rows self-explanatory without a second table per command.
+    """
+    lines = ["| Flag | Aliases | Takes value | Status | Summary | Remedy |"]
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for entry in flags:
+        aliases = ", ".join(f"`{alias}`" for alias in entry["aliases"]) or "--"
+        takes_value = "yes" if entry["takes_value"] else "no"
+        remedy = entry["remedy"] or "--"
+        lines.append(
+            f"| `{entry['flag']}` | {aliases} | {takes_value} | {entry['status']} | "
+            f"{entry['summary']} | {remedy} |"
+        )
+    return lines
+
+
+def _render_compose_flags(compose: dict) -> list[str]:
+    """Render the `compose` verb's flag surface (#47): its sub-verb list, the flags shared
+    across every sub-verb, and each sub-verb's own accepted/refused flags.
+
+    A pure function of `frontdoor.supported()`'s `"compose"` key, same discipline
+    `render()` holds itself to for the verb table above -- nothing typed here that isn't
+    already in the payload.
+    """
+    lines: list[str] = []
+    lines.append("## Compose flags")
+    lines.append("")
+    lines.append(
+        "The `compose` verb's own sub-verb and flag surface (#47). A flag not listed as "
+        "`accepted` for a sub-verb -- including one this table has never heard of -- is "
+        "refused, named, with a remedy; see `bosn.frontdoor.resolve_compose_flag`."
+    )
+    lines.append("")
+    lines.append("Sub-verbs: " + ", ".join(f"`{command}`" for command in compose["commands"]))
+    lines.append("")
+    lines.append("### Global flags")
+    lines.append("")
+    lines.append(
+        "Apply to every sub-verb identically; parsed ahead of the sub-verb "
+        "(`bosn-docker compose -f compose.yaml up`)."
+    )
+    lines.append("")
+    lines += _render_flag_table(compose["global_flags"])
+    lines.append("")
+    for command in compose["commands"]:
+        lines.append(f"### `compose {command}`")
+        lines.append("")
+        flags = compose["flags"][command]
+        if flags:
+            lines += _render_flag_table(flags)
+        else:
+            lines.append(
+                "No sub-verb-specific flags are declared; only the global flags above apply."
+            )
+        lines.append("")
+    return lines
 
 
 def _write(text: str) -> None:

--- a/docs/docker-support.md
+++ b/docs/docker-support.md
@@ -13,7 +13,7 @@ Schema version: `1` (the shape of the `--supported --json` payload this doc refl
 | Verb | Summary |
 | --- | --- |
 | `init` | translate compose.yaml into a starting bosn.toml manifest |
-| `compose` | managed Compose subset (up/down/logs/ps); every resource labeled and leased |
+| `compose` | managed Compose subset (up/down/logs/ps/build/run/exec/config); every resource labeled and leased |
 
 ## Forwarded
 
@@ -64,4 +64,62 @@ Schema version: `1` (the shape of the `--supported --json` payload this doc refl
 | `diff` | list changed files in a container's filesystem | targets a raw container name outside bosn's registry; use `bosn shell` to inspect a managed container directly |
 | `wait` | block until a container stops, then print its exit code | targets a raw container name outside bosn's registry; use `bosn jobs`/`bosn attach` to wait on a daemon-owned job |
 | `search` | search Docker Hub for images | not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
+
+## Compose flags
+
+The `compose` verb's own sub-verb and flag surface (#47). A flag not listed as `accepted` for a sub-verb -- including one this table has never heard of -- is refused, named, with a remedy; see `bosn.frontdoor.resolve_compose_flag`.
+
+Sub-verbs: `up`, `down`, `logs`, `ps`, `build`, `run`, `exec`, `config`
+
+### Global flags
+
+Apply to every sub-verb identically; parsed ahead of the sub-verb (`bosn-docker compose -f compose.yaml up`).
+
+| Flag | Aliases | Takes value | Status | Summary | Remedy |
+| --- | --- | --- | --- | --- | --- |
+| `-f` | `--file` | yes | accepted | path to the compose file (already wired; predates #47) | -- |
+
+### `compose up`
+
+| Flag | Aliases | Takes value | Status | Summary | Remedy |
+| --- | --- | --- | --- | --- | --- |
+| `-d` | `--detach` | no | accepted | run containers in the background instead of attaching to their output | -- |
+| `--wait` | -- | no | accepted | wait for services to report healthy/running before returning | -- |
+| `--build` | -- | no | refused | rebuild images before starting | would rebuild an image outside `bosn ensure`'s spec-digest tracking; declare the build in bosn.toml and run `bosn ensure` first, then `compose up` |
+| `--remove-orphans` | -- | no | refused | remove containers for services not defined in the compose file | accepted on `compose down`, not `up`, in this subset; run `bosn-docker compose down --remove-orphans` |
+
+### `compose down`
+
+| Flag | Aliases | Takes value | Status | Summary | Remedy |
+| --- | --- | --- | --- | --- | --- |
+| `-v` | `--volumes` | no | accepted | remove named volumes declared in the compose file's `volumes` section | -- |
+| `--remove-orphans` | -- | no | accepted | remove containers for services not defined in the compose file | -- |
+| `--rmi` | -- | yes | refused | remove images used by services | deletes images outside lease/GC bookkeeping; use `bosn gc` to reclaim managed resources safely |
+| `-t` | `--timeout` | yes | refused | shutdown timeout in seconds before a container is killed | not part of bosn's managed `compose down` flag subset; run `bosn-docker --supported --json` to see every accepted flag per compose command, or use the real `docker compose` binary directly if you accept the resources it creates will be unmanaged |
+
+### `compose logs`
+
+| Flag | Aliases | Takes value | Status | Summary | Remedy |
+| --- | --- | --- | --- | --- | --- |
+| `-f` | `--follow` | no | refused | follow log output (docker compose's meaning; NOT bosn's global --file) | `-f` is bosn's global compose-file selector, not `--follow`, in this subset; `--follow` itself is not part of the managed flag surface -- not part of bosn's managed `compose logs` flag subset; run `bosn-docker --supported --json` to see every accepted flag per compose command, or use the real `docker compose` binary directly if you accept the resources it creates will be unmanaged |
+
+### `compose ps`
+
+No sub-verb-specific flags are declared; only the global flags above apply.
+
+### `compose build`
+
+No sub-verb-specific flags are declared; only the global flags above apply.
+
+### `compose run`
+
+No sub-verb-specific flags are declared; only the global flags above apply.
+
+### `compose exec`
+
+No sub-verb-specific flags are declared; only the global flags above apply.
+
+### `compose config`
+
+No sub-verb-specific flags are declared; only the global flags above apply.
 

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -797,9 +797,28 @@ class Daemon:
         recompute_manifest_generations(self.registry, recovered)
         return {"ok": True, "adopted": names, "registry_id": registry_id}
 
-    def _verb_compose_adopt(self, _request: dict[str, Any]) -> dict[str, Any]:
-        from bosn.resources import ResourceScanner, adopt
+    def _verb_compose_adopt(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Reconcile the registry against what Compose actually left on the engine.
 
+        Additive by default (`adopt()`): a failed or partial engine listing must never be
+        read as permission to forget rows, so plain reconcile-after-compose (every `up`,
+        `down`, `logs`, `ps`) only ever registers what it finds.
+
+        `prune_missing=True` is the opt-in exception, sent only when the caller just told
+        Compose to *delete* something (`down -v`/`--volumes`): it additionally removes rows
+        for previously-registered resources that the scan's kinds cover but did not find,
+        via `reconcile_owned`'s `prior_resources` path -- the same crash-boundary repair
+        `_reconcile_startup_resources` already trusts. Never used unconditionally here:
+        that would turn an engine hiccup on an ordinary `up`/`logs`/`ps` into silent row
+        loss for resources that never left the engine at all.
+        """
+        from bosn.resources import ResourceScanner, adopt, reconcile_owned
+
+        if bool(request.get("prune_missing")):
+            prior_resources = self.registry.list_resources()
+            scan = ResourceScanner().scan(self.registry.registry_id)
+            reconciled = reconcile_owned(self.registry, scan, prior_resources=prior_resources)
+            return {"ok": True, "adopted": reconciled}
         scan = ResourceScanner().scan(self.registry.registry_id)
         return {"ok": True, "adopted": adopt(self.registry, scan)}
 

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -338,7 +338,7 @@ def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
         handle.close()
 
 
-def _reconcile_after_compose(command: str) -> None:
+def _reconcile_after_compose(command: str, *, prune_missing: bool = False) -> None:
     """Adopt any labeled-but-unregistered resource left behind by a Compose invocation.
 
     Runs unconditionally -- on a clean exit, a non-zero exit, and on the way out of a
@@ -353,13 +353,21 @@ def _reconcile_after_compose(command: str) -> None:
     label new resources, adoption only registers what is not already known, so the scan
     finds nothing to do and returns immediately.
 
+    `prune_missing` is the opt-in the closing reconcile after `down -v`/`--volumes` sets:
+    that flag tells Compose to *delete* named volumes bosn has registry rows for, and the
+    plain adopt-only path here never removes a row for something that vanished (see
+    `daemon._verb_compose_adopt`). Left `False` everywhere else -- including the
+    pre-command reconcile above `_run_compose`'s lease acquisition, which runs before
+    Compose has touched anything this invocation and must not treat an engine hiccup as
+    permission to forget resources that never left.
+
     A failure here is reported to stderr but never raised. Raising would surface as a
     `DockerFrontDoorError` in `main()`, which maps to exit code 1 regardless of what the
     compose command itself returned -- masking `up`'s real exit status behind a
     bookkeeping error the caller didn't ask about.
     """
     try:
-        adopted = daemon.request("compose-adopt")
+        adopted = daemon.request("compose-adopt", prune_missing=prune_missing)
     except KeyboardInterrupt:
         raise
     except Exception as exc:  # daemon unreachable, IPC failure, etc.
@@ -438,9 +446,46 @@ def _release_compose_lease(session: str | None) -> None:
         print(f"bosn-docker compose: could not release project lease: {exc}", file=sys.stderr)
 
 
+# The decided v1 subset (#47): `up -d/--detach --wait` and `down -v/--volumes
+# --remove-orphans`. Anything else after the verb still refuses, named specifically, via
+# `_validate_compose_flags` below -- this table is deliberately not sourced from
+# `bosn.frontdoor`, which does not yet expose per-verb flag data; parsed locally here
+# instead of blocking on that.
+_COMPOSE_ALLOWED_FLAGS: dict[str, frozenset[str]] = {
+    "up": frozenset({"-d", "--detach", "--wait"}),
+    "down": frozenset({"-v", "--volumes", "--remove-orphans"}),
+}
+
+# `-v`/`--volumes` is the flag that makes `down` delete named volumes bosn has registry rows
+# for -- the trigger for the `prune_missing` reconcile below. `--remove-orphans` also
+# removes engine objects (containers for services no longer in the file) but is
+# deliberately not included here: without `-v` a plain `down`/`down --remove-orphans` still
+# reconciles adopt-only, so a row for an orphan container Compose just removed goes stale
+# until the next opportunity to prune it -- currently the daemon's own startup recovery
+# (`_reconcile_startup_resources`, which does pass `prior_resources`), not this call.
+# Widening `prune_missing` to cover it is a separate, deliberate decision, not a gap to
+# close here: it would mean trusting every `down` (not just `-v`) to treat an engine
+# listing failure as removal-worthy, and Problem 2 as scoped is about the volumes `-v`
+# names explicitly.
+_COMPOSE_VOLUME_REMOVAL_FLAGS = frozenset({"-v", "--volumes"})
+
+
+def _validate_compose_flags(command: str, args: list[str]) -> None:
+    """Refuse anything outside the decided per-verb subset, naming the exact flag.
+
+    `command` here is always `up`/`down`/`logs`/`ps` (`_parse_compose_args` already
+    constrains `command` via `choices=`); `logs`/`ps` have no entry in the table above, so
+    `_COMPOSE_ALLOWED_FLAGS.get(command, frozenset())` refuses every argument for them, same
+    as before this change -- only `up`/`down` grew an accepted, non-empty subset.
+    """
+    allowed = _COMPOSE_ALLOWED_FLAGS.get(command, frozenset())
+    for arg in args:
+        if arg not in allowed:
+            raise DockerFrontDoorError(f"unsupported compose flag or argument {arg!r}")
+
+
 def _run_compose(command: str, compose: Path, args: list[str]) -> int:
-    if args:
-        raise DockerFrontDoorError(f"unsupported compose flag or argument {args[0]!r}")
+    _validate_compose_flags(command, args)
     # Resolved before touching the daemon at all: once a `docker` shim that is
     # bosn-docker itself exists on PATH (a later slice of #46), spawning bare
     # `["docker", "compose", ...]` below would resolve to that shim, which re-enters
@@ -454,6 +499,9 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
         raise DockerFrontDoorError(str(reply.get("error") or "cannot reach bosn daemon"))
     overlay = _compose_overlay(str(reply["registry_id"]), compose)
     workspace = str(compose.parent.resolve())
+    prune_missing = command == "down" and any(
+        flag in _COMPOSE_VOLUME_REMOVAL_FLAGS for flag in args
+    )
     try:
         # Reconcile before acquiring: a lease can only protect a resource the registry
         # already knows about, and a project that is already up -- this is a second
@@ -463,7 +511,7 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
         session = _acquire_compose_lease(workspace)
         try:
             completed = subprocess.run(
-                [str(real), "compose", "-f", str(compose), "-f", str(overlay), command],
+                [str(real), "compose", "-f", str(compose), "-f", str(overlay), command, *args],
                 check=False,
                 env=engine_env,
             )
@@ -476,10 +524,37 @@ def _run_compose(command: str, compose: Path, args: list[str]) -> int:
             # propagates -- same ordering guarantee `try/finally` always gives, just applied
             # twice. Release goes first only because it can't discover anything reconcile's
             # scan doesn't need: releasing does not add or remove resource rows.
+            #
+            # This release is unconditional even for `up -d`/`up --wait`, and that is a
+            # considered decision, not an oversight (#47). Those flags make Compose return
+            # as soon as containers start -- the project keeps running after this process
+            # exits, so releasing here stops protecting it via the lease from this point on.
+            # Two ways to keep the lease alive past this call were rejected:
+            #   - hold it open under this process's pid/proc_start anyway: this process is
+            #     about to exit (that is the point of `-d`), so `lease_is_expired` reclaims
+            #     it within one TTL regardless -- "kept" would only mean "kept for a few
+            #     minutes by accident," not durable protection.
+            #   - re-acquire it under the daemon's own identity so it outlives this process:
+            #     `_verb_compose_acquire`'s docstring calls this out explicitly as the one
+            #     thing a Compose lease must never become -- there is no `finally` inside the
+            #     daemon that would ever release it, so it would pin the resources until the
+            #     daemon itself restarts. A lease nothing can release is worse than no lease.
+            #   - refuse `-d`/`--wait` outright: defensible, but it disables the most common
+            #     way people actually run `compose up`, which defeats the point of fronting
+            #     Compose at all.
+            # So: release, exactly as for a blocking `up`. From here, a detached project's
+            # resources are protected only by their age tier -- and that is a real gap, not
+            # a theoretical one: neither retention.py nor gc.py inspects whether a container
+            # is currently running, and non-machine resources are eligible under pressure
+            # regardless of age tier. A freshly-started detached project is indistinguishable
+            # from an idle one to GC the moment this function returns. Closing that gap means
+            # teaching retention/GC about container run state, which is out of scope for this
+            # slice (see the report accompanying this change); it is called out here so the
+            # behavior is documented, not silently accepted.
             try:
                 _release_compose_lease(session)
             finally:
-                _reconcile_after_compose(command)
+                _reconcile_after_compose(command, prune_missing=prune_missing)
         return completed.returncode
     finally:
         overlay.unlink(missing_ok=True)

--- a/src/bosn/frontdoor.py
+++ b/src/bosn/frontdoor.py
@@ -84,7 +84,10 @@ _GOVERNED: tuple[VerbSpec, ...] = (
     VerbSpec(
         verb="compose",
         category=Category.GOVERNED,
-        summary="managed Compose subset (up/down/logs/ps); every resource labeled and leased",
+        summary=(
+            "managed Compose subset (up/down/logs/ps/build/run/exec/config); every "
+            "resource labeled and leased"
+        ),
     ),
 )
 
@@ -406,6 +409,296 @@ def _index_by_verb(verbs: tuple[VerbSpec, ...]) -> dict[str, VerbSpec]:
 _BY_VERB: dict[str, VerbSpec] = _index_by_verb(VERBS)
 
 
+# ---------------------------------------------------------------------------------------
+# Compose flag surface (#47) -- the GOVERNED `compose` verb's own sub-table.
+#
+# `compose` is one row above, but it is not a leaf: it has its own sub-verbs (`up`,
+# `down`, ...) and each of those has its own flag surface. Before this table existed,
+# `_run_compose` refused *any* token after the sub-verb -- "unsupported compose flag or
+# argument" for literally anything, including `-d`. That satisfied #47's "no silent
+# ignoring" half by refusing everything, but not its "decided subset" half: `up -d --wait`
+# and `down -v --remove-orphans` are named in the issue as flags bosn must actually accept.
+#
+# Same shape as the verb table above, for the same reason: a flag a caller might type is
+# either ACCEPTED (bosn understands it and passes it through) or REFUSED (named, with a
+# remedy) -- there is no third "silently drop it" option, because that is exactly the
+# failure mode #47's last acceptance criterion exists to prevent.
+# ---------------------------------------------------------------------------------------
+
+
+class FlagStatus(Enum):
+    """Whether a compose sub-verb's flag is understood, mirroring `Category` above.
+
+    There is no FORWARD equivalent here: a flag either round-trips through bosn's overlay
+    machinery (ACCEPTED) or it does not exist as far as bosn is concerned (REFUSED). Values
+    are lowercase strings for the same JSON-round-trip reason `Category` gives.
+    """
+
+    ACCEPTED = "accepted"
+    REFUSED = "refused"
+
+
+@dataclass(frozen=True)
+class ComposeFlagSpec:
+    """One flag a `compose` sub-verb (`up`, `down`, ...) either accepts or refuses.
+
+    `aliases` holds the flag's other spellings (`-d` and `--detach` are one spec, not
+    two) so a lookup can resolve either without the table declaring the same flag twice.
+    `takes_value` says whether the flag consumes a following token as its argument
+    (`--file compose.yaml`) or stands alone (`--wait`) -- callers building an argv parser
+    for a sub-verb need this to know how many tokens a flag occupies.
+
+    `remedy` is required for REFUSED (same contract `VerbSpec` enforces for REFUSE: there
+    is always something else to do or say) and left `None` for ACCEPTED, where "the flag
+    works" already is the remedy.
+    """
+
+    flag: str
+    status: FlagStatus
+    takes_value: bool = False
+    summary: str = ""
+    remedy: str | None = None
+    aliases: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.status is FlagStatus.REFUSED and not self.remedy:
+            raise ValueError(f"REFUSED flag {self.flag!r} must carry a remedy")
+        if self.status is FlagStatus.ACCEPTED and self.remedy is not None:
+            raise ValueError(f"ACCEPTED flag {self.flag!r} must not carry a remedy")
+
+    def names(self) -> tuple[str, ...]:
+        """Every spelling this spec answers to: the primary flag plus its aliases."""
+        return (self.flag, *self.aliases)
+
+
+# The remedy for a flag this table has never heard of, for a `compose` sub-verb it does
+# recognize. Parallel to `_UNKNOWN_VERB_REMEDY`: generic, because there is no specific
+# governed alternative to point at for a flag this table doesn't know exists.
+def _unknown_compose_flag_remedy(command: str) -> str:
+    return (
+        f"not part of bosn's managed `compose {command}` flag subset; run `bosn-docker "
+        "--supported --json` to see every accepted flag per compose command, or use the "
+        "real `docker compose` binary directly if you accept the resources it creates "
+        "will be unmanaged"
+    )
+
+
+# `-f`/`--file` selects which compose file to read. It is parsed ahead of the sub-verb
+# (`bosn-docker compose -f compose.yaml up`, not `... up -f compose.yaml`) and applies to
+# every sub-verb identically, so it lives here once rather than being copied into all
+# eight per-command tuples below -- the same reasoning `_ESCAPE_HATCH` gives for sharing
+# one remedy string across REFUSE rows instead of retyping it.
+COMPOSE_GLOBAL_FLAGS: tuple[ComposeFlagSpec, ...] = (
+    ComposeFlagSpec(
+        flag="-f",
+        status=FlagStatus.ACCEPTED,
+        takes_value=True,
+        summary="path to the compose file (already wired; predates #47)",
+        aliases=("--file",),
+    ),
+)
+
+# `up`: the issue names `-d`/`--wait` explicitly ("up -d --wait"). `--build`,
+# `--force-recreate`, `--no-recreate`, and `--scale` are all real `docker compose up`
+# flags, but none is named in #47, and each has a bosn-shaped reason to stay out of v1:
+# `--build` would rebuild an image bosn did not track through `bosn ensure`'s spec-digest
+# keying (see the `build` REFUSE row above), and `--remove-orphans` is accepted on `down`
+# below, not here, matching the issue's own pairing of that flag with `down -v`.
+_COMPOSE_UP_FLAGS: tuple[ComposeFlagSpec, ...] = (
+    ComposeFlagSpec(
+        flag="-d",
+        status=FlagStatus.ACCEPTED,
+        summary="run containers in the background instead of attaching to their output",
+        aliases=("--detach",),
+    ),
+    ComposeFlagSpec(
+        flag="--wait",
+        status=FlagStatus.ACCEPTED,
+        summary="wait for services to report healthy/running before returning",
+    ),
+    ComposeFlagSpec(
+        flag="--build",
+        status=FlagStatus.REFUSED,
+        summary="rebuild images before starting",
+        remedy=(
+            "would rebuild an image outside `bosn ensure`'s spec-digest tracking; declare "
+            "the build in bosn.toml and run `bosn ensure` first, then `compose up`"
+        ),
+    ),
+    ComposeFlagSpec(
+        flag="--remove-orphans",
+        status=FlagStatus.REFUSED,
+        summary="remove containers for services not defined in the compose file",
+        remedy=(
+            "accepted on `compose down`, not `up`, in this subset; run "
+            "`bosn-docker compose down --remove-orphans`"
+        ),
+    ),
+)
+
+# `down`: the issue names `-v`/`--remove-orphans` explicitly ("down -v --remove-orphans").
+# `--rmi` is refused for the same reason the top-level `rmi` verb is refused above:
+# deleting images outside lease/GC bookkeeping. `-t`/`--timeout` is real but unnamed by the
+# issue; kept out per "prefer the smaller set" rather than guessed at.
+_COMPOSE_DOWN_FLAGS: tuple[ComposeFlagSpec, ...] = (
+    ComposeFlagSpec(
+        flag="-v",
+        status=FlagStatus.ACCEPTED,
+        summary="remove named volumes declared in the compose file's `volumes` section",
+        aliases=("--volumes",),
+    ),
+    ComposeFlagSpec(
+        flag="--remove-orphans",
+        status=FlagStatus.ACCEPTED,
+        summary="remove containers for services not defined in the compose file",
+    ),
+    ComposeFlagSpec(
+        flag="--rmi",
+        status=FlagStatus.REFUSED,
+        takes_value=True,
+        summary="remove images used by services",
+        remedy=(
+            "deletes images outside lease/GC bookkeeping; use `bosn gc` to reclaim "
+            "managed resources safely"
+        ),
+    ),
+    ComposeFlagSpec(
+        flag="-t",
+        status=FlagStatus.REFUSED,
+        takes_value=True,
+        summary="shutdown timeout in seconds before a container is killed",
+        remedy=_unknown_compose_flag_remedy("down"),
+        aliases=("--timeout",),
+    ),
+)
+
+# `logs`: the issue names no flags for it, so the accepted set is empty -- "prefer the
+# smaller set" per the task brief. `-f` is called out by name (not left to the generic
+# fallback) because it collides with the global `-f`/`--file` above: in real
+# `docker compose logs`, `-f` means `--follow`, a different flag entirely from the file
+# selector every other sub-verb reads `-f` as. Naming it here stops that collision from
+# reading as bosn silently reinterpreting `-f` rather than refusing it outright.
+_COMPOSE_LOGS_FLAGS: tuple[ComposeFlagSpec, ...] = (
+    ComposeFlagSpec(
+        flag="-f",
+        status=FlagStatus.REFUSED,
+        summary="follow log output (docker compose's meaning; NOT bosn's global --file)",
+        remedy=(
+            "`-f` is bosn's global compose-file selector, not `--follow`, in this "
+            "subset; `--follow` itself is not part of the managed flag surface -- "
+            + _unknown_compose_flag_remedy("logs")
+        ),
+        aliases=("--follow",),
+    ),
+)
+
+# `ps`, `build`, `run`, `exec`, `config`: the issue names these as sub-verbs bosn must
+# accept (#47: "build/run/exec/config") but names no flags for any of them. Empty accepted
+# sets, same "prefer the smaller set" call as `logs` -- every flag on these four falls
+# through to the generic per-command remedy until a future issue names one specifically.
+_COMPOSE_PS_FLAGS: tuple[ComposeFlagSpec, ...] = ()
+_COMPOSE_BUILD_FLAGS: tuple[ComposeFlagSpec, ...] = ()
+_COMPOSE_RUN_FLAGS: tuple[ComposeFlagSpec, ...] = ()
+_COMPOSE_EXEC_FLAGS: tuple[ComposeFlagSpec, ...] = ()
+_COMPOSE_CONFIG_FLAGS: tuple[ComposeFlagSpec, ...] = ()
+
+# The single source of truth for both the sub-verb surface (`COMPOSE_COMMANDS` below is
+# derived from these keys, not hand-copied) and each sub-verb's flags. Order is
+# deliberate and matches the order the `compose` row's summary lists them in.
+COMPOSE_FLAGS: dict[str, tuple[ComposeFlagSpec, ...]] = {
+    "up": _COMPOSE_UP_FLAGS,
+    "down": _COMPOSE_DOWN_FLAGS,
+    "logs": _COMPOSE_LOGS_FLAGS,
+    "ps": _COMPOSE_PS_FLAGS,
+    "build": _COMPOSE_BUILD_FLAGS,
+    "run": _COMPOSE_RUN_FLAGS,
+    "exec": _COMPOSE_EXEC_FLAGS,
+    "config": _COMPOSE_CONFIG_FLAGS,
+}
+
+# `docker_cli._parse_compose_args` builds its `choices=[...]` from this instead of
+# hand-maintaining a second list that could drift from the one above it dispatches
+# against -- the same "one source of truth" argument the module docstring makes for verbs.
+COMPOSE_COMMANDS: tuple[str, ...] = tuple(COMPOSE_FLAGS.keys())
+
+
+def _index_compose_flags(
+    flags: tuple[ComposeFlagSpec, ...],
+) -> dict[str, ComposeFlagSpec]:
+    index: dict[str, ComposeFlagSpec] = {}
+    for spec in flags:
+        for name in spec.names():
+            if name in index:
+                raise ValueError(f"duplicate compose flag spelling: {name!r}")
+            index[name] = spec
+    return index
+
+
+_COMPOSE_GLOBAL_INDEX: dict[str, ComposeFlagSpec] = _index_compose_flags(COMPOSE_GLOBAL_FLAGS)
+
+
+def _merge_with_globals(flags: tuple[ComposeFlagSpec, ...]) -> dict[str, ComposeFlagSpec]:
+    """Merge one sub-verb's flags over the globals, letting the sub-verb win a collision.
+
+    A plain concatenate-then-index would raise on `logs`' `-f`, which deliberately reuses
+    the `-f` spelling the globals already claim for `--file` -- see `_COMPOSE_LOGS_FLAGS`'s
+    comment on why that collision is named as a REFUSED row instead of silently inheriting
+    the global meaning. "Sub-verb wins" is what makes that override actually take effect
+    instead of the duplicate-spelling guard rejecting it as a table bug.
+    """
+    merged = dict(_COMPOSE_GLOBAL_INDEX)
+    merged.update(_index_compose_flags(flags))
+    return merged
+
+
+# Per-command index, each pre-merged with the globals so a lookup never has to check two
+# tables. Built once at import time from `COMPOSE_FLAGS`/`COMPOSE_GLOBAL_FLAGS` -- there is
+# no second copy of this merge anywhere else for it to drift from.
+_COMPOSE_FLAGS_BY_COMMAND: dict[str, dict[str, ComposeFlagSpec]] = {
+    command: _merge_with_globals(flags) for command, flags in COMPOSE_FLAGS.items()
+}
+
+
+def compose_flag_spec_for(command: str, flag: str) -> ComposeFlagSpec | None:
+    """Look up `flag`'s spec for `command` (its primary spelling or any alias).
+
+    Raw lookup, `spec_for`'s compose-flag counterpart: `None` means the table has no
+    opinion, and callers must not treat that as "safe to pass through" -- see
+    `resolve_compose_flag` for the fail-closed wrapper. `command` must be a member of
+    `COMPOSE_COMMANDS`; anything else is a caller bug (an unrecognized sub-verb never
+    reaches flag parsing at all, since it fails sub-verb resolution first), so this raises
+    rather than silently returning `None` for a command as well as a flag.
+
+    `flag` must already be the bare flag spelling with any `=value` split off by the
+    caller (`--file=compose.yaml` -> pass `"--file"`, not the raw token) -- this table
+    only knows flag identity, not how a caller chose to spell a value onto it.
+    """
+    if command not in _COMPOSE_FLAGS_BY_COMMAND:
+        raise ValueError(f"{command!r} is not a compose sub-verb; see COMPOSE_COMMANDS")
+    return _COMPOSE_FLAGS_BY_COMMAND[command].get(flag)
+
+
+def resolve_compose_flag(command: str, flag: str) -> ComposeFlagSpec:
+    """The fail-closed caller-facing entry point for a compose sub-verb's flag.
+
+    Always returns a `ComposeFlagSpec`, never `None`: a flag present in `command`'s table
+    (or the globals) returns its row; a flag absent from both is unknown, and this
+    function's job is to make "unknown" resolve to REFUSED, with a usable remedy, as an
+    explicit branch here -- the same fail-closed shape `resolve()` gives verbs, for the
+    same reason. Dispatch code should call this, not `compose_flag_spec_for`, so an
+    un-cataloged flag can never fall through to "pass it to the real engine" by accident.
+    """
+    spec = compose_flag_spec_for(command, flag)
+    if spec is not None:
+        return spec
+    return ComposeFlagSpec(
+        flag=flag,
+        status=FlagStatus.REFUSED,
+        summary="unrecognized compose flag",
+        remedy=_unknown_compose_flag_remedy(command),
+    )
+
+
 def spec_for(verb: str) -> VerbSpec | None:
     """Look up `verb`'s table row. `None` means the table has no opinion -- callers must
     not treat that as "safe to forward"; see `resolve()` for the fail-closed wrapper.
@@ -441,13 +734,30 @@ def resolve(verb: str) -> VerbSpec:
     )
 
 
+def _compose_flag_payload(spec: ComposeFlagSpec) -> dict:
+    return {
+        "flag": spec.flag,
+        "aliases": list(spec.aliases),
+        "status": spec.status.value,
+        "takes_value": spec.takes_value,
+        "summary": spec.summary,
+        "remedy": spec.remedy,
+    }
+
+
 def supported() -> dict:
     """The payload behind `bosn-docker --supported --json`.
 
-    `VERBS` is the only source for it -- there is no second, hand-maintained list for
-    parser help text, generated docs, or this JSON to drift out of sync with. Every field
-    here is JSON-primitive (str/None), so `json.dumps(supported())` always round-trips for
-    the agent this is written for.
+    `VERBS` is the only source for the verb table, and `COMPOSE_FLAGS`/
+    `COMPOSE_GLOBAL_FLAGS` are the only source for the `compose` verb's flag surface --
+    there is no second, hand-maintained list for parser help text, generated docs, or this
+    JSON to drift out of sync with. Every field here is JSON-primitive (str/bool/None/list
+    of same), so `json.dumps(supported())` always round-trips for the agent this is
+    written for.
+
+    Adding the `compose` key below is an additive change to this payload's shape: existing
+    consumers reading `schema_version`/`verbs` see no field renamed or removed underneath
+    them, so `SCHEMA_VERSION` does not move -- see its module-level comment.
     """
     return {
         "schema_version": SCHEMA_VERSION,
@@ -460,4 +770,12 @@ def supported() -> dict:
             }
             for spec in VERBS
         ],
+        "compose": {
+            "commands": list(COMPOSE_COMMANDS),
+            "global_flags": [_compose_flag_payload(spec) for spec in COMPOSE_GLOBAL_FLAGS],
+            "flags": {
+                command: [_compose_flag_payload(spec) for spec in flags]
+                for command, flags in COMPOSE_FLAGS.items()
+            },
+        },
     }

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -432,6 +432,240 @@ def test_a_clean_up_reconciles_exactly_as_before(
     ]
 
 
+# -- the decided v1 compose flag subset (#47) --------------------------------
+
+
+@pytest.mark.parametrize("flag", ["-d", "--detach", "--wait"])
+def test_up_flags_reach_the_engine_intact(
+    flag: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run",
+        lambda argv, **_k: (calls.append(argv), _FakeCompleted(returncode=0))[1],
+    )
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [flag])
+
+    assert returncode == 0
+    assert calls[0][-1] == flag
+    assert calls[0][-2] == "up"
+
+
+@pytest.mark.parametrize("flag", ["-v", "--volumes", "--remove-orphans"])
+def test_down_flags_reach_the_engine_intact(
+    flag: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run",
+        lambda argv, **_k: (calls.append(argv), _FakeCompleted(returncode=0))[1],
+    )
+
+    returncode = _run_compose("down", _compose_file(tmp_path), [flag])
+
+    assert returncode == 0
+    assert calls[0][-1] == flag
+    assert calls[0][-2] == "down"
+
+
+def test_an_unsupported_flag_still_refuses_naming_it(tmp_path: Path) -> None:
+    with pytest.raises(DockerFrontDoorError, match="--scale"):
+        _run_compose("up", tmp_path / "compose.yaml", ["--scale"])
+
+
+def test_a_flag_valid_for_the_other_verb_still_refuses(tmp_path: Path) -> None:
+    """`-v`/`--volumes` only means something on `down`; `up -v` is not in the decided
+    subset and must refuse exactly like any other unrecognized argument."""
+    with pytest.raises(DockerFrontDoorError, match="-v"):
+        _run_compose("up", tmp_path / "compose.yaml", ["-v"])
+
+
+def test_logs_and_ps_still_accept_no_arguments(tmp_path: Path) -> None:
+    """`logs`/`ps` never grew an accepted subset -- only `up`/`down` did."""
+    with pytest.raises(DockerFrontDoorError, match="-f"):
+        _run_compose("logs", tmp_path / "compose.yaml", ["-f"])
+
+
+# -- detached `up -d`/`up --wait` still releases its lease immediately (#47) --
+
+
+@pytest.mark.parametrize("flag", ["-d", "--wait"])
+def test_detached_up_still_releases_the_lease_immediately(
+    flag: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The decided posture: a detached `up` releases its lease exactly like a blocking one,
+    because the lease is held under *this* process's identity and this process is about to
+    exit -- keeping it "alive" here would only delay reclaim by one TTL, not protect the
+    project durably, and re-homing it onto the daemon would be the permanent pin leases
+    exist to prevent (see `_verb_compose_acquire`'s docstring). A detached project's
+    containers are left protected only by their age tier after this call returns; that gap
+    is documented in `_run_compose` and tracked as a follow-up, not silently absorbed here.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    returncode = _run_compose("up", _compose_file(tmp_path), [flag])
+
+    assert returncode == 0
+    assert fake_daemon.calls == [
+        "status",
+        "compose-adopt",
+        "compose-acquire",
+        "compose-release",
+        "compose-adopt",
+    ]
+
+
+# -- `down -v` leaves the registry consistent (#47) ---------------------------
+
+
+def test_down_v_sends_prune_missing_on_the_closing_reconcile_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pre-command reconcile runs before Compose has touched anything this invocation
+    and must stay additive; only the closing reconcile, after Compose has actually deleted
+    the volumes, may prune rows for what is now gone.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    returncode = _run_compose("down", _compose_file(tmp_path), ["-v"])
+
+    assert returncode == 0
+    adopt_requests = [
+        req
+        for call, req in zip(fake_daemon.calls, fake_daemon.requests, strict=True)
+        if call == "compose-adopt"
+    ]
+    assert len(adopt_requests) == 2
+    assert adopt_requests[0]["prune_missing"] is False
+    assert adopt_requests[1]["prune_missing"] is True
+
+
+def test_plain_down_never_sends_prune_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    _run_compose("down", _compose_file(tmp_path), [])
+
+    adopt_requests = [
+        req
+        for call, req in zip(fake_daemon.calls, fake_daemon.requests, strict=True)
+        if call == "compose-adopt"
+    ]
+    assert all(req["prune_missing"] is False for req in adopt_requests)
+
+
+def test_down_v_removes_the_registry_row_for_a_volume_compose_actually_deleted(
+    tmp_path: Path,
+) -> None:
+    """The correctness test for Problem 2: after `down -v`, a volume the registry still has
+    a row for but that no longer exists on the engine must be gone from the registry too.
+
+    Exercises the real daemon handler (`Daemon._verb_compose_adopt`), not the `_FakeDaemon`
+    test double the other tests in this file use -- this is exactly the crash-boundary
+    staleness `reconcile_owned` (#41) was written to repair, applied here to a resource
+    Compose itself removed rather than one that vanished from an engine crash.
+    """
+    from bosn import daemon as daemon_module
+    from bosn.resources import ScanResult
+
+    instance = daemon_module.Daemon(state_dir=tmp_path / "state")
+    try:
+        instance.registry.register_resource(
+            kind="volume",
+            name="proj_data",
+            stack="proj",
+            generation="gen-1",
+            scope="stack",
+            workspace=str(tmp_path),
+        )
+        assert any(r.name == "proj_data" for r in instance.registry.list_resources())
+
+        class _EmptyVolumeScan:
+            def scan(self, _registry_id: str) -> ScanResult:
+                # The volume is gone from the engine -- Compose just deleted it -- but the
+                # scan still covers the "volume" kind, so its absence here is what
+                # `reconcile_owned` reads as "remove the row", not "engine unreachable".
+                return ScanResult(owned=[], scanned_kinds={"volume", "container", "network"})
+
+        def _fake_scanner(*_a: object, **_k: object) -> _EmptyVolumeScan:
+            return _EmptyVolumeScan()
+
+        import bosn.resources as resources_module
+
+        original_scanner = resources_module.ResourceScanner
+        resources_module.ResourceScanner = _fake_scanner  # type: ignore[assignment]
+        try:
+            reply = instance._verb_compose_adopt({"prune_missing": True})
+        finally:
+            resources_module.ResourceScanner = original_scanner  # type: ignore[assignment]
+
+        assert reply["ok"] is True
+        assert not any(r.name == "proj_data" for r in instance.registry.list_resources())
+    finally:
+        instance.registry.close()
+
+
+def test_a_plain_compose_adopt_never_prunes_rows_for_a_resource_the_scan_missed(
+    tmp_path: Path,
+) -> None:
+    """The default (`prune_missing` absent/False) must stay purely additive: a failed or
+    partial engine listing is never permission to forget a row for a resource that never
+    actually left the engine.
+    """
+    from bosn import daemon as daemon_module
+    from bosn.resources import ScanResult
+
+    instance = daemon_module.Daemon(state_dir=tmp_path / "state")
+    try:
+        instance.registry.register_resource(
+            kind="volume",
+            name="proj_data",
+            stack="proj",
+            generation="gen-1",
+            scope="stack",
+            workspace=str(tmp_path),
+        )
+
+        class _EmptyVolumeScan:
+            def scan(self, _registry_id: str) -> ScanResult:
+                return ScanResult(owned=[], scanned_kinds={"volume"})
+
+        def _fake_scanner(*_a: object, **_k: object) -> _EmptyVolumeScan:
+            return _EmptyVolumeScan()
+
+        import bosn.resources as resources_module
+
+        original_scanner = resources_module.ResourceScanner
+        resources_module.ResourceScanner = _fake_scanner  # type: ignore[assignment]
+        try:
+            reply = instance._verb_compose_adopt({})
+        finally:
+            resources_module.ResourceScanner = original_scanner  # type: ignore[assignment]
+
+        assert reply["ok"] is True
+        assert any(r.name == "proj_data" for r in instance.registry.list_resources())
+    finally:
+        instance.registry.close()
+
+
 # -- category-table dispatch (#46) --------------------------------------------
 #
 # `bosn.frontdoor` supplies the category table itself (a separate agent's slice of #46,

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -3,14 +3,27 @@ import json
 import pytest
 
 from bosn.frontdoor import (
+    COMPOSE_COMMANDS,
+    COMPOSE_FLAGS,
+    COMPOSE_GLOBAL_FLAGS,
     FORWARD_SAFE_ALLOWLIST,
     VERBS,
     Category,
+    ComposeFlagSpec,
+    FlagStatus,
     VerbSpec,
+    compose_flag_spec_for,
     resolve,
+    resolve_compose_flag,
     spec_for,
     supported,
 )
+
+# Every (command, spec) pair across every declared compose sub-verb's own flags -- does
+# not include COMPOSE_GLOBAL_FLAGS, which have no single owning command.
+_ALL_COMPOSE_FLAG_ENTRIES: list[tuple[str, ComposeFlagSpec]] = [
+    (command, spec) for command, flags in COMPOSE_FLAGS.items() for spec in flags
+]
 
 # Verbs that create, start, stop, remove, or otherwise mutate an engine-managed resource
 # (container/image/volume/network). If a future edit ever adds one of these to
@@ -160,3 +173,207 @@ def test_governed_and_forward_categories_are_both_represented() -> None:
     assert Category.GOVERNED in categories
     assert Category.FORWARD in categories
     assert Category.REFUSE in categories
+
+
+# ---------------------------------------------------------------------------------------
+# Compose flag surface (#47)
+# ---------------------------------------------------------------------------------------
+
+
+def test_compose_commands_matches_compose_flags_keys() -> None:
+    """COMPOSE_COMMANDS is derived from COMPOSE_FLAGS, not a second hand-typed list."""
+    assert COMPOSE_COMMANDS == tuple(COMPOSE_FLAGS.keys())
+
+
+def test_compose_flags_declared_only_for_known_compose_commands() -> None:
+    expected = {"up", "down", "logs", "ps", "build", "run", "exec", "config"}
+    assert set(COMPOSE_COMMANDS) == expected
+
+
+def test_compose_is_the_only_verb_with_flag_data() -> None:
+    """Flag data belongs to the GOVERNED `compose` sub-surface only; nothing else in VERBS
+    has a flag table, so there is nowhere else flag data could attach by accident.
+    """
+    compose_spec = spec_for("compose")
+    assert compose_spec is not None
+    assert compose_spec.category is Category.GOVERNED
+
+
+@pytest.mark.parametrize("spec", COMPOSE_GLOBAL_FLAGS, ids=lambda spec: spec.flag)
+def test_every_global_flag_declares_its_arity_and_is_accepted(spec: ComposeFlagSpec) -> None:
+    assert spec.status is FlagStatus.ACCEPTED
+    assert isinstance(spec.takes_value, bool)
+    assert spec.remedy is None
+
+
+@pytest.mark.parametrize(
+    "entry", _ALL_COMPOSE_FLAG_ENTRIES, ids=lambda entry: f"{entry[0]}:{entry[1].flag}"
+)
+def test_every_compose_flag_declares_value_taking_arity(entry: tuple[str, ComposeFlagSpec]) -> None:
+    _, spec = entry
+    assert isinstance(spec.takes_value, bool)
+    assert isinstance(spec.flag, str) and spec.flag
+    assert isinstance(spec.summary, str) and spec.summary
+
+
+@pytest.mark.parametrize(
+    "entry", _ALL_COMPOSE_FLAG_ENTRIES, ids=lambda entry: f"{entry[0]}:{entry[1].flag}"
+)
+def test_refused_compose_flags_carry_a_remedy(entry: tuple[str, ComposeFlagSpec]) -> None:
+    _, spec = entry
+    if spec.status is FlagStatus.REFUSED:
+        assert spec.remedy
+    else:
+        assert spec.remedy is None
+
+
+def test_compose_flag_spec_rejects_refused_without_remedy() -> None:
+    with pytest.raises(ValueError, match="remedy"):
+        ComposeFlagSpec(flag="--bogus", status=FlagStatus.REFUSED, summary="no remedy given")
+
+
+def test_compose_flag_spec_rejects_accepted_with_remedy() -> None:
+    with pytest.raises(ValueError, match="remedy"):
+        ComposeFlagSpec(
+            flag="--bogus",
+            status=FlagStatus.ACCEPTED,
+            summary="has a remedy but is accepted",
+            remedy="should not be here",
+        )
+
+
+@pytest.mark.parametrize("command", COMPOSE_COMMANDS)
+def test_no_duplicate_flag_spellings_within_a_command(command: str) -> None:
+    """No flag (including any alias) may be declared twice within one sub-verb's own
+    table -- a duplicate there is a table bug, unlike the deliberate global-flag override
+    `logs`' `-f` performs (covered by the collision test below).
+    """
+    seen: list[str] = []
+    for spec in COMPOSE_FLAGS[command]:
+        seen.extend(spec.names())
+    assert len(seen) == len(set(seen)), f"duplicate flag spelling within `compose {command}`"
+
+
+def test_no_duplicate_flag_spellings_among_global_flags() -> None:
+    seen: list[str] = []
+    for spec in COMPOSE_GLOBAL_FLAGS:
+        seen.extend(spec.names())
+    assert len(seen) == len(set(seen))
+
+
+@pytest.mark.parametrize(
+    "entry", _ALL_COMPOSE_FLAG_ENTRIES, ids=lambda entry: f"{entry[0]}:{entry[1].flag}"
+)
+def test_declared_flags_round_trip_through_compose_flag_spec_for(
+    entry: tuple[str, ComposeFlagSpec],
+) -> None:
+    command, spec = entry
+    for name in spec.names():
+        assert compose_flag_spec_for(command, name) is spec
+
+
+@pytest.mark.parametrize("spec", COMPOSE_GLOBAL_FLAGS, ids=lambda spec: spec.flag)
+def test_global_flags_are_visible_from_every_command_unless_overridden(
+    spec: ComposeFlagSpec,
+) -> None:
+    for command in COMPOSE_COMMANDS:
+        for name in spec.names():
+            command_own_names = {n for s in COMPOSE_FLAGS[command] for n in s.names()}
+            if name in command_own_names:
+                continue  # the sub-verb deliberately overrides this spelling
+            assert compose_flag_spec_for(command, name) is spec
+
+
+def test_logs_overrides_the_global_file_flag_spelling() -> None:
+    """The documented collision: `-f` means `--follow` on `compose logs`, not bosn's
+    global `--file`. The sub-verb's own row must win the lookup, and it must be refused
+    with a remedy that names the collision rather than silently behaving like `--file`.
+    """
+    spec = compose_flag_spec_for("logs", "-f")
+    assert spec is not None
+    assert spec.status is FlagStatus.REFUSED
+    assert spec.aliases == ("--follow",)
+    assert spec.remedy
+
+
+def test_resolve_compose_flag_never_returns_none_for_unknown_flag() -> None:
+    spec = resolve_compose_flag("up", "--nonexistent-flag-nobody-typed")
+    assert spec.status is FlagStatus.REFUSED
+    assert spec.remedy
+
+
+@pytest.mark.parametrize("command", COMPOSE_COMMANDS)
+def test_resolve_compose_flag_agrees_with_declared_flags(command: str) -> None:
+    for spec in COMPOSE_FLAGS[command]:
+        for name in spec.names():
+            assert resolve_compose_flag(command, name) is spec
+    for spec in COMPOSE_GLOBAL_FLAGS:
+        for name in spec.names():
+            own_names = {n for s in COMPOSE_FLAGS[command] for n in s.names()}
+            if name in own_names:
+                continue
+            assert resolve_compose_flag(command, name) is spec
+
+
+def test_compose_flag_spec_for_rejects_unknown_command() -> None:
+    with pytest.raises(ValueError):
+        compose_flag_spec_for("not-a-compose-command", "-d")
+
+
+def test_supported_includes_compose_flag_data() -> None:
+    payload = supported()
+    assert set(payload["compose"]["commands"]) == set(COMPOSE_COMMANDS)
+    assert payload["compose"]["global_flags"]
+    for command in COMPOSE_COMMANDS:
+        assert command in payload["compose"]["flags"]
+
+
+def test_supported_compose_flag_entries_match_the_table() -> None:
+    payload = supported()
+    for command, entries in payload["compose"]["flags"].items():
+        specs = COMPOSE_FLAGS[command]
+        assert len(entries) == len(specs)
+        for entry, spec in zip(entries, specs, strict=True):
+            assert entry["flag"] == spec.flag
+            assert entry["aliases"] == list(spec.aliases)
+            assert entry["status"] == spec.status.value
+            assert entry["takes_value"] == spec.takes_value
+            assert entry["summary"] == spec.summary
+            assert entry["remedy"] == spec.remedy
+
+
+def test_supported_refused_compose_flags_carry_their_remedy() -> None:
+    payload = supported()
+    for entries in payload["compose"]["flags"].values():
+        for entry in entries:
+            if entry["status"] == FlagStatus.REFUSED.value:
+                assert entry["remedy"]
+
+
+def test_supported_with_compose_flags_still_round_trips_through_json() -> None:
+    """The pre-existing round-trip test already covers this, but is repeated here scoped
+    to the new `compose` key specifically: aliases are tuples in the table and must be
+    converted to lists before this payload is built, or `json.loads` would hand back a
+    list where the in-memory payload held a tuple and the equality check would fail.
+    """
+    payload = supported()
+    text = json.dumps(payload)
+    parsed = json.loads(text)
+    assert parsed["compose"] == payload["compose"]
+
+
+@pytest.mark.parametrize(
+    "entry", _ALL_COMPOSE_FLAG_ENTRIES, ids=lambda entry: f"{entry[0]}:{entry[1].flag}"
+)
+def test_compose_flag_fields_contain_no_pipe_or_newline(
+    entry: tuple[str, ComposeFlagSpec],
+) -> None:
+    """Mirrors `test_gen_docker_support.test_table_fields_contain_no_pipe_or_newline`:
+    the generator puts these fields verbatim into a Markdown pipe table with no escaping.
+    """
+    _, spec = entry
+    for field in (spec.flag, spec.summary, spec.remedy, *spec.aliases):
+        if field is None:
+            continue
+        assert "|" not in field, f"{spec.flag!r} field contains '|': {field!r}"
+        assert "\n" not in field, f"{spec.flag!r} field contains a newline: {field!r}"


### PR DESCRIPTION
Implements #47's flag surface. **Does not close #47** — its `twp/e2e` acceptance criterion needs a fixture that is not in this repository (noted on the issue).

`up -d/--detach --wait` and `down -v/--volumes --remove-orphans` now reach the engine verbatim; everything else still refuses by name. The flags are table data in `frontdoor`, beside the verb catalog, so `--supported --json` and the generated doc describe them and cannot drift.

```
up   -d                -> [..., 'up', '-d']              prune_missing=False
up   --wait            -> [..., 'up', '--wait']          prune_missing=False
down -v                -> [..., 'down', '-v']            prune_missing=True
down --remove-orphans  -> [..., 'down', '--remove-orphans'] prune_missing=False

up --scale app=3   refused: unsupported compose flag or argument '--scale'
logs -f            refused: unsupported compose flag or argument '-f'
```

## The plumbing was the easy half

**`down -v` would have corrupted the registry.** It deletes volumes that have registry rows, but `_reconcile_after_compose` is adopt-only — purely additive, never removing rows for things that vanished. The registry would have kept describing volumes that no longer exist.

`compose-adopt` now takes `prune_missing`, routing through `reconcile_owned`'s `prior_resources` path — the same crash-boundary repair startup reconciliation already trusts, rather than a second removal path. It is **opt-in and sent only when the caller just told Compose to delete something**: unconditional pruning would turn an engine hiccup during an ordinary `up`/`logs`/`ps` into silent row loss for resources that never left the engine.

**`up -d` releases the project lease while the project keeps running.** Releasing is still correct — a client-identity lease dies with the client anyway, and re-acquiring under the daemon's identity is precisely what `_verb_compose_acquire` forbids, since nothing inside the daemon would release it.

But the consequence is real, and I verified it before dispatching: **nothing in `retention.py` or `gc.py` inspects whether a container is running.** From the moment that call returns, a freshly started detached project is indistinguishable from an idle one to GC, and under pressure non-machine resources are eligible regardless of age. Documented in place and filed as **#90** rather than absorbed silently.

## One trap worth naming

`docker compose logs -f` means `--follow`; bosn's global `-f` means `--file`. Accepting it on `logs` would have read the next token as a compose file path. The table refuses `-f` on `logs` specifically while keeping it on `up` — exactly the ambiguity that gets resolved silently and wrongly.

## Verification

900 tests pass, `ci/lint.py` clean. The generated doc was regenerated, so the drift guard covers the new flag tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)