### PR TITLE
feat(soldr): express the perf-local workload as a reference manifest (#75)

### DIFF
--- a/docs/soldr-integration.md
+++ b/docs/soldr-integration.md
@@ -1,0 +1,184 @@
+# soldr integration (issue #75)
+
+This records what `examples/soldr.toml` proves, what it does not, and the one part of #75
+that was deliberately left unvalidated.
+
+All destinations, scopes, ENV, and `WORKDIR` claims below were read directly from soldr's
+own source on this machine (`ci/perf_local.py`, `docker/cook-shared-cache/Dockerfile`) and
+bosn's own (`src/bosn/manifest.py`, `src/bosn/converge.py`), not inferred or guessed.
+
+## Which option this manifest represents
+
+Issue #75 originally framed the choice as three options for governing soldr's `ci/perf_local.py`
+workload, two of them blocked at the time:
+
+- **(a)** rewrite soldr's Dockerfile to `COPY` the source instead of bind-mounting it —
+  rejected in the issue itself: that would force a rebuild on every edit, defeating the
+  point of the edit-in-place loop.
+- **(b)** bosn grows a declared workspace bind mount, and governs the whole stack —
+  blocked at the time by two conflicts (see below).
+- **(c)** bosn governs only soldr's cache *volumes*; `perf_local.py` keeps owning the
+  container and the bind mount.
+
+Both blockers on (b) were resolved before this work started (`MountSpec`/`bosn.toml`
+`[stack.X.mounts]` for binds, `VolumeSpec.destination` for fixed image paths — see
+`src/bosn/manifest.py`). `examples/soldr.toml` is option **(b)**: a single bosn stack with
+`[stack.perf.mounts]` and `[stack.perf.volumes]` sections that together express all six of
+`perf_local.py`'s mounts, not just the volumes.
+
+## What it does govern
+
+Loaded through the real loader (`bosn.manifest.load`), `examples/soldr.toml`'s `perf`
+stack expresses exactly the six *mounts* `Runner.volumes` / `create_command()` wire in
+`ci/perf_local.py` (the container's environment and working directory are a separate
+story — see "What it does not govern" below):
+
+| Host (soldr) | Container | soldr wires it by | bosn expresses it as |
+| --- | --- | --- | --- |
+| `{source_root}` | `/repo` | `-v {source_root}:/repo` | `MountSpec` (bind) |
+| `{target}` | `/target` | `-v {target}:/target` + `-e CARGO_TARGET_DIR=/target` | `VolumeSpec`, `scope = "stack"` |
+| `{cargo_home}` | `/root/.cargo` | `-v {cargo_home}:/root/.cargo`; `ENV CARGO_HOME` baked into the image | `VolumeSpec`, `scope = "machine"` |
+| `{soldr_home}` | `/root/.soldr` | `-v {soldr_home}:/root/.soldr` | `VolumeSpec`, `scope = "machine"` |
+| `{uv_cache}` | `/root/.cache/uv` | `-v {uv_cache}:/root/.cache/uv`; `ENV UV_CACHE_DIR` baked into the image | `VolumeSpec`, `scope = "machine"` |
+| `{venv}` | `/venv` | `-v {venv}:/venv`; `ENV UV_PROJECT_ENVIRONMENT` baked into the image | `VolumeSpec`, `scope = "stack"` |
+
+`tests/test_manifest.py` (the `# -- examples/soldr.toml expresses soldr's actual
+perf-local mount table (#75) --` section) loads this file and pins every destination and
+scope in that table, plus: the bind is a `MountSpec` (never registered, labeled, or GC'd —
+see `MountSpec`'s docstring) and never a `VolumeSpec`; none of the six destinations fall
+inside bosn's reserved `/bosn/*` / heartbeat namespace; and the reserved-namespace guard
+still refuses a destination that does.
+
+### The scope split, and the README's number
+
+This repo's `README.md` ("How the disk savings actually work" → "1. Sharing") claims that
+applying bosn's scopes to soldr's own five volumes drops five per-checkout volumes to two
+— `cargo-home`, `soldr-home`, `uv-cache` machine-scoped; `target`, `venv` stack-scoped —
+and that ten checkouts go from 50 volumes to 23. `examples/soldr.toml` **agrees with**
+that split, and it is not a coincidence: `cargo-home`/`soldr-home`/`uv-cache` hold
+content that does not depend on which repo asked for it (a cargo registry, a uv wheel
+cache, soldr's own state dir), while `target`/`venv` are built from one checkout's source
+and would corrupt a sibling checkout's build if shared. `tests/test_manifest.py` pins
+this scope assignment against the checked-in file, so an edit to either the manifest or
+the claim that breaks the correspondence fails a test.
+
+One nuance worth stating plainly, because it's easy to read the README's number as "bosn
+discovered a place soldr was wasting volumes" when the real story is narrower: soldr's own
+`shared_source_root()` (in `ci/perf_local.py`) already collapses every *linked* `git
+worktree` under one checkout root onto a single `Runner` and its five volumes — sibling
+worktrees of the *same* repo never get their own copies today (`RUNNER_SCHEMA` "7"; the
+docstring is explicit that this replaced an older, worse scheme). The 50→23 scenario is
+ten separate *checkout roots* (ten clones, or ten repos with their own `bosn.toml`), each
+of which is its own `Runner` under soldr's current code and its own `workspace` under
+bosn's (`workspace_of(manifest)`, keyed off the manifest's root — see
+`src/bosn/converge.py`). Machine-scoping three of the five volumes is a real win *bosn's*
+scoping model adds on top of soldr's own per-root sharing, not a bug bosn is fixing in
+soldr — soldr never claimed to share `cargo-home` across sibling clones, and it still
+doesn't on its own.
+
+## What it does not govern
+
+**`bosn.toml` cannot declare container environment or a working directory at all.**
+`src/bosn/manifest.py` has no `env`/`environment` table, and neither `converge.py`'s
+`docker create` (`args = ["create", "--rm", "--name", name, *labels, ...]`, no `-e`) nor
+its `docker exec` (`args = ["exec", name, *command]`, no `-w`) pass either. Everything a
+container gets on either axis comes from what its *image* bakes in via `ENV` /
+`WORKDIR` — which is exactly why bosn's own dogfood image (`docker/test.Dockerfile`) sets
+`WORKDIR /repo` explicitly, line 17. soldr's image does not need to, because
+`perf_local.py` supplies both axes itself at container-create time
+(`create_command()` in `ci/perf_local.py`): `-w /repo`, plus eight `-e` flags —
+`CARGO_TARGET_DIR=/target`, `TMPDIR=/target/tmp`, `CARGO_BUILD_JOBS=2`, `SOLDR_JOBS=2`,
+`UV_CACHE_DIR=/root/.cache/uv`, `UV_PROJECT_ENVIRONMENT=/venv`, `NEXTEST_TEST_THREADS=2`
+(the last three duplicate what the Dockerfile already bakes in as `ENV`, harmlessly).
+Checked against `docker/cook-shared-cache/Dockerfile` line by line (not just grepped —
+the file's `ENV` blocks span backslash-continued lines that a naive grep for `ENV` would
+miss part of):
+
+| create-time flag | baked into the image's own `ENV`? | consequence if bosn supplies neither |
+| --- | --- | --- |
+| `CARGO_HOME` | yes (line 86) | none — the volume above lands correctly regardless |
+| `UV_CACHE_DIR`, `UV_PROJECT_ENVIRONMENT` | yes (lines 133–134) | none, same reason |
+| `CARGO_BUILD_JOBS`, `SOLDR_JOBS` | yes (lines 91–92) | none, same reason |
+| `CARGO_TARGET_DIR` | **no** | **breaks cache correctness**: Cargo falls back to `<cwd>/target`, not the `/target` volume |
+| `TMPDIR` | no | smoke-suite temp binaries fall back to the container overlay instead of the target volume (perf, not correctness) |
+| `NEXTEST_TEST_THREADS` | no | nextest picks its own default thread count instead of 2 (perf, not correctness) |
+| working directory (`-w /repo`) | no (image `WORKDIR` is `/work`, an empty dir) | any command that assumes it starts inside the repo fails outright |
+
+So the picture is narrower than "one missing variable": three of soldr's four
+container-side ENV needs are already covered by the image's own defaults and need nothing
+from bosn, one (`CARGO_TARGET_DIR`) silently breaks cache correctness if unaddressed, two
+more degrade performance without breaking correctness, and the working directory is a
+separate, unrelated gap that breaks outright rather than silently. `examples/soldr.toml`'s
+`[task.check]` works around the workdir gap with `cd /repo &&` (cmd runs via `sh -c`, see
+`cli.py`/`converge.py`), which is enough to make `cargo check` run in the right place —
+but *not* enough to make it use the `/target` volume, because `cd` cannot set
+`CARGO_TARGET_DIR`. That specific combination — task runs successfully, uses the wrong
+target dir, builds inside the `/repo` bind on the host instead of the cache volume — is
+the one place this manifest "looks right" while doing the wrong thing, and it is called
+out at the point of use in `examples/soldr.toml`. Closing it for real needs either (a) a
+thin Dockerfile layered on soldr's own that adds `ENV CARGO_TARGET_DIR=/target` (and,
+optionally, `WORKDIR /repo`), or (b) bosn growing a way to declare container environment
+and/or working directory — neither exists today.
+
+**Adoption was not exercised against real soldr volumes.** #75 also asked to run
+`bosn adopt --legacy soldr --yes` against real soldr cache volumes and measure the result.
+That mutates real, potentially large volumes in place (Docker labels are immutable, so
+adoption is a staged copy — recreate under new labels, needing roughly double the volume's
+size in free space; see `src/bosn/legacy.py`'s module docstring and README's "Coming from
+Docker" section) and needs the user's explicit go-ahead, which was not given for this
+pass. What *was* exercised instead: `tests/test_legacy.py` already builds synthetic
+volumes carrying soldr's exact real label shape — `soldr_volume_labels()` stamps only
+`io.soldr.perf-local.managed` and `.source-root`, matching `ensure_runner`'s actual
+`docker volume create --label ... --label ...` call in `ci/perf_local.py` byte-for-byte —
+and adopts them through `legacy.plan_adoption`/`apply_plan` against a fake engine
+(`test_all_five_real_soldr_volume_names_from_one_root_adopt_to_one_workspace`,
+`test_two_checkout_roots_map_to_two_distinct_workspaces_not_one`, and the `apply_plan`
+tests below them). That is real coverage of the *mapping* logic — label→workspace, one
+root's five volumes landing in one workspace, two roots never colliding — without touching
+a real Docker daemon or a real cache. It is not a substitute for the real-volume run;
+nothing here claims otherwise.
+
+## The issue's open item about `RUSTUP_HOME`/cargo-chef — already resolved
+
+Issue #75's last open item claimed the README's soldr paragraph names `RUSTUP_HOME` and
+cargo-chef, which do not appear in `Runner.volumes`. Re-checked directly against the
+README text at the paragraph that actually makes the soldr claim ("How the disk savings
+actually work" → "1. Sharing," the "Applied to soldr's own five..." paragraph): it lists
+exactly `target`, `cargo-home`, `soldr-home`, `uv-cache`, `venv` — a byte-for-byte match
+to `Runner.volumes` in `ci/perf_local.py`, with no mention of `RUSTUP_HOME` or cargo-chef
+anywhere near it. `RUSTUP_HOME` and a `chef` volume appear only in the README's *generic*
+"First run" Rust example (a made-up `family = "rust"` stack, unrelated to soldr) and its
+`rustup toolchain is byte-identical...` sentence a few lines above the soldr paragraph,
+which is about rustup toolchains in general, not soldr's specific five. So this item is
+already resolved — no further edit was needed here.
+
+## `SOLDR.recognized_schema_versions` — re-checked, still correct
+
+`src/bosn/legacy.py`'s `SOLDR` family accepts only schema `"2"` even though soldr's
+`RUNNER_SCHEMA` constant now reads `"7"` (`ci/perf_local.py`, checked on this machine).
+Read against the actual producer code, that mismatch is inert, exactly as the surrounding
+comment in `legacy.py` claims:
+
+- `ensure_runner()`'s `docker volume create` call passes only two labels —
+  `io.soldr.perf-local.managed=true` and `io.soldr.perf-local.source-root=...` — never
+  `.schema`. `.schema` (`expected_labels()`) is stamped only on the *runner container*.
+- `legacy.py` only ever adopts **volumes** (containers/images are reported and skipped —
+  Docker labels are immutable, so relabeling either would mean destroy-and-rebuild).
+- So `SOLDR.map_labels()`'s schema check never actually runs against a real soldr object:
+  the label it validates is never present on the only kind it is ever asked to validate.
+  `recognized_schema_versions=frozenset({"2"})` is accurate about a boundary that soldr's
+  *current* code never crosses, not stale.
+
+This still holds. If soldr ever starts stamping `.schema` on its volumes, adoption starts
+refusing them with "unrecognized schema" until someone audits what changed between "2" and
+"7" and widens the set — which `legacy.py`'s own comment already documents as the intended
+failure mode. Nothing here contradicts that; no code change was needed.
+
+## Files
+
+- `examples/soldr.toml` — the reference manifest itself, meant to be copied to
+  `<soldr-checkout>/bosn.toml`.
+- `tests/test_manifest.py` — loads it through the real loader and pins destinations,
+  scopes, and the bind/volume distinction (see the `#75` section near the end of the file).
+- `tests/test_legacy.py` — pre-existing synthetic-volume adoption coverage for soldr's
+  exact label shape (not modified for this pass; see "What it does not govern" above).

--- a/examples/soldr.toml
+++ b/examples/soldr.toml
@@ -1,0 +1,87 @@
+# Reference manifest for GitHub issue #75: express soldr's `ci/perf_local.py` perf-local
+# workload as a bosn stack, using bind mounts (MountSpec) and configurable volume
+# destinations (VolumeSpec.destination) -- both landed after #75 was filed, which is why
+# this file exists now and did not before. See docs/soldr-integration.md for what running
+# this actually validates and what it deliberately does not.
+#
+# This file is a *reference*, not something bosn's own test suite runs against real soldr
+# volumes -- doing that mutates a developer's real caches and needs the user's explicit
+# go-ahead (see docs/soldr-integration.md). To use it for real: copy it to
+# `<soldr-checkout>/bosn.toml` (the `source = "."` bind below assumes the manifest sits at
+# the checkout root, exactly like bosn's own dogfood `bosn.toml` mounts `.` at `/repo`).
+#
+# Ground truth for every destination and scope below was read directly from soldr's own
+# source on this machine, not inferred or guessed:
+#   - `ci/perf_local.py`, `Runner` / `runner_for()` / `create_command()` (the six `-v`
+#     mounts and the container's `-e` environment)
+#   - `docker/cook-shared-cache/Dockerfile` (which of those container paths are also baked
+#     in as image `ENV`, and which are not -- see the `target`/`cargo-target-dir` comment
+#     below for the one gap that leaves)
+
+[stack.perf]
+# The image `ci/perf_local.py`'s own `ensure_image()` builds and tags locally. bosn does
+# not build it here: soldr's Dockerfile bakes CARGO_HOME, UV_CACHE_DIR, and
+# UV_PROJECT_ENVIRONMENT in as ENV (see docker/cook-shared-cache/Dockerfile lines 86,
+# 133-134), which is exactly what lets the volumes below land at the right paths with zero
+# Dockerfile change. Declaring `dockerfile = "docker/cook-shared-cache/Dockerfile"` instead
+# would work identically once this file sits inside the soldr checkout; `image` is used
+# here so the manifest also loads (and its mounts assert cleanly) from inside the bosn repo,
+# which has no such Dockerfile.
+image = "soldr-cook-dev"
+family = "soldr"
+default = true
+
+[stack.perf.mounts]
+# soldr's edit-in-place bind (perf_local.py: `-v {source_root.resolve()}:/repo`). This is
+# a MountSpec, not a VolumeSpec: bosn references this host path and never labels,
+# registers, or deletes it (see MountSpec's docstring in src/bosn/manifest.py) -- soldr's
+# own working tree stays soldr's to own, exactly like the real harness's bind mount.
+repo = { source = ".", destination = "/repo" }
+
+[stack.perf.volumes]
+# -- machine-scoped: content-identical regardless of which checkout asked for it ---------
+#
+# A cargo registry/toolchain cache, a uv wheel cache, and soldr's own `~/.soldr` state
+# directory do not depend on *which* repo produced them -- only on the family (`family =
+# "soldr"` above) that names the shared volume. `machine` scope keys a volume by
+# (family, volume name) alone, so every soldr checkout on this machine shares one copy
+# instead of duplicating it per checkout. This is the split the README's "50 volumes
+# become 23" claim (see "How the disk savings actually work" -> "1. Sharing") rests on;
+# docs/soldr-integration.md re-derives that number against this exact file.
+cargo-home = { scope = "machine", destination = "/root/.cargo" }
+soldr-home = { scope = "machine", destination = "/root/.soldr" }
+uv-cache   = { scope = "machine", destination = "/root/.cache/uv" }
+
+# -- stack-scoped: built from *this* checkout's own source --------------------------------
+#
+# A cargo target dir and a uv-managed venv are only valid for the code that produced them;
+# sharing them across checkouts would mean one branch's build silently poisoning another's.
+# `stack` scope keys a volume by (workspace, stack), where bosn's `workspace` is this
+# manifest's own root -- i.e. per checkout, matching soldr's own `shared_source_root()`
+# granularity for `Runner.volumes`, just reachable from a *different* set of checkouts (see
+# docs/soldr-integration.md for why those two granularities are not the same claim).
+#
+# NOTE: mounting `target` here reproduces soldr's *volume*, not its *behavior*. Cargo only
+# writes to `/target` because `perf_local.py`'s `create_command()` also passes
+# `-e CARGO_TARGET_DIR=/target` at container-create time -- and that ENV is not baked into
+# the Dockerfile the way CARGO_HOME is (grepped; absent). bosn's manifest has no mechanism
+# to declare container environment variables, so this stack alone does not make cargo use
+# this volume -- see docs/soldr-integration.md, "What this does not govern."
+target = { scope = "stack", destination = "/target" }
+venv   = { scope = "stack", destination = "/venv" }
+
+[task.check]
+stack = "perf"
+# Two things `perf_local.py` sets at container-create time have no bosn.toml equivalent
+# today (bosn's manifest has no way to declare container ENV, and neither `converge.py`'s
+# `docker create` nor its `docker exec` pass a `-w`/workdir override -- see
+# docs/soldr-integration.md, "What this does not govern"):
+#   - CARGO_TARGET_DIR=/target -- without it Cargo defaults to `<cwd>/target`, so this task
+#     works around the gap with `cd /repo` (the image's baked-in WORKDIR is `/work`, an
+#     empty directory -- soldr's own Dockerfile never sets `WORKDIR /repo` because
+#     perf_local.py always supplies `-w /repo` itself) but STILL builds into `/repo/target`
+#     inside the bind mount, not the `/target` volume above. That volume is real; nothing
+#     in this stack makes Cargo use it.
+#   - TMPDIR=/target/tmp, CARGO_BUILD_JOBS, SOLDR_JOBS, NEXTEST_TEST_THREADS -- degrade
+#     behavior (e.g. temp files fall back to the container overlay) rather than break it.
+cmd = "cd /repo && cargo check --workspace"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 
 from bosn import manifest as manifest_mod
-from bosn.manifest import ManifestError, dockerfile_external_images, generation_digest, load
+from bosn.manifest import (
+    ManifestError,
+    StackSpec,
+    dockerfile_external_images,
+    generation_digest,
+    load,
+)
 
 SAMPLE = """
 [stack.test]
@@ -463,3 +469,109 @@ def test_a_git_bash_spelled_bind_source_resolves(tmp_path: Path) -> None:
     stack = load(_write(tmp_path, body)).stacks["test"]
 
     assert stack.mounts[0].resolve_source(root) == (root / "src").resolve()
+
+
+# -- examples/soldr.toml expresses soldr's actual perf-local mount table (#75) ----------
+#
+# `Runner.volumes`/`create_command()` in soldr's `ci/perf_local.py` mount six paths: one
+# bind (the checkout itself, at `/repo`) and five named volumes (`target`, `cargo_home`,
+# `soldr_home`, `uv_cache`, `venv`). These tests load the checked-in example through the
+# real loader -- the same `load()` a `bosn ensure`/`bosn run` invocation uses -- and pin
+# every destination and scope this deliverable claims to soldr's real ones, so a drift
+# between the example and soldr's actual harness fails a test instead of going unnoticed.
+
+EXAMPLES_ROOT = Path(__file__).resolve().parent.parent / "examples"
+
+# Exactly soldr's six container-side paths, read from `create_command()`'s `-v` flags in
+# ci/perf_local.py (bind: /repo; volumes: /root/.cargo, /root/.soldr, /root/.cache/uv,
+# /venv, /target).
+SOLDR_MOUNT_DESTINATIONS = {
+    "repo": "/repo",
+    "cargo-home": "/root/.cargo",
+    "soldr-home": "/root/.soldr",
+    "uv-cache": "/root/.cache/uv",
+    "target": "/target",
+    "venv": "/venv",
+}
+
+
+def _soldr_stack() -> StackSpec:
+    return load(EXAMPLES_ROOT / "soldr.toml").stack("perf")
+
+
+def test_soldr_example_mounts_all_six_soldr_paths_at_soldr_destinations() -> None:
+    stack = _soldr_stack()
+
+    by_destination = {v.name: v.mount_at() for v in stack.volumes}
+    by_destination.update({m.name: m.destination for m in stack.mounts})
+
+    assert by_destination == SOLDR_MOUNT_DESTINATIONS
+
+
+def test_soldr_example_repo_is_a_bind_never_a_volume() -> None:
+    """bosn *references* the checkout; it must never own, label, or delete it (MountSpec).
+
+    Proven both directions: `repo` is absent from `volumes` (so it is never registered,
+    labeled, or GC'd as bosn's own), and present in `mounts` (so it is a bind).
+    """
+    stack = _soldr_stack()
+
+    assert "repo" not in {v.name for v in stack.volumes}
+    assert {m.name for m in stack.mounts} == {"repo"}
+    mount = stack.mounts[0]
+    assert mount.source == "."
+    assert mount.destination == "/repo"
+
+
+def test_soldr_example_scopes_match_the_readme_sharing_claim() -> None:
+    """README.md ("How the disk savings actually work" -> "1. Sharing") claims applying
+    bosn's scopes to soldr's own five volumes drops five per-checkout volumes to two,
+    with cargo-home/soldr-home/uv-cache machine-scoped and target/venv stack-scoped. This
+    pins the claim against the checked-in example so an edit to either one that breaks the
+    correspondence fails a test rather than silently diverging.
+    """
+    stack = _soldr_stack()
+    scopes = {v.name: v.scope for v in stack.volumes}
+
+    assert scopes == {
+        "cargo-home": "machine",
+        "soldr-home": "machine",
+        "uv-cache": "machine",
+        "target": "stack",
+        "venv": "stack",
+    }
+    machine_scoped = {name for name, scope in scopes.items() if scope == "machine"}
+    stack_scoped = {name for name, scope in scopes.items() if scope == "stack"}
+    assert len(machine_scoped) == 3
+    assert len(stack_scoped) == 2
+
+
+def test_soldr_example_destinations_outside_bosns_namespace_are_all_accepted() -> None:
+    """None of soldr's real destinations collide with /bosn/* or the heartbeat file --
+    loading the example at all is already partial proof of this, but the point of this
+    test is to pin it against the exact set rather than "it didn't raise."""
+    stack = _soldr_stack()
+    destinations = {v.mount_at() for v in stack.volumes} | {m.destination for m in stack.mounts}
+
+    for destination in destinations:
+        assert not destination.startswith(manifest_mod.RESERVED_PREFIX)
+        assert destination != manifest_mod.RESERVED_HEARTBEAT
+
+    assert destinations == set(SOLDR_MOUNT_DESTINATIONS.values())
+
+
+def test_soldr_example_reserved_namespace_guard_still_rejects_a_bosn_destination(
+    tmp_path: Path,
+) -> None:
+    """The guard soldr's manifest relies on staying silent is still live: redirect one of
+    its own volumes into bosn's reserved namespace and confirm the loader still refuses.
+    """
+    body = (
+        (EXAMPLES_ROOT / "soldr.toml")
+        .read_text(encoding="utf-8")
+        .replace('"/root/.cargo"', '"/bosn/cargo-home"')
+    )
+    (tmp_path / "bosn.toml").write_text(body, encoding="utf-8")
+
+    with pytest.raises(ManifestError, match="reserved"):
+        load(tmp_path)


### PR DESCRIPTION
Addresses #75.

## The issue's premises were out of date

#75 named two conflicts it called blocking, and predicted its option **(b)** would be needed but unavailable. Both have since landed:

- **Conflict 2 (destinations not configurable)** — `VolumeSpec.destination` / `mount_at()` let a volume mount where an existing image expects it, instead of `/bosn/<name>`.
- **Conflict 1 (no bind mounts)** — `MountSpec` adds a host path bosn *references but never deletes*. That ownership distinction is why binds are a separate table from volumes.

So option (b) is now actually available, and this PR is what it looks like in practice.

## What landed

**`examples/soldr.toml`** — soldr's six mounts at the destinations `docker/cook-shared-cache/Dockerfile` hardcodes: `repo` as a bind at `/repo`, plus target / cargo-home / soldr-home / uv-cache / venv as volumes. Written against soldr's real harness (`ci/perf_local.py`), read-only.

**Scopes match the README rather than quietly diverging from it.** cargo-home / soldr-home / uv-cache are machine-scoped; target / venv are per-stack — which is exactly the README's "50 volumes become 23" claim, and the tests pin the split so the two cannot drift apart silently. One nuance the doc now records: soldr's own `shared_source_root()` already collapses *linked* git worktrees onto one runner, so the 50→23 figure is about ten separate checkout roots. bosn's machine scope is a win *on top of* soldr's per-root sharing, not a fix for a bug in soldr.

**`docs/soldr-integration.md`** — which option this represents, what it governs, and what it does not.

**5 tests** loading the manifest through the real loader: destinations, bind-vs-volume, scopes, and that the reserved-namespace guard still rejects what it should.

## The finding worth reading

**bosn cannot set container env or working directory at all.** `converge.py` passes no `-e` at `docker create` and no `-w` at `docker exec` — everything comes from the image. Checked line by line against soldr's Dockerfile:

- 6 of soldr's 8 create-time flags are already baked into the image (harmless to omit)
- `WORKDIR` is a **visible** gap: soldr's image is `WORKDIR /work` because `perf_local.py` always supplies `-w /repo`. The example works around it with an explicit `cd /repo`.
- `CARGO_TARGET_DIR` is a **silent** one: not baked in, so Cargo falls back to `<cwd>/target` and builds outside the `/target` volume entirely. Nothing errors, the build succeeds, and the cache the stack exists to keep warm is simply never used.

That last one cannot be worked around in a manifest, so it is documented at the point of use rather than left to be discovered, and filed as **#105**.

Also re-verified that `legacy.py`'s deliberately narrow `recognized_schema_versions={"2"}` still holds at soldr's `RUNNER_SCHEMA = "7"`: its volumes carry only `.managed` and `.source-root`, never `.schema`, so the allowlist stays unreachable. No change made.

## What this does not do

The live `adopt --legacy soldr --yes` run against real cache volumes is **deliberately not performed**. It rewrites labels on real data and needs roughly double the free space, so it is the user's call, not mine. Adoption *mapping* is already covered against synthetic soldr-labelled volumes in `tests/test_legacy.py`.

So #75's acceptance is met except for live validation, which I'd rather leave explicitly open than close as if it were done — see the closing comment for the exact split.

## Verification

- `ci/lint.py` → `LINT OK` (pyright 0 errors)
- `pytest tests/ -q -m "not docker"` → 977 passed, 2 skipped
