### PR TITLE
test(daemon): remove the races behind the load-sensitive daemon flakes (#95)

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -46,7 +46,16 @@ def _detach_code() -> str:
     return "\n".join(ast.unparse(node) for node in body)
 
 
-def _wait_until(predicate, timeout: float = 15.0, interval: float = 0.05) -> bool:
+# 60s rather than 15s -- a budget increase, not race-hiding padding. `is_serving` is an IPC
+# ping with its own 2s timeout, so under CPU oversubscription each failed attempt burns 2s
+# and a 15s ceiling is only ~7 tries; a busy stretch then fails on attempt count rather than
+# on anything being broken. Polling means a healthy run returns immediately regardless, so
+# the higher ceiling only changes how long a genuine hang takes to report. Same reasoning,
+# at more length, on `wait_until` in test_daemon_jobs.py (issue #95).
+_WAIT_TIMEOUT = 60.0
+
+
+def _wait_until(predicate, timeout: float = _WAIT_TIMEOUT, interval: float = 0.05) -> bool:
     deadline = time.time() + timeout
     while time.time() < deadline:
         if predicate():
@@ -58,6 +67,17 @@ def _wait_until(predicate, timeout: float = 15.0, interval: float = 0.05) -> boo
 @pytest.fixture
 def served(tmp_path: Path) -> Iterator[Daemon]:
     daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    # A fresh registry has no stored maintenance deadline, so `_next_maintenance_at`
+    # defaults to `started_at` -- due on the watchdog's very first tick. `shutdown()`
+    # joins the watchdog thread with no timeout at all, so if `request_stop()` below lands
+    # while that first tick is mid-`_run_maintenance()`, teardown blocks until the pass
+    # finishes -- including its engine-reachability probe, which is 60s per call and is
+    # called twice on an engine-less/unreachable runner (see
+    # test_idle_retirement_stops_an_unused_daemon below). That race, not a fixed-budget
+    # timing issue, is what made `thread.join(timeout=15)` occasionally fail under load
+    # (see issue #95). Nothing in this fixture exercises maintenance, so it is pushed out
+    # of the way for every test that uses `served`.
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()
     assert _wait_until(lambda: daemon_mod.is_serving(tmp_path)), "daemon never came up"
@@ -196,6 +216,12 @@ def test_registry_is_usable_from_the_server_threads(served: Daemon) -> None:
 
 def test_shutdown_verb_stops_the_daemon_and_clears_state(tmp_path: Path) -> None:
     daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    # See the `served` fixture above: a due first-tick maintenance pass can make
+    # `shutdown()`'s untimed `watchdog.join()` stall for up to ~2 minutes (two 60s engine
+    # probes) if `daemon_mod.stop()` below lands mid-pass. This is the test that was
+    # actually observed flaking that way (issue #95); nothing here exercises maintenance,
+    # so it is pushed out of the way.
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()
     assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
@@ -211,6 +237,9 @@ def test_the_port_is_released_for_the_next_daemon(tmp_path: Path) -> None:
     """A retired daemon must not leave its port wedged, or the singleton becomes a lockout."""
     for _ in range(2):
         daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+        # Prophylactic, not observed failing: same untimed-`watchdog.join()`-vs-first-tick-
+        # maintenance race as `test_shutdown_verb_stops_the_daemon_and_clears_state` above.
+        daemon._set_next_maintenance(daemon.clock.now() + 3600)
         thread = threading.Thread(target=daemon.serve_forever, daemon=True)
         thread.start()
         assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
@@ -228,11 +257,21 @@ def test_idle_retirement_stops_an_unused_daemon(tmp_path: Path) -> None:
     hosted Windows/macOS runner -- that blocks the tick for up to two minutes and this
     assertion times out having measured engine probing rather than idle retirement.
     """
-    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0.5)
+    # idle_retire_seconds starts long, not the 0.5s this test is actually about. Arming the
+    # short window at construction races the watchdog's first tick (also ~0.5s) against
+    # nothing more than "the test thread gets scheduled and lands one IPC round trip" --
+    # under load that race can be lost: the daemon retires before anyone ever contacts it,
+    # and the `is_serving` wait below then fails forever pinging something already gone
+    # (issue #95; see test_a_running_job_blocks_idle_retirement in test_daemon_jobs.py for
+    # the same fix and a 4/40-under-load confirmation this actually happens). The short
+    # window is armed only once the daemon is confirmed up, so "unused" is measured from a
+    # point the test can actually observe, which is what this test means by it anyway.
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
     daemon._set_next_maintenance(daemon.clock.now() + 3600)
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()
     assert _wait_until(lambda: daemon_mod.is_serving(tmp_path))
+    daemon.idle_retire_seconds = 0.5
     thread.join(timeout=30)
     assert not thread.is_alive(), "idle daemon should have retired itself"
     assert not daemon_mod.is_serving(tmp_path)

--- a/tests/test_daemon_jobs.py
+++ b/tests/test_daemon_jobs.py
@@ -7,6 +7,7 @@ streaming transport and the job policy are tested together without needing Docke
 
 from __future__ import annotations
 
+import sqlite3
 import threading
 import time
 from collections.abc import Iterator
@@ -30,13 +31,58 @@ target = { scope = "spec" }
 """
 
 
-def wait_until(predicate, timeout: float = 15.0, interval: float = 0.02) -> bool:
+# 60s, not 15s, and this is a *budget* increase rather than the kind of timeout-padding
+# that hides a race -- the two are worth telling apart, since the rest of issue #95 was
+# fixed by removing a race, not by waiting longer.
+#
+# The predicate these helpers most often carry is `daemon_mod.is_serving(state_dir)`, which
+# is an IPC ping with its own `timeout=2.0` (see daemon.py). Under sustained CPU
+# oversubscription a loopback round trip can miss that 2s window even though the daemon is
+# serving perfectly well, and each miss burns the full 2s -- so a 15s ceiling buys only
+# about seven attempts, and a run where the machine is busy for a couple of seconds fails
+# on attempt count rather than on anything being wrong. Measured, not guessed: with 12 busy
+# loops saturating this 16-core box, daemon startup blew the 15s ceiling on 1 of 5 runs.
+#
+# Raising the ceiling costs a healthy run exactly nothing: this polls and returns the
+# instant the predicate is true, so the larger number is only ever reached by a run that
+# was going to fail anyway -- it changes how long a genuine hang takes to report, not how
+# long a passing test takes. A real hang still fails, just with more evidence that it is
+# real.
+_WAIT_TIMEOUT = 60.0
+
+
+def wait_until(predicate, timeout: float = _WAIT_TIMEOUT, interval: float = 0.02) -> bool:
     deadline = time.time() + timeout
     while time.time() < deadline:
         if predicate():
             return True
         time.sleep(interval)
     return predicate()
+
+
+def _event_kinds(daemon: Daemon, limit: int = 500) -> list[str]:
+    """Read the daemon's own event log without going anywhere near IPC.
+
+    `daemon.registry.events()` is a plain SELECT against the SQLite connection the daemon
+    already holds open in-process (the connection is opened `check_same_thread=False`
+    specifically so callers other than the daemon's own threads can read it). It never
+    touches `note_activity`/`last_activity` -- unlike `daemon_mod.is_serving(state_dir)`,
+    which is a real IPC ping and would reset the very idle clock this module's tests are
+    waiting on. That is why this, and not `is_serving`, is the safe way to watch a
+    self-retiring daemon from the outside.
+
+    `shutdown()` closes the registry before the serve thread actually exits, so there is a
+    real window where the daemon is still alive-by-`thread.is_alive()` but the connection
+    underneath has just been closed by the same shutdown in progress. That is expected,
+    not a bug to chase: treat it as "no new event observed yet" rather than letting the
+    close race fail the read.
+    """
+    try:
+        return [row["kind"] for row in daemon.registry.events(limit=limit)]
+    except KeyboardInterrupt:
+        raise
+    except sqlite3.Error:
+        return []
 
 
 class ControlledBuilder:
@@ -79,6 +125,16 @@ def builder() -> ControlledBuilder:
 def served(tmp_path: Path, builder: ControlledBuilder) -> Iterator[Daemon]:
     state_dir = tmp_path / "state"
     daemon = Daemon(state_dir=state_dir, idle_retire_seconds=3600)
+    # A fresh registry has no stored maintenance deadline, so `_next_maintenance_at`
+    # defaults to `started_at` -- due on the watchdog's very first tick. If teardown's
+    # `request_stop()` lands while that tick is mid-`_run_maintenance()`, `shutdown()`'s
+    # unconditional `watchdog.join()` (no timeout, see daemon.py) blocks until the
+    # maintenance pass finishes -- including its engine-reachability probe, which is
+    # 60s per call and is called twice on an engine-less/unreachable runner (see
+    # test_daemon.py::test_idle_retirement_stops_an_unused_daemon). That race is what
+    # made teardown occasionally blow the `thread.join(timeout=15)` below under load:
+    # nothing here needs a real maintenance pass, so it is pushed out of the way.
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
     daemon.jobs.builder = builder
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()
@@ -316,7 +372,17 @@ def test_a_running_job_blocks_idle_retirement(
 ) -> None:
     """Retiring mid-build would destroy the build; the old idle-only rule would have."""
     state_dir = tmp_path / "state2"
-    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=0.2)
+    # idle_retire_seconds starts long, not the 0.2s this test is actually about. Arming the
+    # short window at construction time races the daemon's own watchdog (0.5s tick) against
+    # nothing more than "the test thread gets scheduled and lands one IPC round trip" --
+    # under load, that can lose: the daemon retires before anyone ever contacts it, and
+    # every later `is_serving` probe then fails forever because the thing being pinged is
+    # already gone (issue #95, confirmed by 4/40 trials under load logging
+    # thread_alive=False and a since-closed registry before the first successful ping).
+    # The short window is armed below, once the test has established the exact state it
+    # means to measure -- so the daemon is definitely up and definitely mid-build before
+    # idle retirement is even a possibility.
+    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=3600)
     # See test_daemon.py::test_idle_retirement_stops_an_unused_daemon: a due maintenance
     # pass probes the engine twice at 60s each inside the same watchdog tick that checks
     # retirement, which on an engine-less runner outlasts the join deadline below.
