### PR TITLE
feat(compose): govern build/config/exec/run sub-verbs (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ policy instead of a blunt instrument.
 
 This is not hypothetical. It happened, on one developer machine, in the summer of 2026.
 
-Every agent-created git worktree spawned its own five-volume Rust cache group (`target`,
-`CARGO_HOME`, `RUSTUP_HOME`, cargo-chef, `.soldr`). Retained history showed **268 Docker
+Every agent-created git worktree spawned its own five-volume cache group (`target`,
+`cargo-home`, `soldr-home`, `uv-cache`, `venv`). Retained history showed **268 Docker
 invocations and zero cleanup calls.** Nothing had a TTL, so nothing was ever deleted:
 
 | Date | State |
@@ -273,8 +273,12 @@ Every volume declares a **scope**, which decides what it is keyed on:
 `target/` is a cold build after every source edit, which is the opposite of what you want
 from a cache. Use `stack` for anything whose value is being warm.
 
-That drops the soldr stack from **five per-worktree volumes to two**. With ten worktrees,
-50 volumes become 23 — and the shared ones are the big ones.
+Applied to soldr's own five (`target`, `cargo-home`, `soldr-home`, `uv-cache`, `venv`,
+per `Runner.volumes` in `ci/perf_local.py`): `cargo-home`, `soldr-home`, and `uv-cache` are
+content-identical per machine and become `machine`-scoped; `target` and `venv` are built
+from the checkout's own source and stay `stack`-scoped. That drops the stack from **five
+per-worktree volumes to two**. With ten worktrees, 50 volumes become 23 — and the shared
+ones are the big ones.
 
 **`family` is the sharing key, and it is easy to get wrong.** A `machine` volume is named
 from the stack's `family`, falling back to the stack *name* when no family is set. So two

--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -22,7 +22,16 @@ from bosn.compose import ComposeError, content_digest, load_compose
 # it always returns a VerbSpec, turning a verb the table has never heard of into a REFUSE
 # with a generic remedy rather than a `None` a dispatcher could mistake for "safe to
 # forward". Dispatch below calls `resolve()`, never `spec_for()`, for that reason.
-from bosn.frontdoor import Category, resolve, supported
+from bosn.frontdoor import (
+    COMPOSE_COMMANDS,
+    COMPOSE_GLOBAL_FLAGS,
+    COMPOSE_SERVICE_COMMANDS,
+    Category,
+    FlagStatus,
+    resolve,
+    resolve_compose_flag,
+    supported,
+)
 from bosn.registry import Registry
 from bosn.resources import process_start_time
 
@@ -238,8 +247,25 @@ def _parse_init_args(args: list[str]) -> argparse.Namespace:
 
 
 def _parse_compose_args(args: list[str]) -> argparse.Namespace:
+    """`command` is not constrained here; `_run_compose` validates it against
+    `frontdoor.COMPOSE_COMMANDS` and refuses with bosn's own structured envelope.
+
+    Used to hardcode `choices=["up", "down", "logs", "ps"]` -- four sub-verbs behind what
+    `frontdoor.COMPOSE_COMMANDS` (and therefore the generated docs and `--supported --json`)
+    already declared, so `build`/`run`/`exec`/`config` were advertised as supported and
+    rejected by argparse before ever reaching dispatch (#47). Switching the literal list for
+    `choices=list(COMPOSE_COMMANDS)` would have fixed that, but traded it for a worse bug: an
+    *invalid* sub-verb (a typo, or a verb this table has never heard of) would then hit
+    argparse's own `parser.error()` -- a bare `SystemExit(2)` and a usage dump, not the
+    prose-or-JSON refusal every other unrecognized verb/flag in this module produces (see
+    `build_parser`'s docstring, which makes exactly this argument for the top-level verb).
+    So `command` is parsed as a plain positional with no `choices=`, and `_run_compose`
+    checks membership in `COMPOSE_COMMANDS` itself, before doing anything else -- reusing
+    the same `DockerFrontDoorError` path `main()` already catches for every other compose
+    refusal.
+    """
     parser = argparse.ArgumentParser(prog="bosn-docker compose")
-    parser.add_argument("command", choices=["up", "down", "logs", "ps"])
+    parser.add_argument("command")
     parser.add_argument("args", nargs=argparse.REMAINDER)
     parser.add_argument("-f", "--file", default="compose.yaml")
     return parser.parse_args(args)
@@ -268,6 +294,20 @@ def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
     `networks:` section at all. Anonymous service-level volumes have no top-level
     key to attach labels to, so they cannot be governed through this overlay; the
     front door refuses to run rather than let them come up unlabeled.
