### PR TITLE
fix(daemon): bound shutdown so a maintenance pass cannot stall `bosn stop` (#97)

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -58,6 +58,25 @@ STREAMING_VERBS = frozenset({"converge", "attach"})
 # then converge still has its registry writes and volume creation to finish).
 SHUTDOWN_DRAIN_SECONDS = 60.0
 
+# The watchdog's periodic maintenance pass asks "is the engine reachable" before doing any
+# real GC work through it. That is a liveness question, not a build or a GC operation, and
+# it does not need Engine.DEFAULT_TIMEOUT's 60s -- a docker/podman CLI that is going to
+# answer at all answers in well under this on every engine this project targets. Kept an
+# int (not a float) because Engine.__init__'s `timeout` parameter is typed int.
+MAINTENANCE_ENGINE_PROBE_TIMEOUT_SECONDS = 5
+
+# Upper bound on how long shutdown() waits for the watchdog thread to notice `_stop` and
+# exit, once the cooperative checks in `_run_maintenance` and the bounded probe above are
+# both in place. `EngineInfo.info()` can make the probe call up to twice before it decides
+# the engine is unreachable (client version, then server version), so the worst case the
+# watchdog can still be doing engine I/O after `_stop` is set is roughly
+# 2 * MAINTENANCE_ENGINE_PROBE_TIMEOUT_SECONDS. This is set well above that with slack for
+# the (fast, non-networked) phases before it, rather than pinned exactly to 2x -- a bound
+# that just barely covers the worst case would make an ordinary stop-during-probe look like
+# the timeout path this constant exists to guard against. See `shutdown()` for what happens
+# if this bound is ever actually exceeded.
+WATCHDOG_JOIN_TIMEOUT_SECONDS = 15.0
+
 
 class DaemonError(RuntimeError):
     """The daemon could not be started, reached, or stopped."""
@@ -465,10 +484,26 @@ class Daemon:
         return True
 
     def _run_maintenance(self) -> None:
-        """Execute a maintenance pass, recording every outcome and scheduling its retry."""
+        """Execute a maintenance pass, recording every outcome and scheduling its retry.
+
+        Checks `self._stop` between every phase so a pass already in progress when
+        shutdown begins abandons itself promptly instead of running to completion.
+        `shutdown()` joins this thread with a bounded timeout on the assumption that it
+        responds to `_stop` quickly; without these checks a pass could hold the watchdog
+        thread for the sum of every phase (including the engine probe below) regardless
+        of how long ago `_stop` was set. Each abandonment is logged -- a pass that gave up
+        partway through must be visible as such, not indistinguishable from one that
+        quietly ran to completion.
+        """
         from bosn.engine import Engine
         from bosn.gc import Collector
         from bosn.resources import prune_dead_leases
+
+        def abandoned_after(phase: str) -> bool:
+            if not self._stop.is_set():
+                return False
+            self.registry.log_event("maintenance.aborted", f"stop requested after {phase}")
+            return True
 
         self.registry.log_event("maintenance.reap.started")
         try:
@@ -482,6 +517,8 @@ class Daemon:
             self.registry.log_event("maintenance.reap.error", f"{type(exc).__name__}: {exc}")
             self._set_next_maintenance(self.clock.now() + self.maintenance_interval_seconds)
             return
+        if abandoned_after("reap"):
+            return
 
         self.registry.log_event("maintenance.prune_leases.started")
         try:
@@ -493,6 +530,8 @@ class Daemon:
             self.registry.log_event(
                 "maintenance.prune_leases.error", f"{type(exc).__name__}: {exc}"
             )
+        if abandoned_after("prune_leases"):
+            return
 
         # Derived done-signals run before GC (so a workspace reclaimed in this very pass is
         # eligible for the same pass's collection) and before the engine reachability check
@@ -511,9 +550,22 @@ class Daemon:
             self.registry.log_event(
                 "maintenance.derived_done.error", f"{type(exc).__name__}: {exc}"
             )
+        if abandoned_after("derived_done"):
+            return
 
-        engine = Engine(self.engine_binary)
-        info = engine.info()
+        # This probe only answers "is the engine there", so it gets the short named
+        # timeout above rather than Engine's 60s default -- that default is right for the
+        # real GC work below (`engine`, a *separate* instance kept at the normal timeout),
+        # which legitimately needs however long a real docker/podman operation takes.
+        # Reusing one Engine instance and mutating its `.timeout` around this call was
+        # considered and rejected: it would leave a window where a concurrent reader of
+        # `engine.timeout` (there are none today, but the next contributor to touch this
+        # method would have no way to know that) sees the wrong value, for a saving of one
+        # cheap, I/O-free constructor call.
+        probe_engine = Engine(self.engine_binary, timeout=MAINTENANCE_ENGINE_PROBE_TIMEOUT_SECONDS)
+        info = probe_engine.info()
+        if abandoned_after("engine reachability probe"):
+            return
         if not info.reachable:
             detail = info.detail or "engine daemon unreachable"
             self.registry.log_event(
@@ -526,9 +578,12 @@ class Daemon:
             )
             return
 
+        engine = Engine(self.engine_binary)
         self.registry.log_event("maintenance.execution_reap.started")
         reaped = self._reap_dead_execution_sessions()
         self.registry.log_event("maintenance.execution_reap.finished", f"reaped={reaped}")
+        if abandoned_after("execution_reap"):
+            return
 
         self.registry.log_event("maintenance.gc.started")
         try:
@@ -623,8 +678,24 @@ class Daemon:
     def shutdown(self) -> None:
         self._stop.set()
         watchdog = self._watchdog_thread
+        watchdog_finished = True
         if watchdog is not None and watchdog is not threading.current_thread():
-            watchdog.join()
+            # Bounding this join alone -- `watchdog.join(timeout=N)` with no other change
+            # -- was considered and rejected. If the timeout expired the old code would
+            # simply fall through to closing the registry a few lines down while the
+            # watchdog thread was still inside a maintenance pass that reads and writes
+            # through that same connection. That turns a bounded *hang* (annoying, but the
+            # daemon is still internally consistent) into an unbounded *crash*
+            # (`sqlite3.ProgrammingError: Cannot operate on a closed database`, raised from
+            # a background thread with no one positioned to handle it -- worse than the bug
+            # this fix exists to close). A bounded join is only safe once the thing being
+            # joined actually responds to `_stop` promptly, which is what the cooperative
+            # checks in `_run_maintenance` and the short probe timeout above are for. With
+            # those in place this join should essentially always succeed well within
+            # WATCHDOG_JOIN_TIMEOUT_SECONDS; the `else` branch below is the last-resort
+            # fallback for the case where it somehow still doesn't.
+            watchdog.join(timeout=WATCHDOG_JOIN_TIMEOUT_SECONDS)
+            watchdog_finished = not watchdog.is_alive()
         # Cancel in-flight builds and wait for them *before* closing the registry they
         # write to. Each one tells its attached clients why it stopped rather than dying
         # silently.
@@ -641,7 +712,55 @@ class Daemon:
         state_file(self.state_dir).unlink(missing_ok=True)
         heartbeat_file(self.state_dir).unlink(missing_ok=True)
         secret_file(self.state_dir).unlink(missing_ok=True)
+
+        if not watchdog_finished:
+            assert watchdog is not None  # implied by watchdog_finished being set False above
+            # The watchdog is still running past our patience. Closing the registry here
+            # would race whatever it is doing right now -- possibly nothing worse than one
+            # more `log_event`, but there is no way from here to know that, and guessing
+            # wrong means a background-thread crash. So instead of closing, hand the close
+            # off to a thread that waits for the watchdog however long that actually takes
+            # (unbounded is fine: this thread is itself daemonic, so it cannot keep the
+            # process alive) and only then performs the close this method would otherwise
+            # have done immediately below. This should be unreachable in ordinary
+            # operation -- see the comment on the join above -- so reaching it at all is
+            # itself worth a loud, findable event before we return.
+            self.registry.log_event(
+                "shutdown.watchdog_join_timeout",
+                f"watchdog still running after {WATCHDOG_JOIN_TIMEOUT_SECONDS:g}s; "
+                "deferring registry close until it exits",
+            )
+            threading.Thread(
+                target=self._close_registry_after_watchdog, args=(watchdog,), daemon=True
+            ).start()
+            return
+
         try:
+            self.registry.log_event("daemon.stopped", "")
+            self.registry.close()
+        except KeyboardInterrupt:
+            raise
+        except Exception:  # noqa: BLE001 - shutdown must not raise
+            pass
+
+    def _close_registry_after_watchdog(self, watchdog: threading.Thread) -> None:
+        """Finish a shutdown whose bounded watchdog join gave up. See `shutdown()`.
+
+        Reached only from the timeout branch above. Waits for the watchdog with no
+        timeout of its own -- by this point there is nothing left to bound against, the
+        goal is simply to never close the registry while that thread might still be
+        touching it. `shutdown()` may itself run again after spawning this (the
+        `serve_forever`/`served`-fixture pattern of calling `shutdown()` both from
+        `serve_forever`'s `finally` and again explicitly is already relied on elsewhere in
+        this codebase); a second call would see `watchdog_finished` true almost
+        immediately -- since by then this thread will usually have long since joined it --
+        and take the ordinary close path itself. If both somehow race, sqlite's `close()`
+        is a no-op on an already-closed connection and the surrounding `except Exception`
+        here and in `shutdown()` swallow the `log_event` that could otherwise fire twice.
+        """
+        watchdog.join()
+        try:
+            self.registry.log_event("shutdown.watchdog_finished_late", "")
             self.registry.log_event("daemon.stopped", "")
             self.registry.close()
         except KeyboardInterrupt:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -904,7 +904,7 @@ def test_maintenance_catches_up_then_runs_on_the_injected_clock(
     calls: list[str] = []
 
     class ReachableEngine:
-        def __init__(self, _binary: str) -> None:
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
             pass
 
         def info(self) -> EngineInfo:
@@ -952,7 +952,7 @@ def test_maintenance_engine_down_is_visible_and_uses_exponential_backoff(
     clock = FakeClock()
 
     class DownEngine:
-        def __init__(self, _binary: str) -> None:
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
             pass
 
         def info(self) -> EngineInfo:
@@ -975,12 +975,127 @@ def test_maintenance_engine_down_is_visible_and_uses_exponential_backoff(
         daemon.registry.close()
 
 
+def test_maintenance_pass_abandoned_for_stop_is_logged(monkeypatch, tmp_path: Path) -> None:
+    """Issue #97: a pass in progress when shutdown begins must give up, visibly.
+
+    `_stop` is set before the pass even starts here, which is the simplest way to prove
+    the cooperative check fires without needing real threads or timing: the reap phase
+    (deliberately left unpatched, so `maintenance.reap.started`/`.finished` prove the pass
+    did begin) still runs to completion, but everything after the first `abandoned_after`
+    check -- prune_leases, derived_done, the engine probe, GC -- must never start.
+    """
+    clock = FakeClock()
+
+    class ExplodingEngine:
+        """Any construction proves the pass ran past the point it should have stopped."""
+
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
+            raise AssertionError("engine must not be constructed once _stop is set")
+
+    import bosn.engine
+
+    monkeypatch.setattr(bosn.engine, "Engine", ExplodingEngine)
+    daemon = Daemon(state_dir=tmp_path, clock=clock, maintenance_interval_seconds=60)
+    try:
+        daemon._stop.set()
+        daemon._run_maintenance()
+        events = [row["kind"] for row in daemon.registry.events()]
+        assert "maintenance.reap.started" in events
+        assert "maintenance.reap.finished" in events
+        assert "maintenance.aborted" in events
+        detail = next(
+            row["detail"]
+            for row in daemon.registry.events()
+            if row["kind"] == "maintenance.aborted"
+        )
+        assert detail == "stop requested after reap"
+        # Nothing past the abandonment point may have run.
+        assert "maintenance.prune_leases.started" not in events
+        assert "maintenance.derived_done.started" not in events
+        assert "maintenance.gc.started" not in events
+    finally:
+        daemon.registry.close()
+
+
+def test_shutdown_does_not_hang_on_a_blocked_engine_probe(monkeypatch, tmp_path: Path) -> None:
+    """Issue #97: `shutdown()` must not wait out an unbounded engine-reachability probe.
+
+    The old `watchdog.join()` had no timeout at all, so a maintenance pass stuck in
+    `Engine.info()` (60s per call, called up to twice) could block `shutdown()` for up to
+    two minutes. The engine probe is monkeypatched to block on a `threading.Event` this
+    test controls -- deterministic and instant to release, unlike racing a real 60s
+    subprocess timeout -- so the pass hangs indefinitely until the test says otherwise.
+
+    `WATCHDOG_JOIN_TIMEOUT_SECONDS` is monkeypatched down so this test (and the repeated
+    runs the task asks for) stays fast; `shutdown()` reads the module-level constant by
+    name at call time, so patching the module attribute changes what it sees.
+
+    After the bounded shutdown returns, the test releases the blocked probe and lets the
+    watchdog thread actually finish, then asserts no exception escaped it unhandled --
+    proving the deferred-close path did not hand the watchdog a closed registry to write
+    into (`sqlite3.ProgrammingError`-style fallout).
+    """
+    import bosn.engine
+
+    probe_entered = threading.Event()
+    release_probe = threading.Event()
+    exceptions: list[BaseException] = []
+
+    def record_exception(args: threading.ExceptHookArgs) -> None:
+        if args.exc_value is not None:
+            exceptions.append(args.exc_value)
+
+    monkeypatch.setattr(threading, "excepthook", record_exception)
+    # raising=False: on the pre-fix code this constant does not exist at all (the join had
+    # no timeout to configure), and the point of this test is to observe that difference
+    # via the assertions below, not via an AttributeError from monkeypatch itself.
+    monkeypatch.setattr(daemon_mod, "WATCHDOG_JOIN_TIMEOUT_SECONDS", 1.0, raising=False)
+
+    class BlockingEngine:
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
+            pass
+
+        def info(self) -> EngineInfo:
+            probe_entered.set()
+            release_probe.wait(30)
+            return EngineInfo(binary="docker", reachable=True)
+
+    monkeypatch.setattr(bosn.engine, "Engine", BlockingEngine)
+
+    # Deliberately do NOT push the maintenance deadline out -- a fresh registry's first
+    # tick is due immediately, which is exactly the scenario this issue is about.
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    try:
+        assert _wait_until(lambda: daemon_mod.is_serving(tmp_path)), "daemon never came up"
+        assert probe_entered.wait(10), "watchdog never reached the blocked engine probe"
+
+        daemon.request_stop()
+        # thread runs serve_forever() -> finally: self.shutdown(), which does the bounded
+        # watchdog join. A generous outer bound catches a genuine regression without
+        # making the test itself flaky under load.
+        thread.join(timeout=15)
+        assert not thread.is_alive(), "shutdown() hung instead of returning within its bound"
+        assert not daemon_mod.is_serving(tmp_path)
+    finally:
+        # Let the stuck watchdog finish so it does not leak into later tests, and so any
+        # exception it raises is observed by our excepthook above.
+        release_probe.set()
+        watchdog = daemon._watchdog_thread
+        if watchdog is not None:
+            watchdog.join(timeout=15)
+            assert not watchdog.is_alive(), "watchdog never noticed the probe unblocking"
+
+    assert exceptions == [], f"watchdog raised unhandled exception(s): {exceptions}"
+
+
 def test_maintenance_deadline_persists_across_scheduler_wake(monkeypatch, tmp_path: Path) -> None:
     clock = FakeClock()
     calls: list[str] = []
 
     class Engine:
-        def __init__(self, *_args):
+        def __init__(self, *_args, **_kwargs):
             pass
 
         def info(self):
@@ -1026,7 +1141,7 @@ def test_maintenance_logs_prune_leases_started_and_finished(monkeypatch, tmp_pat
     clock = FakeClock()
 
     class ReachableEngine:
-        def __init__(self, _binary: str) -> None:
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
             pass
 
         def info(self) -> EngineInfo:
@@ -1076,7 +1191,7 @@ def test_maintenance_prune_leases_failure_is_logged_and_does_not_block_gc(
     clock = FakeClock()
 
     class ReachableEngine:
-        def __init__(self, _binary: str) -> None:
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
             pass
 
         def info(self) -> EngineInfo:
@@ -1305,7 +1420,7 @@ def test_derived_done_raising_classifier_protects_and_does_not_block_gc(
     clock = FakeClock()
 
     class ReachableEngine:
-        def __init__(self, _binary: str) -> None:
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
             pass
 
         def info(self) -> EngineInfo:


### PR DESCRIPTION
Closes #97. Production behavior fix — the user-facing half of the root cause #95 surfaced.

## The bug

`shutdown()` joined the watchdog thread with **no timeout**. The watchdog runs maintenance; maintenance probes the engine; that probe is 60s per call and can run twice on a host where the docker binary exists but its daemon is unreachable. A stop landing mid-pass blocked for up to ~2 minutes with no output — on exactly the machine already having Docker trouble.

A fresh registry has no stored maintenance deadline, so `_next_maintenance_at` defaults to `started_at` and a pass is due on the **first** watchdog tick. Short-lived daemons are therefore the most exposed, which is the ordinary `bosn up && bosn stop` pattern.

## Why the one-line fix would have been worse

Changing `watchdog.join()` to `watchdog.join(timeout=N)` and nothing else was considered and rejected. When that timeout expires, the thread is still reading and writing through the registry connection that the next few lines then close — converting a bounded *hang* (annoying, but internally consistent) into an unbounded *crash*: `sqlite3.ProgrammingError: Cannot operate on a closed database`, raised from a background thread with nobody positioned to handle it.

A bounded join is only safe once the thing being joined actually responds to `_stop`. So the fix has three parts, in dependency order:

1. **Cooperative stop checks between maintenance phases.** `_run_maintenance` now checks `_stop` after each phase and abandons the pass, logging `maintenance.aborted` with the phase it gave up after — a pass that quit early is visible, not silent.
2. **A bounded reachability probe.** `MAINTENANCE_ENGINE_PROBE_TIMEOUT_SECONDS` gives the liveness check its own short budget. Deliberately scoped: the GC work afterward still uses a normal-timeout `Engine`, because real engine operations legitimately take longer than a liveness question.
3. **Only then, a bounded join** (`WATCHDOG_JOIN_TIMEOUT_SECONDS`, set above the probe budget the watchdog may still be inside).

## The interesting part: what happens if the bounded join still expires

It does **not** close the registry. Closing there would race whatever the watchdog is doing, and there is no way from that point to know it's harmless. Instead the close is handed to a thread that joins the watchdog *without* a bound — safe precisely because that thread is daemonic and so cannot keep the process alive — and closes only once the watchdog is actually gone. Reaching that branch at all logs a loud `shutdown.watchdog_join_timeout`, since it should be unreachable in ordinary operation.

The double-`shutdown()` case (`serve_forever`'s `finally` plus an explicit call, a pattern this codebase already relies on) is handled and documented at the deferred-close helper.

## Verification

- **RED verified independently.** I stashed only `src/bosn/daemon.py` and re-ran: both new tests fail without the fix — one on the hang itself, one because the old code runs straight into engine construction after `_stop` is set. A test that passed both before and after would prove nothing.
- The hang test blocks the probe on a `threading.Event` rather than racing a real 60s timeout, so it's deterministic, and runs with `PytestUnhandledThreadExceptionWarning` promoted to an error — the crash this fix avoids cannot silently return.
- `ci/lint.py` → `LINT OK` (ruff format/check, pyright 0 errors, `lint_kbi`)
- `pytest tests/ -q -m "not docker"` → **965 passed**, 2 skipped
- `tests/test_daemon.py tests/test_daemon_jobs.py` → 74 passed across 3 consecutive runs. These were deflaked in #95 hours ago, so any new instability here would be this change's fault.

## Out of scope, filed separately

`_reconcile_startup_resources` is a sibling fire-and-forget thread with the same unjoined-and-unguarded shape: `shutdown()` never joins it despite a comment claiming it's "cancelled by normal shutdown," and nothing catches what it raises. It surfaces intermittently in full-suite runs as a `PytestUnhandledThreadExceptionWarning` (both `sqlite3.ProgrammingError` and `RuntimeError: program not found` observed). Confirmed pre-existing — I saw it in full-suite runs during the #95 work, before this branch existed. Filed as **#101**; folding it in would have meant changing shutdown semantics twice in one PR.