@@ -334,6 +400,11 @@ def test_a_running_job_blocks_idle_retirement(
         next(stream)
         assert builder.started.wait(10)
         stream.close()
+
+        # Now that the build is confirmed running, arm the short idle window this test is
+        # actually about. `idle_retire_seconds` is a plain attribute (daemon.py); the
+        # watchdog reads it fresh on every tick, so this takes effect on the very next one.
+        daemon.idle_retire_seconds = 0.2
 
         # Note: nothing may poll `is_serving` while waiting on retirement -- a ping is a
         # request, and a request resets the idle clock this test is measuring.
@@ -364,7 +435,23 @@ def test_a_job_that_never_reports_cannot_pin_the_daemon_forever(
         return BuildOutcome(returncode=130)
 
     state_dir = tmp_path / "state3"
-    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=0.2, build_ttl_seconds=0.5)
+    # idle_retire_seconds starts long: arming 0.2s at construction races the watchdog's
+    # first tick against nothing more than "the test thread gets scheduled and lands one
+    # IPC round trip", and under load that race can be lost before the test ever contacts
+    # the daemon -- see test_a_running_job_blocks_idle_retirement above for the same fix
+    # and the 4/40-under-load confirmation that this is real, not hypothetical. The short
+    # window is armed below only once the build is confirmed hung, which is the state this
+    # test is actually about. `build_ttl_seconds` stays fixed at construction: the TTL
+    # clock doesn't start until a job exists, so it isn't exposed to the same startup race.
+    daemon = Daemon(state_dir=state_dir, idle_retire_seconds=3600, build_ttl_seconds=0.5)
+    # See test_a_running_job_blocks_idle_retirement above: a fresh registry has no stored
+    # maintenance deadline, so a maintenance pass is due on the very first watchdog tick --
+    # the same tick that has to notice the TTL expiry below. On a runner where the engine
+    # binary is present but its daemon is unreachable, that pass blocks on a 60s-per-call
+    # reachability probe (called twice), which starves the reap/retire check this test is
+    # timing and was the actual cause of this test's flakiness, not scheduler jitter on the
+    # 0.2s/0.5s windows themselves. Pushed out of the way so only the TTL reap is measured.
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
     daemon.jobs.builder = never_finishes
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()
@@ -379,9 +466,33 @@ def test_a_job_that_never_reports_cannot_pin_the_daemon_forever(
         assert hung.wait(10)
         stream.close()
 
-        # The TTL reaps the hung build, and only then can idle retirement proceed. Waiting
-        # on the thread rather than polling `is_serving`, whose ping would reset the clock.
-        thread.join(timeout=30)
+        # Now that the build is confirmed hung, arm the short idle window this test is
+        # actually about. `idle_retire_seconds` is a plain attribute (daemon.py); the
+        # watchdog reads it fresh on every tick, so this takes effect on the very next one.
+        daemon.idle_retire_seconds = 0.2
+
+        # The TTL reaps the hung build, and only then can idle retirement proceed. Rather
+        # than betting everything on one opaque `thread.join(timeout=30)` and only finding
+        # out afterward whether the daemon ever noticed, wait on the state the daemon
+        # itself publishes when it retires: `daemon.idle_retired`, logged right after
+        # `request_stop()` succeeds in `_idle_watchdog` (see daemon.py). That event is
+        # read straight off the daemon's own Registry connection (see `_event_kinds`
+        # above), never through IPC, so unlike polling `is_serving` it cannot reset
+        # `last_activity` -- the very idle clock this test is waiting on.
+        #
+        # Once that event exists the daemon has already committed to stopping; the
+        # remaining `thread.join` only has to cover the mechanical tail of
+        # `_server.serve_forever()` returning and `shutdown()` running, so it gets a much
+        # smaller budget than the wait for retirement itself.
+        retired = wait_until(
+            lambda: "daemon.idle_retired" in _event_kinds(daemon) or not thread.is_alive(),
+            timeout=30,
+        )
+        assert retired, (
+            "the daemon never logged daemon.idle_retired; recent events: "
+            f"{_event_kinds(daemon)[:20]}"
+        )
+        thread.join(timeout=15)
         assert not thread.is_alive(), "a hung build must not pin the daemon forever"
     finally:
         daemon.request_stop()
@@ -394,6 +505,10 @@ def test_shutdown_tells_attached_clients_why_their_build_stopped(
 ) -> None:
     state_dir = tmp_path / "state4"
     daemon = Daemon(state_dir=state_dir, idle_retire_seconds=3600)
+    # Prophylactic, not observed failing: same `request_stop()` + untimed-`watchdog.join()`
+    # race as the `served` fixture above -- see its comment. Pushed out so shutdown here
+    # cannot stall on a same-tick maintenance pass.
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
     daemon.jobs.builder = builder
     thread = threading.Thread(target=daemon.serve_forever, daemon=True)
     thread.start()


### PR DESCRIPTION
Closes #95.

Two daemon tests failed intermittently in full-suite runs and passed reliably alone. The fix removes the races rather than padding the timeouts — the distinction is drawn explicitly in the comments, because one wait here genuinely *is* a budget and is raised as such.

## Root cause (one land mine, two symptoms)

A fresh registry has no stored maintenance deadline, so `_next_maintenance_at` defaults to `started_at` — a maintenance pass is due on the watchdog's **very first tick**. That pass calls `Engine.info()`, whose reachability probe is 60s per call and is invoked twice on a runner where the engine binary exists but its daemon is unreachable. Up to ~120s inside one tick.

That single fact produces both reported failures:

- `test_a_job_that_never_reports_cannot_pin_the_daemon_forever` — the stalled tick is the same one that must reap the expired job and check retirement, so the test's `join` deadline expires while the daemon is stuck in the probe.
- `test_shutdown_verb_stops_the_daemon_and_clears_state` — `shutdown()` joins the watchdog with **no timeout**, so a stop landing mid-pass blocks teardown.

It presents as scheduler luck because it is a race between the watchdog's progress and how fast the test reaches `request_stop()`. Two sibling tests already worked around it; these two never got the mitigation. Tests that don't exercise maintenance now push the deadline out of the way — and maintenance keeps its own dedicated coverage (`maintenance.reap.started/finished` assertions are untouched).

## Second race, found by reproducing rather than trusting a green run

The first fix passed 10/10 for the agent that wrote it. Re-running under deliberate load found more, so this PR also fixes:

Tests constructing a daemon with a sub-second `idle_retire_seconds` race the watchdog's first tick against nothing but *"the test thread gets scheduled."* Under load the daemon correctly retires and closes its registry **before** the test lands its first ping — after which every subsequent ping fails and no timeout increase can possibly help, because the thing being pinged is gone. Confirmed with a 40-trial standalone repro: 4/40 failed with the daemon already retired.

These now construct with a long window and arm the short one only once the state under test is established (the build attached, or the daemon confirmed serving). Each test measures the transition it claims to measure instead of also racing startup. Every `idle_retire_seconds` call site in both files was audited; the ones left alone never start a watchdog, or drive a `FakeClock`, and are noted as such.

## Where a timeout *was* raised, and why that's different

`wait_until`/`_wait_until` go 15s → 60s. `is_serving` is an IPC ping with its own 2s timeout, so a 15s ceiling bought only ~7 attempts under contention — a busy stretch failed on attempt count, not on anything being wrong. Because these poll and return the instant the predicate holds, the higher ceiling costs a healthy run nothing; it only changes how long a genuine hang takes to report.

Blind `thread.join(timeout=N)` retirement waits are replaced by polling the `daemon.idle_retired` event the daemon itself logs, read directly off its registry connection — never through `is_serving`, whose ping would reset the very idle clock under test.

## Verification

Under sustained CPU load (12 busy loops on a 16-core box), which reproducibly failed on the original code:

- 5 green full-suite runs (`963 passed, 2 skipped`) — 3 by the implementing agent, 2 independently
- 8/8 on the two originally-failing tests
- `ci/lint.py` → `LINT OK` (ruff format/check, pyright 0 errors, `lint_kbi`)

Before/after on the same box: original code failed on run 2 of 8 and again on run 3 of 5 with the exact reported assertion; fixed code has not failed under the same load.

## Deliberately not fixed here

The production half of the root cause: `bosn stop` can hang ~2 minutes on that same untimed `watchdog.join()`. Bounding the join alone is unsafe (an expired join leaks a thread still touching the registry), so it needs cooperative stop checks between maintenance phases plus an interruptible engine probe — daemon behavior change, out of scope for a test-only fix. Filed as **#97** with that analysis.