+
+    A service's `labels:` (what `label_block` below writes under each service key)
+    land on the *container* Compose creates from that service -- never on an image
+    `build:` produces. Left at that, `bosn-docker compose build` (#47) would produce
+    a fully unlabeled, unregistered image: exactly the ungoverned resource #48 exists
+    to prevent, created by bosn's own front door. The Compose spec's `build.labels`
+    (verified against a real `docker compose config` merge: a base file's `build:` as
+    either a bare string or a mapping both merge cleanly with an override's
+    `build: {labels: ...}`, preserving `context`/`dockerfile`/`args`) is the image-side
+    equivalent, so every service with a `build:` key also gets a `build.labels` block,
+    `kind="image"`. This runs unconditionally, not only when the sub-verb is literally
+    `build`: `compose up` also builds a service's image implicitly when it has no
+    `image:` (`is_build_only`) or the named image is missing locally, so gating this on
+    the sub-verb string would let exactly that path produce an unlabeled image again.
     """
     if isinstance(registry_id, Registry):
         registry_id = registry_id.registry_id
@@ -301,26 +341,45 @@ def _compose_overlay(registry_id: str | Registry, compose: Path) -> Path:
     # already has -- two invocations are compatible iff their digests are byte-equal.
     generation = content_digest(compose)
 
+    def contract_lines(name: str, kind: str, indent: str) -> list[str]:
+        contract = labels.ResourceLabels(
+            registry=registry_id,
+            kind=kind,
+            stack=name,
+            generation=generation,
+            scope="stack",
+            workspace=workspace,
+            created=created,
+        )
+        return [
+            f"{indent}{key}: {_yaml_scalar(value)}" for key, value in contract.to_dict().items()
+        ]
+
     def label_block(resource_names: list[str], kind: str) -> list[str]:
         block: list[str] = []
         for name in resource_names:
-            contract = labels.ResourceLabels(
-                registry=registry_id,
-                kind=kind,
-                stack=name,
-                generation=generation,
-                scope="stack",
-                workspace=workspace,
-                created=created,
-            )
             block += [f"  {name}:", "    labels:"]
-            block += [
-                f"      {key}: {_yaml_scalar(value)}" for key, value in contract.to_dict().items()
-            ]
+            block += contract_lines(name, kind, "      ")
+        return block
+
+    build_names = {service.name for service in parsed.services.values() if service.has_build}
+
+    def service_block(resource_names: list[str]) -> list[str]:
+        block: list[str] = []
+        for name in resource_names:
+            block += [f"  {name}:", "    labels:"]
+            block += contract_lines(name, "container", "      ")
+            if name in build_names:
+                # `kind="image"`, not "container": this is the label contract for the
+                # image `build:` produces, attached where Compose's `build.labels`
+                # merge rule (see the docstring above) actually reads it -- nested
+                # under the service's own `build:` key, not a sibling of `labels:`.
+                block += ["    build:", "      labels:"]
+                block += contract_lines(name, "image", "        ")
         return block
 
     lines = ["services:"]
-    lines += label_block(names, "container")
+    lines += service_block(names)
     if volume_names:
         lines.append("volumes:")
         lines += label_block(volume_names, "volume")
@@ -446,16 +505,6 @@ def _release_compose_lease(session: str | None) -> None:
         print(f"bosn-docker compose: could not release project lease: {exc}", file=sys.stderr)
 
 
-# The decided v1 subset (#47): `up -d/--detach --wait` and `down -v/--volumes
-# --remove-orphans`. Anything else after the verb still refuses, named specifically, via
-# `_validate_compose_flags` below -- this table is deliberately not sourced from
-# `bosn.frontdoor`, which does not yet expose per-verb flag data; parsed locally here
-# instead of blocking on that.
-_COMPOSE_ALLOWED_FLAGS: dict[str, frozenset[str]] = {
-    "up": frozenset({"-d", "--detach", "--wait"}),
-    "down": frozenset({"-v", "--volumes", "--remove-orphans"}),
-}
-
 # `-v`/`--volumes` is the flag that makes `down` delete named volumes bosn has registry rows
 # for -- the trigger for the `prune_missing` reconcile below. `--remove-orphans` also
 # removes engine objects (containers for services no longer in the file) but is
@@ -469,22 +518,87 @@ _COMPOSE_ALLOWED_FLAGS: dict[str, frozenset[str]] = {
 # names explicitly.
 _COMPOSE_VOLUME_REMOVAL_FLAGS = frozenset({"-v", "--volumes"})
 
+# `-f`/`--file` selects the compose file, and `_parse_compose_args` already consumes it
+# ahead of the sub-verb (`bosn-docker compose -f FILE up`, not `... up -f FILE`) -- so a
+# spelling of it that survives into a sub-verb's own REMAINDER args is always in the wrong
+# position, never a legitimate use of the flag. `resolve_compose_flag` alone cannot catch
+# this: the global row is ACCEPTED (it is a real, understood flag -- just not here), and
+# every sub-verb except `logs` inherits it unchanged through `_merge_with_globals`, so a
+# plain ACCEPTED/REFUSED check would let `compose up -f x` silently pass validation and
+# reach the engine after `up`, where Compose reads it as nothing bosn intended. Named here
+# by the global table's own flag spellings, not a second hand-copied `{"-f", "--file"}`
+# literal, so it can never drift from `COMPOSE_GLOBAL_FLAGS` itself.
+_GLOBAL_COMPOSE_FLAG_NAMES = frozenset(
+    name for spec in COMPOSE_GLOBAL_FLAGS for name in spec.names()
+)
+
 
 def _validate_compose_flags(command: str, args: list[str]) -> None:
-    """Refuse anything outside the decided per-verb subset, naming the exact flag.
+    """Refuse anything outside `frontdoor`'s per-verb accepted-flag table, naming the flag.
 
-    `command` here is always `up`/`down`/`logs`/`ps` (`_parse_compose_args` already
-    constrains `command` via `choices=`); `logs`/`ps` have no entry in the table above, so
-    `_COMPOSE_ALLOWED_FLAGS.get(command, frozenset())` refuses every argument for them, same
-    as before this change -- only `up`/`down` grew an accepted, non-empty subset.
+    Used to check a locally hand-maintained `_COMPOSE_ALLOWED_FLAGS` dict covering only
+    `up`/`down`, written before `bosn.frontdoor.COMPOSE_FLAGS` existed. That table is now
+    the single source of truth for every sub-verb's flag surface -- `up`/`down`'s decided
+    subset, `logs`' empty one plus its named `-f` collision, and `build`/`run`/`exec`/
+    `config`'s currently-empty ones -- so this is the only place flags are validated
+    against it; `resolve_compose_flag` is the fail-closed lookup, so an unrecognized flag
+    always resolves to REFUSED rather than falling through as "unknown means allowed".
+
+    For the `COMPOSE_SERVICE_COMMANDS` sub-verbs (`run`/`exec`), validation stops at the
+    first non-`-` token: that is the SERVICE, and every token after it is the container's
+    own argv, forwarded untouched. Without that split these verbs refuse their own mandatory
+    service name -- `compose run app` resolving `'app'` as an unknown flag -- which would
+    leave them shipped-but-unusable. See `COMPOSE_SERVICE_COMMANDS` for the grammar.
     """
-    allowed = _COMPOSE_ALLOWED_FLAGS.get(command, frozenset())
+    takes_service = command in COMPOSE_SERVICE_COMMANDS
     for arg in args:
-        if arg not in allowed:
-            raise DockerFrontDoorError(f"unsupported compose flag or argument {arg!r}")
+        if takes_service and not arg.startswith("-"):
+            # The SERVICE token. Everything past it is the container's command line, so it
+            # is deliberately never looked up in the flag table -- `exec app ls -la` has to
+            # keep its `-la`. Compose owns the grammar from here on.
+            return
+        spec = resolve_compose_flag(command, arg)
+        if spec.status is FlagStatus.ACCEPTED and arg in _GLOBAL_COMPOSE_FLAG_NAMES:
+            # `logs` already overrides this spelling with its own REFUSED row (the
+            # `--follow` collision), so this branch is unreachable for `logs` -- the
+            # ACCEPTED status here only ever comes from the unmodified global row every
+            # other sub-verb inherits.
+            raise DockerFrontDoorError(
+                f"{arg!r} is bosn's global compose-file selector and must come before the "
+                f"sub-verb, not after it -- use `bosn-docker compose {arg} FILE {command} "
+                f"...`, not `... {command} {arg} FILE`"
+            )
+        if spec.status is not FlagStatus.ACCEPTED:
+            raise DockerFrontDoorError(
+                f"unsupported compose flag or argument {arg!r} for `compose {command}`: "
+                f"{spec.remedy}"
+            )
+    if takes_service:
+        # Falling out of the loop means no SERVICE token was ever seen (the `return` above
+        # is the only path that consumes one). Refused here, in bosn's own envelope, rather
+        # than forwarded for Compose to reject: the refusal is about *bosn's* declared
+        # grammar, and it costs an engine spawn plus an overlay render to learn nothing.
+        # Deeper grammar -- `exec`'s required COMMAND, whether the service exists in the
+        # file -- is left to Compose, which owns it and reports it better.
+        raise DockerFrontDoorError(
+            f"`compose {command}` requires a service name: "
+            f"`bosn-docker compose {command} SERVICE"
+            f"{' COMMAND' if command == 'exec' else ' [COMMAND]'}`"
+        )
 
 
 def _run_compose(command: str, compose: Path, args: list[str]) -> int:
+    if command not in COMPOSE_COMMANDS:
+        # `_parse_compose_args` no longer constrains `command` via argparse `choices=` (see
+        # its docstring) precisely so an unrecognized sub-verb lands here instead of exiting
+        # via a bare `SystemExit(2)` -- every other compose refusal in this module raises
+        # `DockerFrontDoorError`, which `main()` already catches and reports as prose on
+        # stderr with exit code 1, so an unknown sub-verb gets that same shape rather than
+        # an argparse usage dump.
+        raise DockerFrontDoorError(
+            f"unrecognized compose sub-verb {command!r}; run `bosn-docker --supported "
+            "--json` to see every accepted compose sub-verb"
+        )
     _validate_compose_flags(command, args)
     # Resolved before touching the daemon at all: once a `docker` shim that is
     # bosn-docker itself exists on PATH (a later slice of #46), spawning bare

--- a/src/bosn/frontdoor.py
+++ b/src/bosn/frontdoor.py
@@ -616,10 +616,31 @@ COMPOSE_FLAGS: dict[str, tuple[ComposeFlagSpec, ...]] = {
     "config": _COMPOSE_CONFIG_FLAGS,
 }
 
-# `docker_cli._parse_compose_args` builds its `choices=[...]` from this instead of
-# hand-maintaining a second list that could drift from the one above it dispatches
-# against -- the same "one source of truth" argument the module docstring makes for verbs.
+# `docker_cli._run_compose` checks membership in this instead of hand-maintaining a second
+# list that could drift from the one above it dispatches against -- the same "one source of
+# truth" argument the module docstring makes for verbs. (It is deliberately *not* wired into
+# `_parse_compose_args` as an argparse `choices=`: that would refuse an unknown sub-verb with
+# a bare `SystemExit(2)` and a usage dump instead of bosn's structured refusal. See that
+# function's docstring.)
 COMPOSE_COMMANDS: tuple[str, ...] = tuple(COMPOSE_FLAGS.keys())
+
+# Sub-verbs whose grammar is `<verb> [OPTIONS] SERVICE [COMMAND [ARGS...]]` rather than
+# `<verb> [OPTIONS]`. Docker requires a SERVICE for both -- `docker compose run` with no
+# service is an error from Compose itself -- so a front door that validated every token
+# against the flag table would refuse these verbs their own mandatory argument and leave
+# them declared-but-unusable, which is the #47 bug in a different disguise.
+#
+# The split this drives (in `docker_cli._validate_compose_flags`): tokens are checked as
+# flags only up to the first non-`-` token; that token is the SERVICE, and everything after
+# it is the *container's* argv, forwarded untouched. `compose exec app ls -la` must reach
+# the engine with `-la` intact -- it belongs to `ls`, not to `compose exec`, and running it
+# through `resolve_compose_flag` would refuse a legitimate command line.
+#
+# Lives here rather than as a literal in `docker_cli` so the sub-verb surface and its
+# grammar stay described in one place. `logs`/`ps` are deliberately absent: they accept
+# optional service names from Docker, but bosn has always scoped them to the whole project
+# and widening that is not part of #47.
+COMPOSE_SERVICE_COMMANDS: frozenset[str] = frozenset({"run", "exec"})
 
 
 def _index_compose_flags(

--- a/src/bosn/legacy.py
+++ b/src/bosn/legacy.py
@@ -26,8 +26,9 @@ machine, not inferred or guessed:
   creation. There is no schema/version label -- clud has never needed to change this
   contract's shape.
 - **soldr** (`io.soldr.perf-local`) -- ``soldr/ci/perf_local.py``. ``LABEL_PREFIX =
-  "io.soldr.perf-local"``, ``RUNNER_SCHEMA = "2"`` ("Bumped from '1': schema 1 runners are
-  the pre-per-root shared containers" -- a real breaking change in what the labels mean).
+  "io.soldr.perf-local"``. ``RUNNER_SCHEMA`` was ``"2"`` when this module was written
+  ("Bumped from '1': schema 1 runners are the pre-per-root shared containers" -- a real
+  breaking change in what the labels mean) and is ``"7"`` as of soldr 75d7cc80.
   The *runner container* gets ``.managed``, ``.schema``, ``.image-id``, ``.source-root``,
   ``.ptrace``, ``.dockerfile-sha256``. Its *volumes* (target/cargo-home/soldr-home) get only
   ``.managed`` and ``.source-root`` -- notably **not** ``.schema``. Since volumes are the only
@@ -193,10 +194,20 @@ SOLDR = LegacyFamily(
     stack_label=None,  # soldr has no stack concept of its own.
     stack_sentinel="soldr-perf-local",
     schema_label="io.soldr.perf-local.schema",
-    # Only RUNNER_SCHEMA "2" (current, as of this module's writing) is recognized. "1"
-    # is documented in the producer as "the pre-per-root shared containers" -- a real
-    # structural change in what .source-root means -- so it is deliberately excluded
-    # rather than assumed compatible.
+    # Only RUNNER_SCHEMA "2" is recognized. "1" is documented in the producer as "the
+    # pre-per-root shared containers" -- a real structural change in what .source-root
+    # means -- so it is deliberately excluded rather than assumed compatible.
+    #
+    # soldr has since jumped straight to "7" (commit 75d7cc80, one bump, not five), and
+    # this set has deliberately NOT been widened to follow: nothing was audited about what
+    # 3..7 changed, and inventing compatibility is exactly the assumption excluding "1"
+    # exists to prevent. That is safe *today* only because of the paragraph below -- soldr
+    # volumes still emit only .managed and .source-root, verified against perf_local.py at
+    # 75d7cc80, so this allowlist is unreachable for every object bosn actually adopts.
+    # If soldr ever stamps .schema on its volumes, adoption starts refusing them with the
+    # "unrecognized schema" error until someone audits 3..7 and widens this set. That
+    # refusal is the intended failure mode, not a bug -- but it is the thing to look up
+    # when a soldr adoption suddenly starts refusing.
     #
     # soldr's *volumes* (the only object this module ever relabels) never carry .schema --
     # only the runner *container* does, and containers are never adopted (see module

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -14,7 +14,7 @@ from bosn.docker_cli import (
     compose_to_manifest,
     main,
 )
-from bosn.frontdoor import Category, VerbSpec
+from bosn.frontdoor import COMPOSE_COMMANDS, Category, VerbSpec
 from bosn.registry import Registry
 
 
@@ -489,6 +489,230 @@ def test_logs_and_ps_still_accept_no_arguments(tmp_path: Path) -> None:
     """`logs`/`ps` never grew an accepted subset -- only `up`/`down` did."""
     with pytest.raises(DockerFrontDoorError, match="-f"):
         _run_compose("logs", tmp_path / "compose.yaml", ["-f"])
+
+
+# -- the four verbs #47 declared but never wired: build/run/exec/config ------
+
+
+def test_parser_accepts_exactly_what_compose_commands_declares(tmp_path: Path) -> None:
+    """The parser used to hardcode `choices=["up", "down", "logs", "ps"]` -- four of the
+    eight sub-verbs `frontdoor.COMPOSE_COMMANDS` (and therefore the generated docs and
+    `--supported --json`) already declared, so `build`/`run`/`exec`/`config` were
+    advertised as supported and rejected by argparse before ever reaching dispatch.
+
+    Asserted directly against the table, not a literal copy of its current contents, so a
+    future ninth sub-verb added to `COMPOSE_FLAGS` without the parser being touched fails
+    this test instead of silently going unimplemented again. The negative half is exercised
+    against `_run_compose`, not the parser: an invalid sub-verb must not raise `SystemExit`
+    (argparse's own bare exit-2 usage dump) -- it must refuse through the same
+    `DockerFrontDoorError` path every other compose refusal in this module uses. See
+    `test_an_undeclared_compose_subcommand_refuses_with_the_structured_envelope` below.
+    """
+    parser = docker_cli._parse_compose_args
+    for command in COMPOSE_COMMANDS:
+        ns = parser([command])
+        assert ns.command == command
+
+
+def test_an_undeclared_compose_subcommand_refuses_with_the_structured_envelope(
+    tmp_path: Path,
+) -> None:
+    """An unrecognized compose sub-verb (a typo, or one this table has never heard of) must
+    refuse the same way every other unsupported compose flag/argument does: a
+    `DockerFrontDoorError` `main()` turns into prose-on-stderr and exit code 1, not
+    argparse's bare `SystemExit(2)` usage dump the parser alone would give.
+    """
+    with pytest.raises(DockerFrontDoorError, match="frobnicate"):
+        _run_compose("frobnicate", _compose_file(tmp_path), [])
+
+
+def test_main_refuses_an_undeclared_compose_subcommand(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same refusal, exercised end to end through `main()` -- the compose branch has no
+    `--json` envelope of its own (see `_run_compose`'s dispatch comment), so this is prose
+    on stderr and exit code 1, exactly like `test_compose_subset_refuses_unknown_argument`.
+    """
+
+    def _fail_if_called(*_a: Any, **_k: Any) -> _FakeCompleted:
+        raise AssertionError("an unrecognized sub-verb must never reach the engine")
+
+    monkeypatch.setattr(docker_cli.subprocess, "run", _fail_if_called)
+
+    returncode = main(["compose", "frobnicate"])
+
+    assert returncode == 1
+    assert "frobnicate" in capsys.readouterr().err
+
+
+def test_a_global_file_flag_typed_after_the_subverb_still_refuses_naming_it(
+    tmp_path: Path,
+) -> None:
+    """`-f`/`--file` is parsed ahead of the sub-verb (`compose -f FILE up`, not
+    `compose up -f FILE`). It is `resolve_compose_flag`'s ACCEPTED global row for every
+    sub-verb except `logs` (which overrides it), so a naive ACCEPTED/REFUSED check on that
+    lookup alone would let it silently pass validation here and reach the engine positioned
+    after the sub-verb, where Compose does not read it as bosn intends. Must still refuse,
+    naming the flag, exactly like any other out-of-place argument.
+    """
+    with pytest.raises(DockerFrontDoorError, match="-f"):
+        _run_compose("up", _compose_file(tmp_path), ["-f", "other-compose.yaml"])
+
+    with pytest.raises(DockerFrontDoorError, match="--file"):
+        _run_compose("down", _compose_file(tmp_path), ["--file", "other-compose.yaml"])
+
+
+@pytest.mark.parametrize(
+    ("command", "extra"),
+    [
+        ("build", []),
+        ("config", []),
+        # `run`/`exec` take a mandatory SERVICE (`COMPOSE_SERVICE_COMMANDS`); passing none
+        # is its own refusal, covered below, so the reach-the-engine case has to supply one.
+        ("exec", ["app", "sh"]),
+        ("run", ["app"]),
+    ],
+)
+def test_the_four_newly_governed_verbs_reach_the_engine_with_the_verb_intact(
+    command: str, extra: list[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`build`/`config`/`exec`/`run` used to refuse before reaching `_run_compose` at all
+    (blocked by the hardcoded `choices=` above); now they route through the same governed
+    path `up`/`down`/`logs`/`ps` already use.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run",
+        lambda argv, **_k: (calls.append(argv), _FakeCompleted(returncode=0))[1],
+    )
+
+    returncode = _run_compose(command, _compose_file(tmp_path), list(extra))
+
+    assert returncode == 0
+    # The verb sits immediately before its own arguments, and those arrive in order --
+    # asserting on the tail rather than `[-1]` so the SERVICE/COMMAND tokens are pinned too.
+    assert calls[0][-1 - len(extra) :] == [command, *extra]
+
+
+def test_a_built_services_image_carries_the_bosn_label_contract_in_the_overlay(
+    tmp_path: Path,
+) -> None:
+    """A service's plain `labels:` land on the *container* Compose creates, never on an
+    image `build:` produces -- `compose build` would otherwise hand back a fully
+    unlabeled, unregistered image, exactly the ungoverned resource #48 exists to prevent.
+    The overlay must also carry a `build.labels` block, `kind="image"`, for any service
+    with a `build:` key.
+    """
+    (tmp_path / "ctx").mkdir()
+    (tmp_path / "ctx" / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    text = _overlay_text(
+        tmp_path,
+        "services:\n  app:\n    build: ./ctx\n    labels:\n      existing: yes\n",
+    )
+    # The container-side contract is untouched.
+    assert _labelled(text)["app"]["kind"] == "container"
+
+    build_labels_index = text.index("build:")
+    assert build_labels_index != -1
+    build_block = text[build_labels_index:]
+    kind_line = next(line for line in build_block.splitlines() if "com.zackees.bosn.kind" in line)
+    assert kind_line.split(":", 1)[1].strip().strip("'\"") == "image"
+
+
+def test_a_build_only_service_also_gets_an_image_label_block(tmp_path: Path) -> None:
+    """`is_build_only` services (`build:` with no `image:`) are exactly the class of
+    service `compose build`/an implicit build under `up` targets -- they must be governed
+    too, not just services that also declare an `image:`.
+    """
+    (tmp_path / "ctx").mkdir()
+    (tmp_path / "ctx" / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    text = _overlay_text(
+        tmp_path,
+        "services:\n  app:\n    build: ./ctx\n",
+    )
+    assert "build:" in text
+    services_section = text.split("networks:", 1)[0]
+    assert services_section.count("com.zackees.bosn.kind") == 2  # container + image
+
+
+def test_a_service_with_no_build_key_gets_no_build_labels_block(tmp_path: Path) -> None:
+    text = _overlay_text(tmp_path, "services:\n  app:\n    image: alpine\n")
+    assert "build:" not in text
+
+
+def test_run_acquires_and_releases_the_project_lease_like_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`run` creates a container, so it must be leased and reconciled exactly like `up` --
+    verified against a real `docker compose run` merge, which does apply a service's
+    `labels:` to the container it starts (same mechanism `up` relies on), so no separate
+    label plumbing is needed for `run` -- only the same lease/reconcile treatment.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    returncode = _run_compose("run", _compose_file(tmp_path), ["app"])
+
+    assert returncode == 0
+    assert fake_daemon.calls == [
+        "status",
+        "compose-adopt",
+        "compose-acquire",
+        "compose-release",
+        "compose-adopt",
+    ]
+
+
+def test_a_container_command_survives_flag_validation_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Everything after the SERVICE token belongs to the *container*, not to `compose exec`.
+
+    `exec app ls -la` must reach the engine with `-la` attached to `ls`. Running trailing
+    tokens through `resolve_compose_flag` would refuse `-la` as an unsupported compose flag
+    and make every non-trivial command line unusable -- so this pins the boundary against a
+    future "validate all the args" simplification.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run",
+        lambda argv, **_k: (calls.append(argv), _FakeCompleted(returncode=0))[1],
+    )
+
+    assert _run_compose("exec", _compose_file(tmp_path), ["app", "ls", "-la"]) == 0
+    assert calls[0][-4:] == ["exec", "app", "ls", "-la"]
+
+
+@pytest.mark.parametrize("command", ["run", "exec"])
+def test_a_service_scoped_verb_refuses_when_no_service_is_named(
+    command: str, tmp_path: Path
+) -> None:
+    """Docker itself errors on `compose run` with no service, so bosn refuses in its own
+    envelope rather than spending an engine spawn and an overlay render to learn nothing.
+    """
+    with pytest.raises(DockerFrontDoorError, match="requires a service name"):
+        _run_compose(command, _compose_file(tmp_path), [])
+
+
+@pytest.mark.parametrize("command", ["run", "exec"])
+def test_a_service_scoped_verb_still_refuses_flags_before_the_service(
+    command: str, tmp_path: Path
+) -> None:
+    """The SERVICE split must not become a hole: tokens *before* the service are still
+    flags, and `run`/`exec` accept none, so they refuse exactly as they did before.
+    """
+    with pytest.raises(DockerFrontDoorError, match="-d"):
+        _run_compose(command, _compose_file(tmp_path), ["-d", "app"])
+
+    with pytest.raises(DockerFrontDoorError, match="must come before the sub-verb"):
+        _run_compose(command, _compose_file(tmp_path), ["-f", "other.yaml", "app"])
 
 
 # -- detached `up -d`/`up --wait` still releases its lease immediately (#47) --

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -203,6 +203,118 @@ def test_a_real_soldr_volume_adopts_even_though_it_carries_no_schema_label() -> 
     assert mapped.kind == "volume"
 
 
+def test_all_five_real_soldr_volume_names_from_one_root_adopt_to_one_workspace() -> None:
+    """Shaped like an actual checkout, not the two-label fixture in isolation.
+
+    `Runner.volumes` in soldr/ci/perf_local.py returns exactly these five names for one
+    checkout root (`target`, `cargo-home`, `soldr-home`, `uv-cache`, `venv`), each created
+    with only `.managed` and `.source-root` (verified in `ensure_runner`'s `docker volume
+    create` call -- no other label is ever passed to a volume). All five must adopt and
+    land in the same workspace, or the family is dead on arrival against soldr's real shape.
+    """
+    root = "/home/dev/soldr"
+    names = [
+        "soldr-perf-target-soldr-a6c74af0",
+        "soldr-perf-cargo-home-soldr-a6c74af0",
+        "soldr-perf-soldr-home-soldr-a6c74af0",
+        "soldr-perf-uv-cache-soldr-a6c74af0",
+        "soldr-perf-venv-soldr-a6c74af0",
+    ]
+    engine = FakeEngine(
+        {
+            "volume": [
+                {
+                    "Name": name,
+                    "Labels": json.dumps(
+                        soldr_volume_labels(
+                            **{
+                                "io.soldr.perf-local.source-root": root,
+                            }
+                        )
+                    ),
+                }
+                for name in names
+            ]
+        }
+    )
+    plan = legacy.plan_adoption(
+        ResourceScanner(engine),  # type: ignore[arg-type]
+        legacy.SOLDR,
+        registry_id=OURS,
+        now=1000.0,
+    )
+    assert {entry.resource.name for entry in plan.eligible} == set(names)
+    assert {entry.new_labels.workspace for entry in plan.eligible} == {root}
+    assert plan.refused == ()
+    assert plan.skipped_immutable == ()
+
+
+def test_two_checkout_roots_map_to_two_distinct_workspaces_not_one() -> None:
+    """The per-worktree duplication issue #75 measures: two checkouts' volumes must never
+    collide into a single adopted workspace, even though both carry the same producer
+    labels and only differ by `.source-root`."""
+    root_a = "/home/dev/soldr"
+    root_b = "/home/dev/soldr2"
+    engine = FakeEngine(
+        {
+            "volume": [
+                {
+                    "Name": "soldr-perf-target-soldr-a6c74af0",
+                    "Labels": json.dumps(
+                        soldr_volume_labels(**{"io.soldr.perf-local.source-root": root_a})
+                    ),
+                },
+                {
+                    "Name": "soldr-perf-target-soldr2-b1c2d3e4",
+                    "Labels": json.dumps(
+                        soldr_volume_labels(**{"io.soldr.perf-local.source-root": root_b})
+                    ),
+                },
+            ]
+        }
+    )
+    plan = legacy.plan_adoption(
+        ResourceScanner(engine),  # type: ignore[arg-type]
+        legacy.SOLDR,
+        registry_id=OURS,
+        now=1000.0,
+    )
+    workspaces_by_name = {
+        entry.resource.name: entry.new_labels.workspace for entry in plan.eligible
+    }
+    assert workspaces_by_name == {
+        "soldr-perf-target-soldr-a6c74af0": root_a,
+        "soldr-perf-target-soldr2-b1c2d3e4": root_b,
+    }
+    assert len(set(workspaces_by_name.values())) == 2
+
+
+def test_a_volume_from_a_different_producer_namespace_is_not_adopted_by_legacy_soldr() -> None:
+    """Label-gated, never name-gated: a volume shaped like soldr's real target volume but
+    stamped under a different producer's namespace (e.g. clud, which manages the same kind
+    of Rust cache) must not qualify for `--legacy soldr`."""
+    engine = FakeEngine(
+        {
+            "volume": [
+                {
+                    "Name": "clud-docker-build-soldr-abc123-target",
+                    "Labels": json.dumps(
+                        clud_volume_labels(**{"com.clud.docker-build.cache-role": "target"})
+                    ),
+                },
+            ]
+        }
+    )
+    plan = legacy.plan_adoption(
+        ResourceScanner(engine),  # type: ignore[arg-type]
+        legacy.SOLDR,
+        registry_id=OURS,
+        now=1000.0,
+    )
+    assert plan.eligible == ()
+    assert plan.is_empty()
+
+
 def test_a_soldr_volume_missing_its_source_root_still_fails_closed() -> None:
     """Relaxing the schema rule must not relax the required fields it sat in front of."""
     without_root = soldr_volume_labels()


### PR DESCRIPTION
Closes #47.

## The gap

`frontdoor.COMPOSE_COMMANDS` has declared eight compose sub-verbs since it landed, but `_parse_compose_args` hardcoded `choices=["up", "down", "logs", "ps"]`. `build`/`config`/`exec`/`run` were advertised by `--supported --json` and the generated `docs/docker-support.md` while argparse rejected them before dispatch ever saw them.

## What changed

**Parser reads the table.** `command` is now a plain positional; `_run_compose` validates membership against `COMPOSE_COMMANDS` itself. Using argparse `choices=list(COMPOSE_COMMANDS)` would have fixed the missing verbs but traded the bug for a worse one — an *invalid* sub-verb would hit argparse's bare `SystemExit(2)` and a usage dump instead of the structured refusal every other unrecognized verb in this module produces.

**One source of flag truth.** The local `_COMPOSE_ALLOWED_FLAGS` dict (covering only `up`/`down`, written before `frontdoor.COMPOSE_FLAGS` existed) is deleted in favour of `resolve_compose_flag`, which is fail-closed.

**`build` is actually governed.** A service's `labels:` land on the *container* Compose creates, never on an image `build:` produces — so `compose build` would have returned a fully unlabeled, unregistered image: exactly the ungoverned resource #48 exists to prevent, minted by bosn's own front door. The overlay now emits a `build.labels` block (`kind="image"`) for every service with a `build:` key. Verified against a real `docker compose config` merge that `build.labels` combines cleanly whether the base file's `build:` is a bare string or a mapping. It runs unconditionally rather than gated on the `build` sub-verb, because `up` builds implicitly when a service has no local image — gating would leave that path producing unlabeled images again.

**`run`/`exec` grammar.** These take a mandatory SERVICE, so validating every token against the flag table refused their own required argument — they'd have shipped declared-but-unusable, the same bug in a new disguise. New `frontdoor.COMPOSE_SERVICE_COMMANDS` declares the grammar (`<verb> [OPTIONS] SERVICE [COMMAND...]`); validation stops at the first non-`-` token and everything after it is the container's argv, forwarded untouched — `exec app ls -la` keeps its `-la`. Naming no service refuses in bosn's envelope; deeper grammar (does the service exist, does `exec` have its COMMAND) stays Compose's to report.

**`-f` misposition.** `-f`/`--file` is globally ACCEPTED and inherited by every sub-verb, so a plain status check would have let `compose up -f x` pass validation and reach the engine mispositioned. Named by the global table's own spellings rather than a second hand-copied literal.

**Stale doc corrected.** `legacy.py` asserted soldr's `RUNNER_SCHEMA` is `"2"`; it reached `"7"` in soldr `75d7cc80` (one bump, not five). `recognized_schema_versions` is deliberately **not** widened — nothing was audited about schemas 3–7, and inventing compatibility is what excluding schema `1` exists to prevent. Verified unreachable today: soldr volumes still emit only `.managed` and `.source-root`, never `.schema`. The comment now records the one condition that would make it bite.

## Verification

- `ci/lint.py` → `LINT OK` (ruff format/check, pyright 0 errors, `lint_kbi`)
- `tests/test_docker_cli.py` + `tests/test_frontdoor.py` → 311 passed
- Full suite `-m "not docker"` → 962 passed, 2 skipped
- `run`'s container labelling verified against real Docker (`docker inspect .Config.Labels` after `compose run`) — it flows through the existing overlay path, no separate plumbing needed

### Known flake, not from this change

The daemon test family is load-sensitive: `test_daemon_jobs.py::test_a_job_that_never_reports_cannot_pin_the_daemon_forever` and `test_daemon.py::test_shutdown_verb_stops_the_daemon_and_clears_state` each failed in one full-suite run and passed in another, and both pass 3/3 in isolation. The first was bisected to fail identically on clean `main` (stash → full suite → same failure), so it predates this branch. Filed separately; if a CI lane trips it, re-run the lane.
