### PR TITLE
perf(resources): batch the scanner's label inspects (#99)

### DIFF
--- a/src/bosn/docker_cli.py
+++ b/src/bosn/docker_cli.py
@@ -35,6 +35,44 @@ from bosn.frontdoor import (
 from bosn.registry import Registry
 from bosn.resources import process_start_time
 
+# `compose-adopt`'s daemon-side cost is `ResourceScanner.scan`, which -- after #99's
+# batching fix collapsed the per-resource `docker inspect` fallback into one batched call
+# per kind -- is O(kinds) subprocesses rather than O(host-object-count). That fix alone was
+# not enough to make `ipc.DEFAULT_TIMEOUT` (10s) safe here: measured on the same ~280-object
+# development host the batching fix was validated against, a full scan still took 7-11s
+# across repeated runs (the batched `docker image inspect` call is the dominant cost --
+# image inspect output is far larger per object than volume/network/container, roughly
+# 70ms/image vs 10ms/volume here), meaning it sometimes lands past the 10s client budget by
+# itself before any daemon-side scheduling delay or host load is added on top. Raising
+# `ipc.DEFAULT_TIMEOUT` itself was rejected: that constant is shared by every verb, and
+# widening it to cover this one daemon-side cost would silently loosen the budget for verbs
+# that have no reason to need it. `daemon.request` already accepts a per-call
+# `request_timeout` override for exactly this situation.
+#
+# Sized against two measurement regimes on the same ~280-object host, because they differ
+# by more than 2x and only the slower one is safe to size against:
+#   - quiet host:   7.1-11.5s across repeated runs
+#   - loaded host: 23.7s, measured while a full test suite ran concurrently
+# The loaded figure is not a pathological outlier to be discounted -- a developer running
+# `compose build` while their own build, test suite, or editor indexes is running IS the
+# loaded case, and it is exactly when this call is most likely to be issued.
+#
+# 45s is ~2x the loaded measurement and ~4x the quiet one. 30s was the first value here,
+# derived from the quiet numbers alone; against the loaded measurement that is only ~1.25x,
+# which is thin next to the ~40% run-to-run swing observed even on a quiet host.
+#
+# Raising `ipc.DEFAULT_TIMEOUT` instead was rejected: it is shared by every verb, and
+# widening it to cover this one daemon-side cost would silently loosen budgets for verbs
+# with no reason to need it. `daemon.request` already takes a per-call `request_timeout`.
+#
+# This is a bound on how long the CLI *waits for bookkeeping*, and the trade is deliberate:
+# the timeout is non-fatal, so a shorter one does not fail the command, it just returns
+# before the registry has caught up -- which is the silent staleness #99 exists to fix.
+# Waiting is the lesser cost. If a future host pushes the batched scan past this too, that
+# is a signal the O(kinds) approach has hit its own limit and needs the "partial results" or
+# "async adopt" directions #99 discusses, not another timeout bump.
+COMPOSE_ADOPT_TIMEOUT_SECONDS = 45.0
+
 
 class DockerFrontDoorError(ValueError):
     pass
@@ -426,7 +464,11 @@ def _reconcile_after_compose(command: str, *, prune_missing: bool = False) -> No
     bookkeeping error the caller didn't ask about.
     """
     try:
-        adopted = daemon.request("compose-adopt", prune_missing=prune_missing)
+        adopted = daemon.request(
+            "compose-adopt",
+            prune_missing=prune_missing,
+            request_timeout=COMPOSE_ADOPT_TIMEOUT_SECONDS,
+        )
     except KeyboardInterrupt:
         raise
     except Exception as exc:  # daemon unreachable, IPC failure, etc.

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 import sys
 import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -44,6 +45,64 @@ _INSPECT_COMMANDS: dict[str, list[str]] = {
     "image": ["image", "inspect", "--format", "{{json .Config.Labels}}"],
     "network": ["network", "inspect", "--format", "{{json .Labels}}"],
 }
+
+# Batch inspect commands, one per kind, that accept N names/ids on the command line and
+# emit one JSON line per *found* object -- see `_batch_inspect_labels`. Each format string
+# hand-builds a JSON object (`{"<id-field>": {{json .X}}, "Labels": {{json .Y}}}`) rather
+# than relying on line position to recover which name a line belongs to. That is not
+# cosmetic: verified against real Docker, a batch inspect where one of N names does not
+# exist prints output for the ones that *were* found, writes an error for the missing one
+# to stderr, and exits 1 -- and the missing name produces no line at all. With a plain
+# `{{json .Labels}}` format (the single-name shape `_INSPECT_COMMANDS` still uses, since a
+# single-name call has nothing to misalign), N names in and fewer than N lines out would
+# make "which line is whose" a guess. Embedding the identity turns each line into a
+# self-describing (name, labels) pair, so mapping is a dict build, not a zip().
+#
+# The identity field differs per kind because Docker's inspect JSON does: containers and
+# volumes expose `.Name` (containers with a leading "/", stripped in
+# `_batch_inspect_labels`),
+# images expose only `.Id` -- there is no name at the image-inspect layer, mirroring why
+# `_LIST_COMMANDS["image"]` passes `--no-trunc` and `_name_of` reads `.ID` for images --
+# and networks expose `.Name`. Each was checked against a real `docker <kind> inspect`
+# invocation rather than assumed from the single-name formats above, which is what caught
+# the container leading-slash and the image having no `.Name` at all.
+_BATCH_INSPECT_COMMANDS: dict[str, tuple[list[str], str]] = {
+    "container": (
+        ["inspect"],
+        '{"Name":{{json .Name}},"Labels":{{json .Config.Labels}}}',
+    ),
+    "volume": (
+        ["volume", "inspect"],
+        '{"Name":{{json .Name}},"Labels":{{json .Labels}}}',
+    ),
+    "image": (
+        ["image", "inspect"],
+        '{"Id":{{json .Id}},"Labels":{{json .Config.Labels}}}',
+    ),
+    "network": (
+        ["network", "inspect"],
+        '{"Name":{{json .Name}},"Labels":{{json .Labels}}}',
+    ),
+}
+
+# The JSON key `_BATCH_INSPECT_COMMANDS`' format string uses for each kind's identity,
+# needed to read the right field back out of the parsed line in `_batch_inspect_labels`.
+_BATCH_IDENTITY_KEY: dict[str, str] = {
+    "container": "Name",
+    "volume": "Name",
+    "image": "Id",
+    "network": "Name",
+}
+
+# Names per `docker <kind> inspect` invocation. Chunking exists purely so a host with
+# thousands of unlabeled objects (this is exactly the population `_discover` is scanning
+# when it falls back to inspect at all -- see the module docstring) cannot build a command
+# line past the OS argv-length limit; it is not a batching-effectiveness knob. A few hundred
+# is comfortably under every platform's limit (Windows CreateProcess ~32K chars is the
+# tightest of the three) even for the longest identifiers this code handles (a 64-hex-char
+# `sha256:` image id), and it still collapses a 255-object host from ~255 subprocesses down
+# to a small constant per kind (issue #99).
+INSPECT_BATCH_SIZE = 200
 
 
 @dataclass(frozen=True)
@@ -107,6 +166,33 @@ def _parse_labels(blob: str) -> dict[str, str]:
     return result
 
 
+def _chunked(items: list[str], size: int) -> Iterator[list[str]]:
+    """Split `items` into consecutive slices of at most `size`, preserving order.
+
+    Extracted purely so `_batch_inspect_labels` reads as "for each chunk" rather than
+    hand-rolled range/slice arithmetic at the call site -- there is no other behavior here.
+    """
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def _labels_from_row(value: object) -> dict[str, str]:
+    """Normalize a `Labels` field already parsed out of a batch-inspect JSON line.
+
+    Unlike `_parse_labels`, the input here is a Python object (dict or `None`), not a raw
+    string blob -- `_BATCH_INSPECT_COMMANDS`' hand-built format strings emit `{{json
+    .Labels}}` as a nested JSON value inside the already-parsed outer object, so by the time
+    this runs `json.loads` has already turned it into `dict | None` (Docker renders an
+    unlabeled object's `.Labels` as JSON `null`, confirmed against real `docker image
+    inspect`/`docker network inspect` output). Re-serializing back to a string just to hand
+    it to `_parse_labels` would work but adds a pointless round trip for no shared logic
+    beyond "stringify values, drop Nones", which is inlined here instead.
+    """
+    if not isinstance(value, dict):
+        return {}
+    return {str(k): str(v) for k, v in value.items() if v is not None}
+
+
 def _name_of(kind: str, row: dict[str, object]) -> str:
     if kind == "volume":
         return str(row.get("Name", ""))
@@ -131,7 +217,17 @@ class ResourceScanner:
         if not result.ok:
             return [], False
 
-        discovered: list[DiscoveredResource] = []
+        # Two passes rather than one: the list format truncates labels for some kinds, and
+        # confirming a truncated-looking row used to mean "call `inspect_labels` right here,
+        # one subprocess per such row" (issue #99). On a host with hundreds of foreign or
+        # unlabeled objects -- not bounded by anything bosn owns, since it is whatever else
+        # happens to exist on the machine -- that made a single `scan()` cost tens of
+        # seconds and blow the IPC client's timeout. Collecting every name that needs
+        # confirming first and resolving them together in one batched (and internally
+        # chunked) call per kind is what turns that into O(kinds) subprocesses instead of
+        # O(resources).
+        rows: list[tuple[str, dict[str, str]]] = []
+        incomplete_names: list[str] = []
         for line in result.stdout.splitlines():
             line = line.strip()
             if not line:
@@ -146,10 +242,15 @@ class ResourceScanner:
             if not name:
                 continue
             raw = _parse_labels(str(row.get("Labels", "")))
+            rows.append((name, raw))
             if not labels.is_complete(raw):
-                # The list format truncates labels for some kinds; confirm via inspect
-                # before concluding a resource is unlabeled.
-                raw = self.inspect_labels(kind, name) or raw
+                incomplete_names.append(name)
+
+        confirmed = self._batch_inspect_labels(kind, incomplete_names) if incomplete_names else {}
+        discovered: list[DiscoveredResource] = []
+        for name, raw in rows:
+            if not labels.is_complete(raw):
+                raw = confirmed.get(name) or raw
             discovered.append(DiscoveredResource(kind=kind, name=name, raw_labels=raw))
         return discovered, True
 
@@ -159,6 +260,7 @@ class ResourceScanner:
         return discovered
 
     def inspect_labels(self, kind: str, name: str) -> dict[str, str]:
+        """Single-name inspect: the fallback path, not the hot path (see `_discover`)."""
         args = _INSPECT_COMMANDS.get(kind)
         if args is None:
             return {}
@@ -166,6 +268,69 @@ class ResourceScanner:
         if not result.ok:
             return {}
         return _parse_labels(result.stdout)
+
+    def _batch_inspect_labels(self, kind: str, names: list[str]) -> dict[str, dict[str, str]]:
+        """Resolve labels for many names in a handful of `docker <kind> inspect` calls.
+
+        Chunked per `INSPECT_BATCH_SIZE` so this stays a small constant number of
+        subprocesses regardless of host size, rather than one per name (the O(resources)
+        cost issue #99 is about) or one unbounded command line (a host with thousands of
+        objects could otherwise exceed the OS argv-length limit).
+
+        Every name in `names` was just observed to exist by `_discover`'s `ls`, but Docker
+        objects are not frozen between that listing and this inspect -- something else on
+        the host (or a concurrent bosn operation) can remove one in between. Verified
+        against real Docker: when that happens the batch command still prints a JSON line
+        for every name it *did* find, writes an error to stderr for the one it didn't, and
+        exits 1 for the whole invocation. So a nonzero exit does not mean "discard this
+        chunk's output" -- `_BATCH_INSPECT_COMMANDS`' format embeds each row's identity
+        precisely so the lines that did come back can still be trusted and mapped correctly
+        even when the process itself reports failure.
+
+        For whatever names a chunk's output did *not* account for -- true removal, or some
+        other reason the whole invocation failed (permissions, a transient engine hiccup) --
+        this falls back to `inspect_labels` one name at a time, i.e. exactly today's
+        pre-#99 per-resource behavior. That fallback is scoped to the unresolved names only,
+        not the whole chunk: names the batch call did resolve are not re-fetched just
+        because a sibling name in the same chunk failed.
+        """
+        command = _BATCH_INSPECT_COMMANDS.get(kind)
+        if command is None:
+            return {}
+        args_prefix, fmt = command
+        identity_key = _BATCH_IDENTITY_KEY[kind]
+        recovered: dict[str, dict[str, str]] = {}
+        for chunk in _chunked(names, INSPECT_BATCH_SIZE):
+            result = self.engine.run([*args_prefix, "--format", fmt, *chunk])
+            found_in_chunk: set[str] = set()
+            for line in result.stdout.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                identity = row.get(identity_key)
+                if not isinstance(identity, str):
+                    continue
+                if kind == "container":
+                    # `docker inspect`'s `.Name` carries a leading "/" that `docker ps`'s
+                    # `.Names` does not (confirmed against real Docker) -- without this the
+                    # identity would never match what `_name_of` put in `names`.
+                    identity = identity.lstrip("/")
+                recovered[identity] = _labels_from_row(row.get("Labels"))
+                found_in_chunk.add(identity)
+            if not result.ok:
+                for name in chunk:
+                    if name in found_in_chunk:
+                        continue
+                    single = self.inspect_labels(kind, name)
+                    if single:
+                        recovered[name] = single
+        return recovered
 
     def scan(self, registry_id: str, kinds: list[str] | None = None) -> ScanResult:
         scan = ScanResult()

--- a/tests/test_docker_cli.py
+++ b/tests/test_docker_cli.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from bosn import daemon, docker_cli
+from bosn import daemon, docker_cli, ipc
 from bosn.docker_cli import (
     DockerFrontDoorError,
     _compose_overlay,
@@ -248,6 +248,38 @@ def test_a_failed_up_still_reconciles(tmp_path: Path, monkeypatch: pytest.Monkey
 
     assert returncode == 1
     assert "compose-adopt" in fake_daemon.calls
+
+
+def test_compose_adopt_uses_its_own_timeout_not_the_shared_ipc_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#99: `compose-adopt`'s daemon-side scan cost is a poor fit for `ipc.DEFAULT_TIMEOUT`.
+
+    Batching `_discover`'s inspect fallback (#99) made the scan O(kinds) instead of
+    O(host-object-count), but a batched `docker image inspect` call is still measurably slow
+    on an object-heavy host -- comfortably past 10s in repeated on-host measurement -- so
+    `_reconcile_after_compose` gives this one verb its own named budget via `request_timeout`
+    rather than the global default every other verb still uses. Regression guard: a future
+    edit that reverted to the bare `daemon.request("compose-adopt", ...)` call would still
+    pass every other compose test in this file, since none of them assert on the timeout.
+    """
+    fake_daemon = _FakeDaemon()
+    monkeypatch.setattr(daemon, "request", fake_daemon.request)
+    monkeypatch.setattr(
+        "bosn.docker_cli.subprocess.run", lambda *a, **k: _FakeCompleted(returncode=0)
+    )
+
+    _run_compose("up", _compose_file(tmp_path), [])
+
+    adopt_requests = [
+        req
+        for verb, req in zip(fake_daemon.calls, fake_daemon.requests, strict=True)
+        if verb == "compose-adopt"
+    ]
+    assert adopt_requests, "compose-adopt was never called"
+    for req in adopt_requests:
+        assert req.get("request_timeout") == docker_cli.COMPOSE_ADOPT_TIMEOUT_SECONDS
+        assert req["request_timeout"] > ipc.DEFAULT_TIMEOUT
 
 
 def test_an_interrupted_up_still_reconciles_and_the_interrupt_still_propagates(

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -44,15 +44,57 @@ def label_dict(registry: str = OURS, **overrides: str) -> dict[str, str]:
 
 
 class FakeEngine:
-    """Records commands and replays canned output."""
+    """Records commands and replays canned output.
 
-    def __init__(self, listings: dict[str, list[dict]], inspects: dict[str, dict] | None = None):
+    Batch inspect (`resources._BATCH_INSPECT_COMMANDS`) is modeled after real Docker
+    behavior verified for issue #99: a requested name that is not in `self.inspects` simply
+    produces no output line (rather than an empty/error line), and the command's exit code
+    goes non-zero whenever any requested name in the batch was missing -- mirroring "found
+    ones print, missing ones don't, and the process still reports failure overall". Names in
+    `batch_command_failures` skip straight to a total failure (empty stdout, exit 1) with no
+    lines at all, modeling a batch call that failed for a reason unrelated to any single
+    name (permissions, a transient engine error) -- the case `_batch_inspect_labels`'s
+    per-name fallback exists for.
+    """
+
+    def __init__(
+        self,
+        listings: dict[str, list[dict]],
+        inspects: dict[str, dict] | None = None,
+        batch_command_failures: set[str] | None = None,
+    ):
         self.listings = listings
         self.inspects = inspects or {}
+        self.batch_command_failures = batch_command_failures or set()
         self.commands: list[list[str]] = []
 
-    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+    def run(
+        self, args: list[str], *, check: bool = False, timeout: float | None = None
+    ) -> EngineResult:
         self.commands.append(list(args))
+        for kind, (prefix, fmt) in resources._BATCH_INSPECT_COMMANDS.items():
+            if args[: len(prefix)] != prefix or "--format" not in args:
+                continue
+            fmt_index = args.index("--format")
+            if args[fmt_index + 1] != fmt:
+                continue
+            if kind in self.batch_command_failures:
+                return EngineResult(1, "", "simulated total batch failure")
+            names = args[fmt_index + 2 :]
+            identity_key = resources._BATCH_IDENTITY_KEY[kind]
+            lines: list[str] = []
+            any_missing = False
+            for name in names:
+                label_map = self.inspects.get(name)
+                if label_map is None:
+                    any_missing = True
+                    continue
+                # Container inspect's `.Name` carries a leading "/" in real Docker; the
+                # other kinds' identity field is the bare name/id.
+                identity = f"/{name}" if kind == "container" else name
+                lines.append(json.dumps({identity_key: identity, "Labels": label_map}))
+            returncode = 1 if any_missing else 0
+            return EngineResult(returncode, "\n".join(lines), "missing name" if any_missing else "")
         if "inspect" in args:
             name = args[-1]
             return EngineResult(0, json.dumps(self.inspects.get(name, {})), "")
@@ -119,6 +161,89 @@ def test_labels_are_confirmed_by_inspect_when_the_listing_truncates_them() -> No
     scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
     assert [r.name for r in scan.owned] == ["ours"]
     assert any("inspect" in cmd for cmd in engine.commands)
+
+
+def test_inspect_confirmation_is_batched_not_one_call_per_resource() -> None:
+    """The #99 regression guard: N incomplete-label resources must cost O(chunks), not N.
+
+    A future refactor that silently reintroduces a per-resource `inspect_labels` call
+    inside `_discover`'s loop would still pass every ownership-bucketing test in this file
+    -- those only check where a resource lands, not how many subprocesses it took to get
+    there. This asserts on the recorded engine calls directly, which is the only thing that
+    would catch that regression.
+    """
+    count = resources.INSPECT_BATCH_SIZE * 2 + 30  # forces exactly 3 chunks
+    names = [f"vol-{i}" for i in range(count)]
+    engine = FakeEngine(
+        {"volume": [{"Name": name, "Labels": ""} for name in names]},
+        inspects={name: label_dict() for name in names},
+    )
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+
+    assert len(scan.owned) == count
+    inspect_calls = [cmd for cmd in engine.commands if "inspect" in cmd]
+    assert len(inspect_calls) == 3, inspect_calls
+    for call in inspect_calls:
+        assert call[: len(resources._BATCH_INSPECT_COMMANDS["volume"][0])] == ["volume", "inspect"]
+
+
+def test_batch_inspect_maps_labels_to_the_correct_resource_when_a_name_is_missing() -> None:
+    """The positional-mapping hazard: Docker prints no line for a name it can't find.
+
+    Real Docker, verified for #99: when one of several requested names does not exist, the
+    batch inspect command prints output only for the ones it *did* find, and exits non-zero
+    overall. A naive implementation that zipped output lines to input names positionally
+    would silently misattribute every name after the missing one. This asserts each
+    surviving resource's labels landed on the resource with the matching name, not merely
+    that the right *count* of labels came back (which the positional bug would not catch).
+    """
+    engine = FakeEngine(
+        {
+            "volume": [
+                {"Name": "alpha", "Labels": ""},
+                {"Name": "removed-between-ls-and-inspect", "Labels": ""},
+                {"Name": "gamma", "Labels": ""},
+            ]
+        },
+        inspects={
+            "alpha": label_dict(**{labels.STACK: "alpha-stack"}),
+            # "removed-between-ls-and-inspect" deliberately absent: gone by inspect time.
+            "gamma": label_dict(**{labels.STACK: "gamma-stack"}),
+        },
+    )
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+
+    owned_by_name = {r.name: r for r in scan.owned}
+    assert owned_by_name["alpha"].parsed().stack == "alpha-stack"
+    assert owned_by_name["gamma"].parsed().stack == "gamma-stack"
+    assert [r.name for r in scan.unlabeled] == ["removed-between-ls-and-inspect"]
+    # One batched call covering all three names, plus exactly one per-name fallback call
+    # for the single name that call could not account for -- not three per-name calls,
+    # and not a wholesale re-fetch of the two names the batch call already resolved.
+    inspect_calls = [cmd for cmd in engine.commands if "inspect" in cmd]
+    assert len(inspect_calls) == 2, inspect_calls
+    assert inspect_calls[1][-1] == "removed-between-ls-and-inspect"
+
+
+def test_batch_inspect_falls_back_to_per_name_when_the_whole_batch_command_fails() -> None:
+    """Mitigation #2: a batch call that fails outright degrades to pre-#99 behavior.
+
+    Distinct from the missing-name case above -- here the batch command fails for a reason
+    unrelated to any single name (simulated: total failure, no output lines at all), so
+    every name in the batch is unresolved from that call's own output. The fallback must
+    still recover labels via one inspect per name, exactly like the pre-#99 code path.
+    """
+    engine = FakeEngine(
+        {"volume": [{"Name": "solo", "Labels": ""}]},
+        inspects={"solo": label_dict()},
+        batch_command_failures={"volume"},
+    )
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+
+    assert [r.name for r in scan.owned] == ["solo"]
+    inspect_calls = [cmd for cmd in engine.commands if "inspect" in cmd]
+    # One failed batch call, then one per-name fallback call for the sole unresolved name.
+    assert len(inspect_calls) == 2, inspect_calls
 
 
 def test_image_discovery_requests_and_keeps_the_full_immutable_id() -> None:


### PR DESCRIPTION
Closes #99.

## The problem

`ResourceScanner.scan` spent **one `docker inspect` subprocess per resource** whose list-format labels looked incomplete. That cost scales with whatever exists on the host — including objects belonging to other tools entirely — so it is unbounded from bosn's point of view.

That is what made `compose-adopt` blow the fixed 10s IPC budget: every reconcile timed out client-side. The timeout is non-fatal by design (bookkeeping must never mask Compose's exit code), so `compose build` exited 0 while the registry row landed seconds later. The registry ran silently behind the engine on exactly the busy hosts most in need of governing.

## The fix

All four inspect commands accept many names, so the per-resource fallback becomes one batched call per kind, chunked so a host with thousands of objects cannot blow a command-line limit.

### The part that would have been silently wrong

I tested the failure mode against real Docker before writing the direction: when a requested name does not exist — a real case, since a resource can be removed between the `ls` and the `inspect` — Docker prints results for the found ones, writes an error to stderr, exits 1, and emits **no line at all** for the missing one. Output therefore cannot be mapped positionally.

So each line carries its own identity, and the identity field was verified per kind against real Docker rather than assumed:

| kind | identity | gotcha |
|---|---|---|
| container | `.Name` | comes back with a leading `/`, stripped |
| volume | `.Name` | plain |
| image | `.Id` | images have **no** `.Name` at the inspect layer |
| network | `.Name` | plain |

A batch whose command fails still falls back to per-name inspects, so partial failure degrades to the old behavior rather than losing labels.

## Measured

Both scanners run back-to-back **in one process** on a ~280-object host, so the comparison is same-machine, same-moment:

| | wall clock | engine subprocesses |
|---|---|---|
| main | 42.87s | 121 |
| this branch | 23.74s | 8 |

Correctness checked beyond counts — the two scanners classify the same objects identically, and critically **zero resources moved from labeled to unlabeled**, which is the direction a mapping bug would show up in. The small remaining deltas were object churn from a concurrent agent's tests creating and removing resources mid-measurement (`bosn-test-*` names).

Tests assert the **subprocess count**, not just resulting behavior: a future refactor could reintroduce per-resource inspects with every behavior test still passing, and that is precisely the regression this PR exists to prevent. There are also dedicated tests for the missing-name mapping and the whole-batch fallback.

## The timeout, sized against the slower regime

Batching alone did not make 10s safe. Two measurement regimes on the same host:

- quiet: 7.1–11.5s across repeated runs
- loaded: 23.7s, measured with a full test suite running concurrently

The loaded figure is not an outlier to discount — a developer running `compose build` while their own suite or editor indexing runs *is* the loaded case, and it is exactly when this call gets issued. So `compose-adopt` gets its own **45s** budget (~2x loaded, ~4x quiet). The first value here was 30s, derived from the quiet numbers alone; against the loaded measurement that is only ~1.25x, thin next to the ~40% run-to-run swing seen even when quiet. The authoring agent flagged this itself once it saw my numbers rather than defending its own.

`ipc.DEFAULT_TIMEOUT` deliberately stays put — it is shared by every verb, and widening it for one daemon-side cost would loosen budgets with no reason to move.

## Verification

- `ci/lint.py` → `LINT OK` (pyright 0 errors)
- `pytest tests/ -q -m "not docker"` → **973 passed**, 2 skipped
- `pytest tests/ -q -m docker` → 32 passed, 1 failed: `test_accounting_docker.py::test_system_df_attributes_a_real_named_volume`

That docker failure is **not** from this change, and I checked rather than assumed: `accounting.py` imports only `Engine` and `Resource`, never `ResourceScanner`, so this diff cannot reach it. It failed with `StorageInventory(sizes={})` — `docker system df -v` returned nothing at all — and passes 3/3 in isolation. It is the same underlying condition as #99 (host object count driving command cost) surfacing somewhere else, and it silently degrades GC's pressure view to zero bytes. Filed separately.
