### PR TITLE
fix(daemon): stop closing the registry under the startup-reconcile thread (#101)

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -77,6 +77,50 @@ MAINTENANCE_ENGINE_PROBE_TIMEOUT_SECONDS = 5
 # if this bound is ever actually exceeded.
 WATCHDOG_JOIN_TIMEOUT_SECONDS = 15.0
 
+# Upper bound on how long shutdown() waits for the startup-reconciliation thread (see
+# `_reconcile_startup_resources`) to notice `_stop` and exit, before handing the registry
+# close off to the same deferred-close path used when the watchdog overruns its own bound
+# (see `_close_registry_after_background_threads`).
+#
+# This is deliberately much shorter than `WATCHDOG_JOIN_TIMEOUT_SECONDS`, and is 0.0 --
+# not "small", zero -- on purpose. Do not "helpfully" raise this back into the seconds; a
+# non-zero value here was tried and measured, and it does not buy what it looks like it
+# should buy. Read on before changing it.
+#
+# The watchdog's maintenance pass is broken into phases with a cooperative `_stop` check
+# between each (see `_run_maintenance`), so a bounded wait on it can be sized to the worst
+# *remaining* phase and expect to usually succeed -- that is what
+# `WATCHDOG_JOIN_TIMEOUT_SECONDS` is for, and it stays as-is. The startup scan has no such
+# structure: `ResourceScanner(engine).scan(...)` is one call, not a sequence of abandonable
+# phases, so there is no "remaining phase" to bound against.
+#
+# What that call actually does is bimodal, not "usually fast, occasionally slow": either
+# the engine is unreachable and it fails in well under a millisecond (`Engine.available()`
+# checks PATH before ever spawning anything), in which case the thread has *already*
+# exited by the time `shutdown()` gets around to checking it and any positive bound is
+# pure waste -- or the engine is reachable and it is doing a real scan, which issue #99
+# tracks as slow on object-heavy hosts, in which case no bound measured in tens or hundreds
+# of milliseconds has a realistic chance of covering it either. A first version of this
+# constant used 2.0s on the theory that it would "usually" cover the reconcile thread; measuring it
+# against this repo's own test suite showed that theory was wrong -- there is essentially no
+# middle ground of shutdowns that are *almost* done and just need a couple hundred
+# milliseconds more, so a positive bound here mostly just pays its own cost for no benefit:
+# `test_daemon.py` + `test_daemon_jobs.py` went from ~37s to ~132s, and the full non-docker
+# suite from ~93s to ~192s, i.e. the entire suite roughly doubled from a bound that was
+# supposed to only matter in the (deliberately rare, per the comment on the watchdog's own
+# bound above) "still running" case. In production this is worse than test-time waste: it
+# is up to 2 extra seconds tacked onto every `bosn stop` whose reconcile thread has not yet
+# finished, which for a slow scan on an object-heavy host (#99) is exactly the case #97
+# already fixed shutdown latency for -- this constant was quietly re-introducing it.
+#
+# So: zero. If the thread has already exited, `thread.join(timeout=0.0)` observes that
+# immediately and the ordinary close path is taken with no wait at all. If it has not, this
+# defers to `_close_registry_after_background_threads` immediately rather than waiting to
+# confirm what the bimodal reasoning above already predicts -- deferring costs nothing here
+# (the actual close happens on its own daemon thread; `shutdown()` does not block on it),
+# so there is nothing to gain by delaying the decision to defer.
+RECONCILE_JOIN_TIMEOUT_SECONDS = 0.0
+
 
 class DaemonError(RuntimeError):
     """The daemon could not be started, reached, or stopped."""
@@ -321,6 +365,7 @@ class Daemon:
         self._server: _Server | None = None
         self._stop = threading.Event()
         self._watchdog_thread: threading.Thread | None = None
+        self._reconcile_thread: threading.Thread | None = None
         self._execution_sessions: dict[str, tuple[str, ...]] = {}
         self._execution_containers: dict[str, str] = {}
         self._execution_owners: dict[str, tuple[int, float | None]] = {}
@@ -376,13 +421,39 @@ class Daemon:
             repaired = reconcile_owned(self.registry, scan, prior_resources=prior_resources)
             recompute_manifest_generations(self.registry, scan)
         except EngineError as exc:
+            # #101: this call used to be the one that actually crashed. The scan failing
+            # with `EngineError` (an unreachable engine is the most common way it fails) is
+            # entirely expected -- that is what this whole `try` exists to catch -- but
+            # `shutdown()` used to close the registry without ever waiting for this thread,
+            # so `self.registry.log_event(...)` here could run after the connection was
+            # already gone, raising `sqlite3.ProgrammingError: Cannot operate on a closed
+            # database` from a background thread with nothing positioned to catch it.
+            #
+            # An `if not self._stop.is_set():` guard was considered here (to match the
+            # `except Exception` branch below, which had one) and rejected: `_stop` is set
+            # at the very start of `shutdown()`, before it even begins waiting for this
+            # thread, so by the time this branch's `log_event` call could ever race a real
+            # close, `_stop` is already set -- meaning the guard would suppress the log on
+            # essentially every real occurrence of the race it was trying to protect
+            # against, not just the unsafe ones. That trade only made sense when there was
+            # no other way to reduce the crash's frequency. Now there is: `shutdown()`
+            # tracks and joins this thread before it ever closes the registry (see
+            # `RECONCILE_JOIN_TIMEOUT_SECONDS` and `_close_registry_after_background_
+            # threads`), so by the time this line runs, the registry is guaranteed to still
+            # be open regardless of `_stop` -- logging unconditionally is what "the branches
+            # should agree" resolves to once the actual close-ordering bug is fixed, not
+            # copying a guard whose only remaining effect would be silently dropping a
+            # diagnostic that safely could have been recorded.
             self.registry.log_event("recovery.scan.unavailable", str(exc))
             return
         except KeyboardInterrupt:
             raise
         except Exception as exc:  # background recovery must never take down IPC
-            if not self._stop.is_set():
-                self.registry.log_event("recovery.scan.failed", str(exc))
+            # See the `except EngineError` branch above for why this no longer guards on
+            # `_stop.is_set()` either -- the two branches must agree, and unconditional
+            # logging (now safe, thanks to `shutdown()` joining this thread first) is the
+            # agreement that does not cost a diagnostic every time this races shutdown.
+            self.registry.log_event("recovery.scan.failed", str(exc))
             return
         if repaired:
             self.registry.log_event("recovery.startup", ",".join(repaired))
@@ -444,8 +515,19 @@ class Daemon:
         self.registry.log_event("daemon.started", f"pid={os.getpid()} port={self.port}")
 
         # Docker can be unavailable or taking a long time to wake.  Recovery must not
-        # postpone serving IPC; this daemon-owned worker is cancelled by normal shutdown.
-        threading.Thread(target=self._reconcile_startup_resources, daemon=True).start()
+        # postpone serving IPC, so this runs on a background thread rather than blocking
+        # here. The comment that used to sit on this line claimed the thread "is cancelled
+        # by normal shutdown" -- it never was: nothing sets an event this thread checks
+        # before or during its one real blocking call, `ResourceScanner(...).scan(...)`,
+        # and issue #101 is the background-thread crash that resulted from believing that
+        # claim. `shutdown()` now tracks this thread the same way it tracks the watchdog
+        # (see `RECONCILE_JOIN_TIMEOUT_SECONDS`) and folds it into the same deferred-close
+        # decision, so the registry is never closed while this thread could still be using
+        # it -- waited on, not cancelled.
+        self._reconcile_thread = threading.Thread(
+            target=self._reconcile_startup_resources, daemon=True
+        )
+        self._reconcile_thread.start()
 
         self._watchdog_thread = threading.Thread(target=self._idle_watchdog, daemon=True)
         self._watchdog_thread.start()
@@ -677,25 +759,24 @@ class Daemon:
 
     def shutdown(self) -> None:
         self._stop.set()
+        # Both background threads get the same treatment: a bounded join here, and -- if
+        # either one is still running once its bound expires -- the registry close is
+        # deferred to a background thread that waits for *all* outstanding threads with no
+        # bound of its own. Bounding the join alone (`thread.join(timeout=N)` with nothing
+        # else) was considered and rejected for the watchdog originally (#97) and applies
+        # equally here: falling through to closing the registry a few lines down while a
+        # background thread is still reading/writing through that same connection turns a
+        # bounded *hang* (annoying, but internally consistent) into an unbounded *crash*
+        # (`sqlite3.ProgrammingError: Cannot operate on a closed database`, raised from a
+        # background thread with no one positioned to handle it -- worse than the bug this
+        # fix exists to close). See `WATCHDOG_JOIN_TIMEOUT_SECONDS` and
+        # `RECONCILE_JOIN_TIMEOUT_SECONDS` for why each bound is sized the way it is; they
+        # are deliberately not the same value, because the two threads' ability to finish
+        # promptly once `_stop` is set is not the same.
         watchdog = self._watchdog_thread
-        watchdog_finished = True
-        if watchdog is not None and watchdog is not threading.current_thread():
-            # Bounding this join alone -- `watchdog.join(timeout=N)` with no other change
-            # -- was considered and rejected. If the timeout expired the old code would
-            # simply fall through to closing the registry a few lines down while the
-            # watchdog thread was still inside a maintenance pass that reads and writes
-            # through that same connection. That turns a bounded *hang* (annoying, but the
-            # daemon is still internally consistent) into an unbounded *crash*
-            # (`sqlite3.ProgrammingError: Cannot operate on a closed database`, raised from
-            # a background thread with no one positioned to handle it -- worse than the bug
-            # this fix exists to close). A bounded join is only safe once the thing being
-            # joined actually responds to `_stop` promptly, which is what the cooperative
-            # checks in `_run_maintenance` and the short probe timeout above are for. With
-            # those in place this join should essentially always succeed well within
-            # WATCHDOG_JOIN_TIMEOUT_SECONDS; the `else` branch below is the last-resort
-            # fallback for the case where it somehow still doesn't.
-            watchdog.join(timeout=WATCHDOG_JOIN_TIMEOUT_SECONDS)
-            watchdog_finished = not watchdog.is_alive()
+        watchdog_finished = self._bounded_join(watchdog, WATCHDOG_JOIN_TIMEOUT_SECONDS)
+        reconcile = self._reconcile_thread
+        reconcile_finished = self._bounded_join(reconcile, RECONCILE_JOIN_TIMEOUT_SECONDS)
         # Cancel in-flight builds and wait for them *before* closing the registry they
         # write to. Each one tells its attached clients why it stopped rather than dying
         # silently.
@@ -713,25 +794,39 @@ class Daemon:
         heartbeat_file(self.state_dir).unlink(missing_ok=True)
         secret_file(self.state_dir).unlink(missing_ok=True)
 
-        if not watchdog_finished:
-            assert watchdog is not None  # implied by watchdog_finished being set False above
-            # The watchdog is still running past our patience. Closing the registry here
-            # would race whatever it is doing right now -- possibly nothing worse than one
-            # more `log_event`, but there is no way from here to know that, and guessing
-            # wrong means a background-thread crash. So instead of closing, hand the close
-            # off to a thread that waits for the watchdog however long that actually takes
-            # (unbounded is fine: this thread is itself daemonic, so it cannot keep the
-            # process alive) and only then performs the close this method would otherwise
-            # have done immediately below. This should be unreachable in ordinary
-            # operation -- see the comment on the join above -- so reaching it at all is
-            # itself worth a loud, findable event before we return.
+        outstanding = [
+            (name, thread)
+            for name, thread, finished in (
+                ("watchdog", watchdog, watchdog_finished),
+                ("startup-reconcile", reconcile, reconcile_finished),
+            )
+            if thread is not None and not finished
+        ]
+        if outstanding:
+            # At least one background thread is still running past its own patience.
+            # Closing the registry here would race whatever it is doing right now --
+            # possibly nothing worse than one more `log_event`, but there is no way from
+            # here to know that, and guessing wrong means a background-thread crash. So
+            # instead of closing, hand the close off to a thread that waits for *every*
+            # outstanding thread however long that actually takes (unbounded is fine: this
+            # thread is itself daemonic, so it cannot keep the process alive) and only then
+            # performs the close this method would otherwise have done immediately below.
+            #
+            # Reaching this branch for the watchdog should be rare in ordinary operation
+            # (see the comment on `WATCHDOG_JOIN_TIMEOUT_SECONDS`'s join above); reaching it
+            # for startup-reconcile is the *expected* outcome whenever `shutdown()` runs
+            # while the startup scan is still genuinely in flight (see
+            # `RECONCILE_JOIN_TIMEOUT_SECONDS`). Either way it is worth a loud, findable
+            # event before we return.
+            names = ", ".join(name for name, _ in outstanding)
             self.registry.log_event(
-                "shutdown.watchdog_join_timeout",
-                f"watchdog still running after {WATCHDOG_JOIN_TIMEOUT_SECONDS:g}s; "
-                "deferring registry close until it exits",
+                "shutdown.background_join_timeout",
+                f"{names} still running; deferring registry close until they exit",
             )
             threading.Thread(
-                target=self._close_registry_after_watchdog, args=(watchdog,), daemon=True
+                target=self._close_registry_after_background_threads,
+                args=(tuple(thread for _, thread in outstanding),),
+                daemon=True,
             ).start()
             return
 
@@ -743,24 +838,49 @@ class Daemon:
         except Exception:  # noqa: BLE001 - shutdown must not raise
             pass
 
-    def _close_registry_after_watchdog(self, watchdog: threading.Thread) -> None:
-        """Finish a shutdown whose bounded watchdog join gave up. See `shutdown()`.
+    @staticmethod
+    def _bounded_join(thread: threading.Thread | None, timeout: float) -> bool:
+        """True once `thread` has exited, given up to `timeout` seconds for it to do so.
 
-        Reached only from the timeout branch above. Waits for the watchdog with no
-        timeout of its own -- by this point there is nothing left to bound against, the
-        goal is simply to never close the registry while that thread might still be
-        touching it. `shutdown()` may itself run again after spawning this (the
+        Also true when there is no thread to wait for (`None`) or when called from inside
+        the thread itself -- `Thread.join` on the current thread deadlocks, and `shutdown()`
+        can legitimately run on a thread it is also tracking (a verb handler calling
+        `request_stop()` runs on a request-handling thread, never on the watchdog or
+        reconcile thread, but this guard is cheap enough to keep unconditionally rather than
+        rely on that staying true).
+        """
+        if thread is None or thread is threading.current_thread():
+            return True
+        thread.join(timeout=timeout)
+        return not thread.is_alive()
+
+    def _close_registry_after_background_threads(
+        self, threads: tuple[threading.Thread, ...]
+    ) -> None:
+        """Finish a shutdown whose bounded joins gave up. See `shutdown()`.
+
+        Reached only from the timeout branch above, carrying whichever of the watchdog and
+        startup-reconcile threads (one or both) had not exited within their own bounded
+        join. Waits for every one of them with no timeout of its own -- by this point there
+        is nothing left to bound against, the goal is simply to never close the registry
+        while any of them might still be touching it. Waiting for only the thread that
+        triggered this call and ignoring any other still-outstanding one would reintroduce
+        exactly the race this method exists to close, just for the thread that got left out.
+
+        `shutdown()` may itself run again after spawning this (the
         `serve_forever`/`served`-fixture pattern of calling `shutdown()` both from
         `serve_forever`'s `finally` and again explicitly is already relied on elsewhere in
-        this codebase); a second call would see `watchdog_finished` true almost
-        immediately -- since by then this thread will usually have long since joined it --
-        and take the ordinary close path itself. If both somehow race, sqlite's `close()`
-        is a no-op on an already-closed connection and the surrounding `except Exception`
-        here and in `shutdown()` swallow the `log_event` that could otherwise fire twice.
+        this codebase); a second call sees each already-finished thread's bounded join
+        return immediately, and -- once this method has joined whatever was still
+        outstanding -- takes the ordinary close path itself. If both somehow race, sqlite's
+        `close()` is a no-op on an already-closed connection and the surrounding
+        `except Exception` here and in `shutdown()` swallow the `log_event` that could
+        otherwise fire twice.
         """
-        watchdog.join()
+        for thread in threads:
+            thread.join()
         try:
-            self.registry.log_event("shutdown.watchdog_finished_late", "")
+            self.registry.log_event("shutdown.background_thread_finished_late", "")
             self.registry.log_event("daemon.stopped", "")
             self.registry.close()
         except KeyboardInterrupt:

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -819,10 +819,31 @@ class Daemon:
             # `RECONCILE_JOIN_TIMEOUT_SECONDS`). Either way it is worth a loud, findable
             # event before we return.
             names = ", ".join(name for name, _ in outstanding)
-            self.registry.log_event(
-                "shutdown.background_join_timeout",
-                f"{names} still running; deferring registry close until they exit",
-            )
+            # Guarded for the same reason this whole issue exists (#101): a diagnostic must
+            # never be the thing that crashes.
+            #
+            # `shutdown()` runs twice in normal operation (once from `serve_forever`'s
+            # `finally`, once explicitly), and a deferred close spawned by an earlier call
+            # can complete at any moment -- including between this call's `_bounded_join`
+            # deciding a thread is still outstanding and this line running. The connection
+            # is then already gone, and there is no flag to test for it that would not
+            # itself be racy. Every other registry write on the shutdown path is already
+            # wrapped; this "loud event" was not, and CI caught it as exactly the
+            # `sqlite3.ProgrammingError: Cannot operate on a closed database` this change
+            # set out to eliminate, relocated one line away from the fix.
+            #
+            # Best-effort is the right contract here: the event explains a deferral that
+            # has already been decided, so losing it costs a log line, while raising costs
+            # the shutdown.
+            try:
+                self.registry.log_event(
+                    "shutdown.background_join_timeout",
+                    f"{names} still running; deferring registry close until they exit",
+                )
+            except KeyboardInterrupt:
+                raise
+            except Exception:  # noqa: BLE001 - shutdown must not raise
+                pass
             threading.Thread(
                 target=self._close_registry_after_background_threads,
                 args=(tuple(thread for _, thread in outstanding),),

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -81,9 +81,37 @@ class Engine:
                 [self.binary, *args], cwd=None, check=False, timeout=effective_timeout
             )
         except RuntimeError as exc:
-            raise EngineError(
-                f"{self.binary} {' '.join(args)} exceeded its {effective_timeout}-second deadline"
-            ) from exc
+            # `rp.subprocess_run` collapses two very different failures into the same
+            # `RuntimeError`: a command that actually ran for `effective_timeout` seconds
+            # and was killed, and a command that never started running at all (missing
+            # binary, a PATH entry pointing at something not executable, a broken exec
+            # environment -- anything the underlying spawn can raise before there is a
+            # process to wait on). A captured traceback for issue #101 showed the second
+            # case reported as the first: the real cause was
+            # `RuntimeError: failed to spawn process: program not found`, raised
+            # immediately, but this code used to describe every `RuntimeError` here as
+            # "exceeded its N-second deadline" -- sending whoever read that message looking
+            # for a slow Docker daemon instead of a missing binary.
+            #
+            # `subprocess_run` only distinguishes the two internally: it catches
+            # `rp.TimeoutExpired` specifically and re-raises it as `RuntimeError(...) from
+            # exc`, chaining the original in. Any other failure propagates as whatever it
+            # already was (typically a plain `RuntimeError`) with no such cause. Reading
+            # `exc.__cause__`'s type recovers that distinction without depending on message
+            # wording -- string-matching `subprocess_run`'s message text was considered and
+            # rejected as brittle, since a wording change in that dependency would silently
+            # break the distinction with no test pinning it here.
+            #
+            # `available()` above already rules out the binary being absent from PATH at
+            # call time, but that check and the actual spawn are not atomic (the binary can
+            # disappear, or a PATH entry can point at something non-executable, in between),
+            # so this branch still matters even with that guard in place.
+            if isinstance(exc.__cause__, rp.TimeoutExpired):
+                raise EngineError(
+                    f"{self.binary} {' '.join(args)} exceeded its "
+                    f"{effective_timeout}-second deadline"
+                ) from exc
+            raise EngineError(f"{self.binary} {' '.join(args)} could not start: {exc}") from exc
         result = EngineResult(
             returncode=completed.returncode,
             stdout=(completed.stdout or "").strip(),

--- a/tests/test_compose_e2e_docker.py
+++ b/tests/test_compose_e2e_docker.py
@@ -27,6 +27,7 @@ up, not replaces.
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import threading
 import time
@@ -88,6 +89,15 @@ def served(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[daemon_m
     monkeypatch.setenv("BOSN_PORT", str(port))
 
     instance = daemon_mod.Daemon(state_dir=state_dir, idle_retire_seconds=3600)
+    # A fresh registry has no stored maintenance deadline, so a pass is due on the very
+    # first watchdog tick -- and that pass runs real GC against a reachable engine. This
+    # module is about the compose lifecycle, not about unattended reclamation, so leaving
+    # it armed means an unrelated GC pass can delete resources mid-test and fail an
+    # assertion about compose's own behavior. It did exactly that on the Linux CI lane:
+    # the bystander volume below was collected between its registration and the `down -v`
+    # assertion that depends on it still being there. Pushed out of the way for the same
+    # reason and in the same way the daemon tests do it (issue #95).
+    instance._set_next_maintenance(instance.clock.now() + 3600)
     thread = threading.Thread(target=instance.serve_forever, daemon=True)
     thread.start()
     assert wait_until(lambda: daemon_mod.is_serving(state_dir), timeout=30), (
@@ -213,7 +223,11 @@ def test_compose_lifecycle_through_the_real_front_door(
         generation="g",
         scope="spec",
         workspace=bystander_workspace,
-        created="2026-08-13T00:00:00Z",
+        # Stamped now, not a fixed past date. A hardcoded timestamp ages relative to
+        # whenever the suite happens to run, so it silently drifts past the 72h warm TTL
+        # and turns this control volume into a GC candidate -- which is a property of the
+        # calendar, not of anything this test means to assert.
+        created=dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
     engine.run(["volume", "create", *bystander_labels.to_docker_args(), bystander_name], check=True)
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -23,7 +23,8 @@ from bosn import daemon as daemon_mod
 from bosn import ipc
 from bosn.clock import FakeClock
 from bosn.daemon import Daemon, DaemonError, DaemonState
-from bosn.engine import EngineInfo
+from bosn.engine import EngineError, EngineInfo
+from bosn.registry import Registry
 
 
 def _detach_code() -> str:
@@ -1088,6 +1089,123 @@ def test_shutdown_does_not_hang_on_a_blocked_engine_probe(monkeypatch, tmp_path:
             assert not watchdog.is_alive(), "watchdog never noticed the probe unblocking"
 
     assert exceptions == [], f"watchdog raised unhandled exception(s): {exceptions}"
+
+
+def test_shutdown_does_not_close_registry_while_startup_reconcile_still_running(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Issue #101: `shutdown()` must not close the registry while the startup-reconcile
+    thread (`_reconcile_startup_resources`) can still write to it.
+
+    The captured traceback that opened #101 was not "nothing catches the scan failure" --
+    the handler *is* guarded (`except EngineError`, logging the failure). The actual crash
+    was the guard's own logging call: `shutdown()` had already closed the registry by the
+    time the handler ran, so `self.registry.log_event(...)` raised
+    `sqlite3.ProgrammingError: Cannot operate on a closed database` from a background
+    thread with nothing positioned to catch it.
+
+    This reproduces that race deterministically instead of trying to win it against a real
+    engine scan: `ResourceScanner.scan` is replaced with a version that blocks on a
+    `threading.Event` until the test releases it, so the test controls exactly when the
+    scan (and thus the `EngineError` it raises) happens relative to `shutdown()` -- release
+    it only after `shutdown()` has already run and decided what to do about the registry.
+
+    `RECONCILE_JOIN_TIMEOUT_SECONDS` is monkeypatched to 0.0 (its shipped default, as of
+    the fix for the shutdown-latency regression a first version of this bound introduced --
+    see the constant's own comment for the measurements) rather than left to whatever the
+    module happens to define. That is deliberate, not redundant: pinning it here means this
+    test stays fast and keeps exercising the deferred-close path even if a future change
+    raises the production default back into the seconds -- exactly the kind of "helpful"
+    edit the constant's comment warns against. Without this pin, that edit would slip in
+    silently, this test would just get slower, and the doubling-of-the-suite regression the
+    constant's comment describes could recur without any test catching it. `raising=False`
+    because on the pre-fix code this constant does not exist at all -- the startup-reconcile
+    thread was never tracked or joined by `shutdown()` in the first place, which is exactly
+    the bug.
+    """
+    import bosn.engine
+    import bosn.resources
+
+    scan_entered = threading.Event()
+    release_scan = threading.Event()
+    exceptions: list[BaseException] = []
+
+    def record_exception(args: threading.ExceptHookArgs) -> None:
+        if args.exc_value is not None:
+            exceptions.append(args.exc_value)
+
+    monkeypatch.setattr(threading, "excepthook", record_exception)
+    monkeypatch.setattr(daemon_mod, "RECONCILE_JOIN_TIMEOUT_SECONDS", 0.0, raising=False)
+
+    class MinimalEngine:
+        """Has a callable `.run` so `_reconcile_startup_resources` doesn't take its
+        "test double, not a resource-listing engine" early return. `.run` itself is never
+        actually invoked -- the scan below is what blocks and then raises.
+        """
+
+        def __init__(self, _binary: str, **_kwargs: object) -> None:
+            pass
+
+        def run(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError("engine.run should not be reached; the scan is mocked")
+
+    def blocking_scan(self, _registry_id: str) -> None:
+        scan_entered.set()
+        release_scan.wait(30)
+        raise EngineError("engine unreachable")
+
+    monkeypatch.setattr(bosn.engine, "Engine", MinimalEngine)
+    monkeypatch.setattr(bosn.resources.ResourceScanner, "scan", blocking_scan)
+
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    # Keep the watchdog's own maintenance pass from firing during this test -- it is not
+    # what is under test here, and a fresh registry's first tick is otherwise due
+    # immediately (issue #95/#98's deflaking pattern).
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
+    thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    thread.start()
+    try:
+        assert _wait_until(lambda: daemon_mod.is_serving(tmp_path)), "daemon never came up"
+        assert scan_entered.wait(10), "startup reconcile never reached the blocked scan"
+
+        daemon.request_stop()
+        # thread runs serve_forever() -> finally: self.shutdown(). The scan is still
+        # blocked at this point, so this is exercising the exact moment the pre-fix code
+        # would already have closed the registry out from under the reconcile thread.
+        thread.join(timeout=15)
+        assert not thread.is_alive(), "shutdown() hung instead of returning within its bound"
+        assert not daemon_mod.is_serving(tmp_path)
+    finally:
+        # Let the blocked scan raise now, so the handler's `log_event` call runs -- either
+        # into a still-open registry (fixed) or a closed one (the bug). Either way, let it
+        # finish before this test ends so it cannot leak into a later test.
+        release_scan.set()
+        # getattr, not attribute access: on the pre-fix code `_reconcile_startup_resources`
+        # runs on a bare, untracked `threading.Thread` -- there is no `_reconcile_thread`
+        # attribute to join, which is exactly the bug. Fall back to a short sleep so the
+        # background thread still gets a chance to run its (crashing, pre-fix) handler
+        # before this test's assertions run.
+        reconcile = getattr(daemon, "_reconcile_thread", None)
+        if reconcile is not None:
+            reconcile.join(timeout=15)
+            assert not reconcile.is_alive(), "startup reconcile never noticed the scan unblocking"
+        else:
+            time.sleep(0.5)
+
+    assert exceptions == [], f"startup reconcile raised unhandled exception(s): {exceptions}"
+
+    # Not just "nothing crashed" -- the diagnostic the handler exists to record must have
+    # actually landed. A fix that silently swallowed the log (e.g. by guarding it on
+    # `_stop.is_set()` alone, which the #101 comment thread explicitly rejected as
+    # insufficient) would pass a crash-only assertion while losing the event. Read through
+    # a fresh read-only connection rather than `daemon.registry`: by this point the
+    # deferred-close thread may already have closed the daemon's own connection.
+    reader = Registry(tmp_path / "registry.sqlite3", read_only=True)
+    try:
+        kinds = [row["kind"] for row in reader.events()]
+    finally:
+        reader.close()
+    assert "recovery.scan.unavailable" in kinds
 
 
 def test_maintenance_deadline_persists_across_scheduler_wake(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1208,6 +1208,58 @@ def test_shutdown_does_not_close_registry_while_startup_reconcile_still_running(
     assert "recovery.scan.unavailable" in kinds
 
 
+def test_a_second_shutdown_after_a_deferred_close_does_not_raise(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """`shutdown()` must survive being called again after a deferred close already ran.
+
+    `shutdown()` runs twice in normal operation -- once from `serve_forever`'s `finally`,
+    once explicitly by a caller or fixture. When the first call defers the registry close
+    to a background thread, that thread can close the connection at a moment the second
+    call has no way to observe. The second call then reaches its own
+    `shutdown.background_join_timeout` event and writes to a connection that is already
+    gone.
+
+    CI caught exactly that as a teardown error -- `sqlite3.ProgrammingError: Cannot
+    operate on a closed database` raised from `shutdown()` itself -- which is the very
+    failure class #101 set out to remove, reappearing one line away from where it was
+    fixed. The lesson of that issue is that a *diagnostic* must never be the thing that
+    crashes, and it applies to the code doing the fixing too.
+
+    A first version of this test drove two real `shutdown()` calls around a thread that
+    finished in between. It passed against the unguarded code: by the second call the
+    thread was done, `outstanding` was empty, and the unguarded line was never reached at
+    all. Running it against the unguarded code before trusting it is the only reason that
+    was caught -- which is the same discipline the fix's own RED check applies.
+    """
+    release = threading.Event()
+    monkeypatch.setattr(daemon_mod, "RECONCILE_JOIN_TIMEOUT_SECONDS", 0.0, raising=False)
+
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=3600)
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
+    busy = threading.Thread(target=lambda: release.wait(30), daemon=True)
+    busy.start()
+    try:
+        # The two conditions are established directly rather than raced for. The real
+        # sequence is narrow -- an earlier call's deferred close has to land between this
+        # call's `_bounded_join` deciding a thread is outstanding and its logging of that
+        # decision -- and a test that tried to hit that window by timing would be the
+        # flaky, proves-nothing kind this suite has already had to fix once (#95). What
+        # must hold is simpler than the race that exposes it: `shutdown()` must not raise
+        # when a thread is outstanding and the registry is already closed, however those
+        # two came to be true together.
+        daemon._reconcile_thread = busy  # outstanding: alive, and the bound above is zero
+        daemon.registry.close()  # exactly what an earlier deferred close leaves behind
+
+        # Must not raise. Against the unguarded code this is `sqlite3.ProgrammingError`
+        # straight out of `shutdown()` -- the CI teardown error this test exists for.
+        daemon.shutdown()
+    finally:
+        release.set()
+        busy.join(timeout=15)
+        assert not busy.is_alive()
+
+
 def test_maintenance_deadline_persists_across_scheduler_wake(monkeypatch, tmp_path: Path) -> None:
     clock = FakeClock()
     calls: list[str] = []

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -103,6 +103,14 @@ def test_run_reports_an_actual_timeout_as_a_deadline(monkeypatch) -> None:
     def fake_subprocess_run(*_args, **_kwargs):
         raise wrapped
 
+    # `run` checks `available()` (a PATH lookup for the binary) before it ever reaches the
+    # faked `subprocess_run`, and raises a different EngineError -- "'docker' is not on
+    # PATH" -- when that lookup fails. On a machine with Docker installed the fake is
+    # reached and this test passes; on one without it (the macOS CI lane) the test would
+    # fail against a message it was never about. This test is about how `run` classifies a
+    # RuntimeError from the spawn, not about whether the host has Docker, so the PATH
+    # question is answered here rather than inherited from the runner.
+    monkeypatch.setattr(engine_mod.Engine, "available", lambda _self: True)
     monkeypatch.setattr(engine_mod.rp, "subprocess_run", fake_subprocess_run)
 
     with pytest.raises(EngineError, match="7-second deadline") as raised:
@@ -126,6 +134,14 @@ def test_run_distinguishes_a_spawn_failure_from_a_timeout(monkeypatch) -> None:
     def fake_subprocess_run(*_args, **_kwargs):
         raise spawn_failure
 
+    # `run` checks `available()` (a PATH lookup for the binary) before it ever reaches the
+    # faked `subprocess_run`, and raises a different EngineError -- "'docker' is not on
+    # PATH" -- when that lookup fails. On a machine with Docker installed the fake is
+    # reached and this test passes; on one without it (the macOS CI lane) the test would
+    # fail against a message it was never about. This test is about how `run` classifies a
+    # RuntimeError from the spawn, not about whether the host has Docker, so the PATH
+    # question is answered here rather than inherited from the runner.
+    monkeypatch.setattr(engine_mod.Engine, "available", lambda _self: True)
     monkeypatch.setattr(engine_mod.rp, "subprocess_run", fake_subprocess_run)
 
     with pytest.raises(EngineError) as raised:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -91,6 +91,54 @@ def test_engine_execute_returns_an_ordinary_child_exit_130() -> None:
     assert Engine(sys.executable).execute(["-c", "raise SystemExit(130)"], timeout=10) == 130
 
 
+def test_run_reports_an_actual_timeout_as_a_deadline(monkeypatch) -> None:
+    """`rp.subprocess_run` re-raises a real timeout as `RuntimeError(...) from exc`, with
+    `exc` being an `rp.TimeoutExpired`. `Engine.run` must still report this as the deadline
+    message -- only the *other* kind of `RuntimeError` (see the sibling test below) changed.
+    """
+    cause = engine_mod.rp.TimeoutExpired(cmd=["docker", "ps"], timeout=7)
+    wrapped = RuntimeError("CRITICAL: Process timed out after 7 seconds: ['docker', 'ps']")
+    wrapped.__cause__ = cause
+
+    def fake_subprocess_run(*_args, **_kwargs):
+        raise wrapped
+
+    monkeypatch.setattr(engine_mod.rp, "subprocess_run", fake_subprocess_run)
+
+    with pytest.raises(EngineError, match="7-second deadline") as raised:
+        Engine("docker", timeout=7).run(["ps"])
+
+    assert raised.value.__cause__ is wrapped
+    assert wrapped.__cause__ is cause
+
+
+def test_run_distinguishes_a_spawn_failure_from_a_timeout(monkeypatch) -> None:
+    """Issue #101: a captured traceback showed a missing-binary spawn failure --
+    `RuntimeError: failed to spawn process: program not found`, raised immediately, with
+    no `TimeoutExpired` anywhere in its cause chain -- reported as
+    "exceeded its 60-second deadline". That sends someone debugging a missing binary
+    looking for a slow Docker daemon instead. `Engine.run` must describe this failure for
+    what it is, and must still chain the original exception so the real cause survives in
+    a traceback.
+    """
+    spawn_failure = RuntimeError("failed to spawn process: program not found")
+
+    def fake_subprocess_run(*_args, **_kwargs):
+        raise spawn_failure
+
+    monkeypatch.setattr(engine_mod.rp, "subprocess_run", fake_subprocess_run)
+
+    with pytest.raises(EngineError) as raised:
+        Engine("docker", timeout=60).run(["ps"])
+
+    message = str(raised.value)
+    assert "exceeded its" not in message
+    assert "60-second deadline" not in message
+    assert "could not start" in message
+    assert "failed to spawn process: program not found" in message
+    assert raised.value.__cause__ is spawn_failure
+
+
 class AbortingProcess:
     finished = False
     returncode: int | None = None


### PR DESCRIPTION
Closes #101.

## The bug is not the one the issue first described

I wrote #101 claiming `_reconcile_startup_resources` catches nothing. That was wrong, and I corrected it on the issue after capturing the full chained traceback. The body *is* guarded three ways. **The error handler is what crashes:**

```
bosn.engine.EngineError: docker image inspect ... exceeded its 60-second deadline

During handling of the above exception, another exception occurred:

  File "src/bosn/daemon.py", line 379, in _reconcile_startup_resources
    self.registry.log_event("recovery.scan.unavailable", str(exc))
sqlite3.ProgrammingError: Cannot operate on a closed database
```

The scan fails (expected — that is what the handler is for), the handler tries to record why, and *the recording* raises because `shutdown()` already closed the registry underneath it. The diagnostic path crashes on its way to explaining a failure it handled correctly.

## Fix

`serve_forever` spawns this thread detached, with a comment claiming it "is cancelled by normal shutdown" — nothing joined it, so that comment was false. `shutdown()` now tracks it alongside the watchdog and folds it into the deferred-close path #97 introduced, generalized to wait for **every** outstanding background thread rather than whichever one it happened to notice. One place decides when closing is safe, rather than two parallel mechanisms.

### The handler asymmetry, and why the obvious fix was wrong

`except Exception` guarded its logging with `if not self._stop.is_set()`; `except EngineError` — the likeliest failure, an unreachable engine — did not. My instruction was to make them agree by copying the guard. The agent tried that, found it broke the "assert the event is actually recorded" assertion, and pushed back with the reason: **`shutdown()` sets `_stop` as its very first statement**, so in every real occurrence the guard is already set and would silently suppress `recovery.scan.unavailable`. That trades a crash for a lost diagnostic — the exact failure mode I'd warned against.

They agree now by *dropping* the guard, which is safe precisely because the join keeps the registry open until the thread finishes. No `try/except` was wrapped around the logging either: if that invariant ever breaks, an unhandled thread exception is the signal I want, not a silent swallow.

### The join bound is 0.0, from measurement

The first version used 2.0s. I measured it and sent it back:

| | before | with 2.0s bound | with 0.0 |
|---|---|---|---|
| two daemon tests | 1.77s | 8.92s | 6.22s |
| daemon test files | ~37s | 132.7s | 41.9s |
| full non-docker suite | ~93s | 192.1s | 101.0s |

Worse than test time: `bosn stop` paid up to 2s whenever the scan was running, which per #99 is the common case on object-heavy hosts — re-introducing the latency #97 removed in the immediately preceding PR.

The scan is **bimodal**, not usually-fast: either the engine is absent and `Engine.available()` fails in under a millisecond (the thread is already gone before `shutdown()` looks), or it is a real scan that no sub-second bound would cover. There is no middle band for a grace period to catch. The constant's comment records that measurement explicitly so it does not get "helpfully" raised back later.

## Also fixed: the misleading diagnostic that sent this investigation sideways

`Engine.run` reported every `RuntimeError` as `exceeded its N-second deadline` — including `failed to spawn process: program not found`, raised instantly. Anyone debugging a missing binary was sent hunting a slow Docker daemon. It now reads `exc.__cause__`'s type to distinguish a real timeout from a spawn failure, deliberately *not* string-matching the dependency's message text, which would break silently on a wording change.

## Verification

- **RED reproduced independently.** I ran the agent's stated repro myself (`git stash push -- src/bosn/daemon.py`) and got the exact `ProgrammingError('Cannot operate on a closed database.')` from the issue.
- `ci/lint.py` → `LINT OK` (pyright 0 errors)
- `pytest tests/ -q -m "not docker"` → **968 passed**, 2 skipped
- Same suite with `-W error::pytest.PytestUnhandledThreadExceptionWarning` → **968 passed, exit 0**. This is the assertion that actually matters: it proves the crash class is gone rather than merely unobserved, and it holds under the zero-wait bound where deferring is now the common path. No other sources of that warning surfaced anywhere in the suite.
