### PR TITLE
feat(manifest): declare container env and workdir (#105)

### DIFF
--- a/docs/soldr-integration.md
+++ b/docs/soldr-integration.md
@@ -30,8 +30,10 @@ Both blockers on (b) were resolved before this work started (`MountSpec`/`bosn.t
 
 Loaded through the real loader (`bosn.manifest.load`), `examples/soldr.toml`'s `perf`
 stack expresses exactly the six *mounts* `Runner.volumes` / `create_command()` wire in
-`ci/perf_local.py` (the container's environment and working directory are a separate
-story — see "What it does not govern" below):
+`ci/perf_local.py`, plus, since #105, the two container-create-time knobs that used to
+have no bosn.toml equivalent at all — `CARGO_TARGET_DIR` via `[stack.perf.env]` and the
+working directory via `workdir = "/repo"` (see "What it does not govern" below for what is
+still left over, which is narrower than it used to be).
 
 | Host (soldr) | Container | soldr wires it by | bosn expresses it as |
 | --- | --- | --- | --- |
@@ -78,14 +80,13 @@ doesn't on its own.
 
 ## What it does not govern
 
-**`bosn.toml` cannot declare container environment or a working directory at all.**
-`src/bosn/manifest.py` has no `env`/`environment` table, and neither `converge.py`'s
-`docker create` (`args = ["create", "--rm", "--name", name, *labels, ...]`, no `-e`) nor
-its `docker exec` (`args = ["exec", name, *command]`, no `-w`) pass either. Everything a
-container gets on either axis comes from what its *image* bakes in via `ENV` /
-`WORKDIR` — which is exactly why bosn's own dogfood image (`docker/test.Dockerfile`) sets
-`WORKDIR /repo` explicitly, line 17. soldr's image does not need to, because
-`perf_local.py` supplies both axes itself at container-create time
+**Historical note (resolved by #105): `bosn.toml` used to be unable to declare container
+environment or a working directory at all.** `src/bosn/manifest.py` had no `env` table or
+`workdir` key, and neither `converge.py`'s `docker create` nor its `docker exec` passed
+`-e`/`-w`. Everything a container got on either axis came from what its *image* baked in
+via `ENV` / `WORKDIR` — which is exactly why bosn's own dogfood image
+(`docker/test.Dockerfile`) sets `WORKDIR /repo` explicitly, line 17. soldr's image does
+not need to, because `perf_local.py` supplies both axes itself at container-create time
 (`create_command()` in `ci/perf_local.py`): `-w /repo`, plus eight `-e` flags —
 `CARGO_TARGET_DIR=/target`, `TMPDIR=/target/tmp`, `CARGO_BUILD_JOBS=2`, `SOLDR_JOBS=2`,
 `UV_CACHE_DIR=/root/.cache/uv`, `UV_PROJECT_ENVIRONMENT=/venv`, `NEXTEST_TEST_THREADS=2`
@@ -94,31 +95,41 @@ Checked against `docker/cook-shared-cache/Dockerfile` line by line (not just gre
 the file's `ENV` blocks span backslash-continued lines that a naive grep for `ENV` would
 miss part of):
 
-| create-time flag | baked into the image's own `ENV`? | consequence if bosn supplies neither |
-| --- | --- | --- |
-| `CARGO_HOME` | yes (line 86) | none — the volume above lands correctly regardless |
-| `UV_CACHE_DIR`, `UV_PROJECT_ENVIRONMENT` | yes (lines 133–134) | none, same reason |
-| `CARGO_BUILD_JOBS`, `SOLDR_JOBS` | yes (lines 91–92) | none, same reason |
-| `CARGO_TARGET_DIR` | **no** | **breaks cache correctness**: Cargo falls back to `<cwd>/target`, not the `/target` volume |
-| `TMPDIR` | no | smoke-suite temp binaries fall back to the container overlay instead of the target volume (perf, not correctness) |
-| `NEXTEST_TEST_THREADS` | no | nextest picks its own default thread count instead of 2 (perf, not correctness) |
-| working directory (`-w /repo`) | no (image `WORKDIR` is `/work`, an empty dir) | any command that assumes it starts inside the repo fails outright |
+| create-time flag | baked into the image's own `ENV`? | consequence if bosn supplies neither | bosn's #105 fix |
+| --- | --- | --- | --- |
+| `CARGO_HOME` | yes (line 86) | none — the volume above lands correctly regardless | not needed |
+| `UV_CACHE_DIR`, `UV_PROJECT_ENVIRONMENT` | yes (lines 133–134) | none, same reason | not needed |
+| `CARGO_BUILD_JOBS`, `SOLDR_JOBS` | yes (lines 91–92) | none, same reason | not needed |
+| `CARGO_TARGET_DIR` | **no** | **breaks cache correctness**: Cargo falls back to `<cwd>/target`, not the `/target` volume | closed — `[stack.perf.env]` in `examples/soldr.toml` |
+| `TMPDIR` | no | smoke-suite temp binaries fall back to the container overlay instead of the target volume (perf, not correctness) | still open (see below) |
+| `NEXTEST_TEST_THREADS` | no | nextest picks its own default thread count instead of 2 (perf, not correctness) | still open (see below) |
+| working directory (`-w /repo`) | no (image `WORKDIR` is `/work`, an empty dir) | any command that assumes it starts inside the repo fails outright | closed — `workdir = "/repo"` in `examples/soldr.toml` |
 
-So the picture is narrower than "one missing variable": three of soldr's four
-container-side ENV needs are already covered by the image's own defaults and need nothing
-from bosn, one (`CARGO_TARGET_DIR`) silently breaks cache correctness if unaddressed, two
-more degrade performance without breaking correctness, and the working directory is a
-separate, unrelated gap that breaks outright rather than silently. `examples/soldr.toml`'s
-`[task.check]` works around the workdir gap with `cd /repo &&` (cmd runs via `sh -c`, see
-`cli.py`/`converge.py`), which is enough to make `cargo check` run in the right place —
-but *not* enough to make it use the `/target` volume, because `cd` cannot set
-`CARGO_TARGET_DIR`. That specific combination — task runs successfully, uses the wrong
-target dir, builds inside the `/repo` bind on the host instead of the cache volume — is
-the one place this manifest "looks right" while doing the wrong thing, and it is called
-out at the point of use in `examples/soldr.toml`. Closing it for real needs either (a) a
-thin Dockerfile layered on soldr's own that adds `ENV CARGO_TARGET_DIR=/target` (and,
-optionally, `WORKDIR /repo`), or (b) bosn growing a way to declare container environment
-and/or working directory — neither exists today.
+`src/bosn/manifest.py` now has a `[stack.X.env]` table (validated: an empty key or a key
+containing `=` is a manifest error) and a `workdir` key on the stack (validated: must be an
+absolute path, sharing its validator with `MountSpec`/`VolumeSpec`'s destination check).
+`converge.py`'s `docker create` now emits `--env KEY=VALUE` for every declared entry, and
+its `docker exec` (both the task path and the interactive shell path) now emits `--workdir`
+when one is declared. `examples/soldr.toml` uses both: `[stack.perf.env]` declares
+`CARGO_TARGET_DIR = "/target"`, and `workdir = "/repo"` replaced `[task.check]`'s old
+`cd /repo &&` workaround with a real working directory. That workaround was never enough
+on its own — `cd` gets `cargo check` running in the right place but cannot set
+`CARGO_TARGET_DIR`, so the task used to run successfully while still quietly building into
+`/repo/target` on the bind mount instead of the `/target` volume. Both halves of that gap
+are closed now.
+
+Two things remain genuinely open, and are unrelated to #105's fix:
+
+- `TMPDIR`, `CARGO_BUILD_JOBS`, `SOLDR_JOBS`, `NEXTEST_TEST_THREADS` are not declared in
+  `examples/soldr.toml`'s `env` table. All four are perf-only (see table above), not
+  correctness gaps like `CARGO_TARGET_DIR` was, so leaving them out is a choice, not an
+  oversight — the reference manifest declares only what changes correctness.
+- The issue's own "suggested direction" also raised a speculative idea: bosn could warn
+  when a well-known cache-path env var (`CARGO_TARGET_DIR` and friends) points somewhere no
+  declared mount destination covers, which is really what would have caught soldr's
+  original gap structurally instead of by manual line-by-line audit. That is explicitly out
+  of scope for #105 (needs its own design for what "well-known" means and how false
+  positives are avoided) and is not implemented here.
 
 **Adoption was not exercised against real soldr volumes.** #75 also asked to run
 `bosn adopt --legacy soldr --yes` against real soldr cache volumes and measure the result.

--- a/examples/soldr.toml
+++ b/examples/soldr.toml
@@ -10,13 +10,13 @@
 # `<soldr-checkout>/bosn.toml` (the `source = "."` bind below assumes the manifest sits at
 # the checkout root, exactly like bosn's own dogfood `bosn.toml` mounts `.` at `/repo`).
 #
-# Ground truth for every destination and scope below was read directly from soldr's own
-# source on this machine, not inferred or guessed:
+# Ground truth for every destination, scope, ENV, and workdir claim below was read directly
+# from soldr's own source on this machine, not inferred or guessed:
 #   - `ci/perf_local.py`, `Runner` / `runner_for()` / `create_command()` (the six `-v`
-#     mounts and the container's `-e` environment)
+#     mounts, the `-w /repo`, and the container's `-e` environment)
 #   - `docker/cook-shared-cache/Dockerfile` (which of those container paths are also baked
-#     in as image `ENV`, and which are not -- see the `target`/`cargo-target-dir` comment
-#     below for the one gap that leaves)
+#     in as image `ENV`, and which are not -- see `[stack.perf.env]` below for the one
+#     that was not, and how it is expressed now that bosn's manifest can say so (#105))
 
 [stack.perf]
 # The image `ci/perf_local.py`'s own `ensure_image()` builds and tags locally. bosn does
@@ -30,6 +30,21 @@
 image = "soldr-cook-dev"
 family = "soldr"
 default = true
+# perf_local.py's create_command() supplies `-w /repo` itself at container-create time
+# (the image's own WORKDIR is `/work`, an empty directory soldr never repoints -- see
+# docs/soldr-integration.md). bosn now has the same knob (#105): declaring it here means
+# `[task.check]` below no longer needs a `cd /repo &&` workaround to run in the right place.
+workdir = "/repo"
+
+[stack.perf.env]
+# perf_local.py's create_command() also passes `-e CARGO_TARGET_DIR=/target`, and that ENV
+# is not baked into the Dockerfile the way CARGO_HOME is (grepped; absent) -- see the
+# `target` volume comment below. Before #105, bosn's manifest had no way to declare
+# container environment at all, so this stack alone did not make cargo use the `/target`
+# volume: `cd /repo && cargo check` ran in the right directory but still built into
+# `/repo/target` inside the bind mount, silently missing the cache the volume exists to
+# keep warm. Declaring it here closes that gap for real, instead of working around it.
+CARGO_TARGET_DIR = "/target"
 
 [stack.perf.mounts]
 # soldr's edit-in-place bind (perf_local.py: `-v {source_root.resolve()}:/repo`). This is
@@ -61,27 +76,23 @@ uv-cache   = { scope = "machine", destination = "/root/.cache/uv" }
 # granularity for `Runner.volumes`, just reachable from a *different* set of checkouts (see
 # docs/soldr-integration.md for why those two granularities are not the same claim).
 #
-# NOTE: mounting `target` here reproduces soldr's *volume*, not its *behavior*. Cargo only
-# writes to `/target` because `perf_local.py`'s `create_command()` also passes
-# `-e CARGO_TARGET_DIR=/target` at container-create time -- and that ENV is not baked into
-# the Dockerfile the way CARGO_HOME is (grepped; absent). bosn's manifest has no mechanism
-# to declare container environment variables, so this stack alone does not make cargo use
-# this volume -- see docs/soldr-integration.md, "What this does not govern."
+# NOTE: mounting `target` here reproduces soldr's *volume*, not (on its own) its
+# *behavior*. Cargo only writes to `/target` because `perf_local.py`'s `create_command()`
+# also passes `-e CARGO_TARGET_DIR=/target` at container-create time -- and that ENV is not
+# baked into the Dockerfile the way CARGO_HOME is (grepped; absent). `[stack.perf.env]`
+# above supplies that same variable through bosn's own `env` table (#105), which is what
+# actually makes this volume the one Cargo writes into.
 target = { scope = "stack", destination = "/target" }
 venv   = { scope = "stack", destination = "/venv" }
 
 [task.check]
 stack = "perf"
-# Two things `perf_local.py` sets at container-create time have no bosn.toml equivalent
-# today (bosn's manifest has no way to declare container ENV, and neither `converge.py`'s
-# `docker create` nor its `docker exec` pass a `-w`/workdir override -- see
-# docs/soldr-integration.md, "What this does not govern"):
-#   - CARGO_TARGET_DIR=/target -- without it Cargo defaults to `<cwd>/target`, so this task
-#     works around the gap with `cd /repo` (the image's baked-in WORKDIR is `/work`, an
-#     empty directory -- soldr's own Dockerfile never sets `WORKDIR /repo` because
-#     perf_local.py always supplies `-w /repo` itself) but STILL builds into `/repo/target`
-#     inside the bind mount, not the `/target` volume above. That volume is real; nothing
-#     in this stack makes Cargo use it.
-#   - TMPDIR=/target/tmp, CARGO_BUILD_JOBS, SOLDR_JOBS, NEXTEST_TEST_THREADS -- degrade
-#     behavior (e.g. temp files fall back to the container overlay) rather than break it.
-cmd = "cd /repo && cargo check --workspace"
+# perf_local.py sets four more `-e` flags at container-create time that this task still
+# does not reproduce: TMPDIR=/target/tmp, CARGO_BUILD_JOBS, SOLDR_JOBS,
+# NEXTEST_TEST_THREADS. All four degrade behavior rather than break it (e.g. temp files
+# fall back to the container overlay instead of the target volume; nextest picks its own
+# default thread count) -- see docs/soldr-integration.md, "What this does not govern".
+# CARGO_TARGET_DIR and the working directory, the two that used to be silent-wrongness and
+# outright-failure gaps respectively, are now closed above via `[stack.perf.env]` and
+# `workdir = "/repo"` -- no `cd /repo &&` workaround needed any more.
+cmd = "cargo check --workspace"

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -599,6 +599,12 @@ class Converger:
             for mount in expected_mounts.values():
                 suffix = ":ro" if not mount["rw"] else ""
                 args += ["--volume", f"{mount['source']}:{mount['destination']}{suffix}"]
+            # Sorted for a deterministic argv (helps tests and log-reading humans), not for
+            # correctness: `stack.env` is part of `converged.digest` (see
+            # `generation_digest`'s comment on why), so any change here already forces a
+            # fresh container through `_container_stale_reasons` before this code runs.
+            for key, value in sorted(stack.env.items()):
+                args += ["--env", f"{key}={value}"]
             # PID 1 exits only when the daemon heartbeat goes stale. Execution deadlines
             # belong to the individual `docker exec`, not the container's creation time:
             # a warm container may correctly serve many later sessions.
@@ -1000,7 +1006,12 @@ class Converger:
         name, leases = self._acquire_execution_container(
             converged, stack_name=stack_name, workspace=workspace
         )
-        args = ["exec", name, *command]
+        # `workdir` is not baked into the container at create time (see
+        # `generation_digest`'s comment on why it is excluded from the digest) -- it is
+        # supplied here, fresh, on every `exec`, the same way `command` itself is.
+        workdir = self.manifest.stack(converged.stack).workdir
+        workdir_args = ["--workdir", workdir] if workdir else []
+        args = ["exec", *workdir_args, name, *command]
         try:
             result = self.engine.run(args, timeout=self.run_max_duration)
         finally:
@@ -1016,8 +1027,10 @@ class Converger:
         name, leases = self._acquire_execution_container(
             converged, stack_name=stack_name, workspace=workspace
         )
+        workdir = self.manifest.stack(converged.stack).workdir
+        workdir_args = ["--workdir", workdir] if workdir else []
         try:
-            return self.engine.interactive(["exec", "-it", name, "sh"])
+            return self.engine.interactive(["exec", "-it", *workdir_args, name, "sh"])
         finally:
             for lease in leases:
                 self.registry.release_lease(lease.id)

--- a/src/bosn/manifest.py
+++ b/src/bosn/manifest.py
@@ -49,6 +49,30 @@ def _validate_destination(destination: str, *, what: str, name: str) -> str:
     return normalized
 
 
+def _validate_workdir(workdir: str, *, stack: str) -> str:
+    """A stack's `workdir` must be an absolute path, same as any mount destination.
+
+    Reuses `_validate_destination` wholesale rather than re-deriving "absolute, and not
+    inside bosn's reserved namespace" a second time. The reserved-namespace half is a
+    freebie, not the point (nothing stops `sh -c` from `cd`-ing there once running), but
+    there is no legitimate reason a task would want its cwd to start inside `/bosn/*` or
+    at the heartbeat file, so refusing it here is consistent with why mounts refuse it.
+    """
+    return _validate_destination(workdir, what="workdir", name=stack)
+
+
+def _validate_env_key(key: str, *, stack: str) -> None:
+    """`docker create -e` splits its argument on the first `=`; an empty or `=`-bearing
+    key would either be silently misparsed by the engine or collide with the value it is
+    supposed to precede. Catching it here, at manifest load, is a much better failure mode
+    than a wrong container running and 1000 miles from the missing environment variable.
+    """
+    if not key:
+        raise ManifestError(f"[stack.{stack}.env] has an empty key")
+    if "=" in key:
+        raise ManifestError(f"[stack.{stack}.env] key {key!r} must not contain '='")
+
+
 @dataclass(frozen=True)
 class VolumeSpec:
     name: str
@@ -136,6 +160,26 @@ class StackSpec:
     default: bool = False
     volumes: tuple[VolumeSpec, ...] = ()
     mounts: tuple[MountSpec, ...] = ()
+    # Container-level `-e KEY=VALUE` pairs, applied at `docker create` (see converge.py).
+    # A dict, not a tuple of a small dataclass like VolumeSpec/MountSpec: there is nothing
+    # here to validate per-entry beyond the key shape (`_validate_env_key`), no destination,
+    # no scope, no readonly flag -- the extra structure those specs carry would be empty
+    # ceremony for a bare key/value pair. `field(default_factory=dict)` is safe on a frozen
+    # dataclass: frozen only blocks *reassigning* `self.env`, not mutating the dict object,
+    # and nothing here ever mutates it after construction.
+    env: dict[str, str] = field(default_factory=dict)
+    # Container-level `-w` override, applied at `docker exec` (see converge.py). Unlike
+    # `env`, this is not baked into the persistent container at `docker create` time -- it
+    # is supplied fresh on every `exec`, the same way a task's `cmd` is. See
+    # `generation_digest`'s comment on why that puts it on the opposite side of the digest
+    # boundary from `env`.
+    workdir: str | None = None
+
+    def __post_init__(self) -> None:
+        for key in self.env:
+            _validate_env_key(key, stack=self.name)
+        if self.workdir is not None:
+            object.__setattr__(self, "workdir", _validate_workdir(self.workdir, stack=self.name))
 
     def referenced_files(self, root: Path) -> list[Path]:
         """Files whose byte content folds into this stack's digest."""
@@ -277,6 +321,14 @@ def parse(raw: dict, root: Path) -> Manifest:
             for mount_name, mount_body in (body.get("mounts") or {}).items()
         )
         _refuse_duplicate_destinations(name, volumes, mounts)
+        env: dict[str, str] = {}
+        for env_key, env_value in (body.get("env") or {}).items():
+            if isinstance(env_value, (dict, list)):
+                raise ManifestError(
+                    f"[stack.{name}.env] key {env_key!r} must be a scalar, not a table or array"
+                )
+            env[str(env_key)] = str(env_value)
+        workdir = body.get("workdir")
         stack = StackSpec(
             name=name,
             dockerfile=body.get("dockerfile"),
@@ -285,6 +337,8 @@ def parse(raw: dict, root: Path) -> Manifest:
             default=bool(body.get("default", False)),
             volumes=volumes,
             mounts=mounts,
+            env=env,
+            workdir=str(workdir) if workdir else None,
         )
         if stack.dockerfile is None and stack.image is None:
             raise ManifestError(f"[stack.{name}] must set either `dockerfile` or `image`")
@@ -331,6 +385,35 @@ def generation_digest(manifest: Manifest, stack: StackSpec) -> str:
         # content identity -- and hashing it would be both enormous and never stable.
         "volumes": sorted((v.name, v.scope, v.mount_at()) for v in stack.volumes),
         "mounts": sorted((m.name, m.source, m.destination, m.readonly) for m in stack.mounts),
+        # `env` IS digested; `workdir` (below `referenced_files`, not in this dict at all)
+        # is NOT. Both look like "just another stack attribute" but they land on opposite
+        # sides of `docker create` vs `docker exec`, and that is what decides this, not
+        # convenience:
+        #
+        # `env` is baked into the persistent container at `docker create` time, exactly
+        # like the image tag or a volume mount -- Docker has no "update the env of a
+        # running container" verb, so once created, a container serves its create-time env
+        # forever. If `env` were excluded from the digest the way a bind's *contents* are
+        # (see the comment on `mounts` above), an env edit would change nothing this
+        # function hashes, `_container_stale_reasons` would see the same generation and
+        # happily reuse the old container, and every task run against it would keep
+        # observing the stale environment indefinitely -- silently, with no error, in
+        # exactly the same shape as the `CARGO_TARGET_DIR` bug that motivated this feature
+        # in the first place (issue #105). That risk -- an unrelated env tweak forcing an
+        # otherwise-warm generation to roll -- is real but bounded and visible: the task
+        # rebuilds once, obviously, and moves on. A stale env silently steering a build
+        # into the wrong place is unbounded and invisible. Digesting it is the smaller cost.
+        #
+        # `workdir` is supplied fresh on every `docker exec` (see `converge.py`), never
+        # baked into the container at create time -- it is closer to a task's `cmd` than to
+        # `env`, and `cmd` (on `TaskSpec`, not `StackSpec`) was never part of this digest
+        # either. There is no "stale workdir survives in an old container" failure mode to
+        # guard against: the very next `exec` picks up whatever `workdir` currently reads.
+        # Digesting it anyway would force a container replacement for a change that cannot
+        # make the existing container wrong, which is exactly the kind of unrelated-cache-
+        # invalidation cost `env`'s comment above accepts only because the alternative is
+        # worse. For `workdir` the alternative is not worse, so it stays out.
+        "env": sorted(stack.env.items()),
     }
     _hash_field(
         hasher,

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -1079,6 +1079,101 @@ secrets = { source = "secrets", destination = "/etc/app", readonly = true }
     assert f"{source}:/etc/app:ro" in create
 
 
+def test_declared_env_reaches_docker_create_as_env_flags(
+    tmp_path: Path, registry: Registry
+) -> None:
+    """The #105 gap: `converge.py` used to pass no `-e` at all, so a manifest `env` table
+    was silently invisible to the container regardless of what it declared."""
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(
+        """
+[stack.test]
+dockerfile = "Dockerfile"
+default = true
+
+[stack.test.env]
+CARGO_TARGET_DIR = "/target"
+TMPDIR = "/target/tmp"
+""",
+        encoding="utf-8",
+    )
+    engine = FakeEngine()
+    converger = Converger(load(tmp_path), registry, engine)  # type: ignore[arg-type]
+
+    converger.run(["true"])
+
+    create = engine.ran("create")[0]
+    assert "--env" in create
+    assert "CARGO_TARGET_DIR=/target" in create
+    assert "TMPDIR=/target/tmp" in create
+
+
+def test_no_env_table_means_no_env_flags(converger: Converger) -> None:
+    converger.run(["true"])
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+
+    assert "--env" not in engine.ran("create")[0]
+
+
+def test_declared_workdir_reaches_docker_exec_as_a_workdir_flag(
+    tmp_path: Path, registry: Registry
+) -> None:
+    """The #105 gap: `converge.py` used to pass no `-w` at all, so any command assuming it
+    started inside a manifest-declared `workdir` would run from the image's own `WORKDIR`
+    (or its default) instead."""
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(
+        """
+[stack.test]
+dockerfile = "Dockerfile"
+default = true
+workdir = "/repo"
+""",
+        encoding="utf-8",
+    )
+    engine = FakeEngine()
+    converger = Converger(load(tmp_path), registry, engine)  # type: ignore[arg-type]
+
+    converger.run(["cargo", "check"])
+
+    exec_cmd = engine.ran("exec")[0]
+    assert exec_cmd == ["exec", "--workdir", "/repo", exec_cmd[3], "cargo", "check"]
+
+
+def test_declared_workdir_also_reaches_an_interactive_shell(
+    tmp_path: Path, registry: Registry
+) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text(
+        """
+[stack.test]
+dockerfile = "Dockerfile"
+default = true
+workdir = "/repo"
+""",
+        encoding="utf-8",
+    )
+    engine = FakeEngine()
+    converger = Converger(load(tmp_path), registry, engine)  # type: ignore[arg-type]
+    converged = converger.converge()
+
+    converger.shell_converged(
+        converged, stack_name=None, workspace=workspace_of(converger.manifest)
+    )
+
+    exec_cmd = engine.ran("exec")[0]
+    assert exec_cmd[1:3] == ["-it", "--workdir"]
+    assert exec_cmd[3] == "/repo"
+
+
+def test_no_workdir_means_no_workdir_flag(converger: Converger) -> None:
+    converger.run(["true"])
+    engine: FakeEngine = converger.engine  # type: ignore[assignment]
+
+    exec_cmd = engine.ran("exec")[0]
+    assert "--workdir" not in exec_cmd
+
+
 def test_bind_mount_source_is_never_registered_labeled_or_collected(
     bind_project: Path, registry: Registry
 ) -> None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -471,6 +471,95 @@ def test_a_git_bash_spelled_bind_source_resolves(tmp_path: Path) -> None:
     assert stack.mounts[0].resolve_source(root) == (root / "src").resolve()
 
 
+# -- container env and workdir (#105) ---------------------------------------
+
+ENV_SAMPLE = """
+[stack.test]
+dockerfile = "docker/test.Dockerfile"
+default = true
+workdir = "/repo"
+
+[stack.test.env]
+CARGO_TARGET_DIR = "/target"
+TMPDIR = "/target/tmp"
+"""
+
+
+def test_env_and_workdir_parse(project: Path) -> None:
+    (project / "bosn.toml").write_text(ENV_SAMPLE, encoding="utf-8")
+    stack = load(project).stacks["test"]
+
+    assert stack.env == {"CARGO_TARGET_DIR": "/target", "TMPDIR": "/target/tmp"}
+    assert stack.workdir == "/repo"
+
+
+def test_env_and_workdir_default_to_empty_and_none(project: Path) -> None:
+    stack = load(project).stacks["test"]
+
+    assert stack.env == {}
+    assert stack.workdir is None
+
+
+def test_an_empty_env_key_is_rejected(tmp_path: Path) -> None:
+    # TOML requires a quoted key to spell an empty string; a bare empty key is a syntax
+    # error caught by the TOML parser itself, not by bosn's own validation.
+    body = ENV_SAMPLE.replace('CARGO_TARGET_DIR = "/target"', '"" = "/target"')
+    with pytest.raises(ManifestError, match="empty key"):
+        load(_write(tmp_path, body))
+
+
+def test_an_env_key_containing_equals_is_rejected(tmp_path: Path) -> None:
+    # Same reasoning as the empty-key test above: a bare TOML key cannot contain '=', so
+    # the offending key must be quoted to reach bosn's own validation at all.
+    body = ENV_SAMPLE.replace('CARGO_TARGET_DIR = "/target"', '"CARGO=TARGET_DIR" = "/target"')
+    with pytest.raises(ManifestError, match="must not contain '='"):
+        load(_write(tmp_path, body))
+
+
+def test_an_env_value_that_is_a_table_is_rejected(tmp_path: Path) -> None:
+    body = ENV_SAMPLE.replace('CARGO_TARGET_DIR = "/target"', "CARGO_TARGET_DIR = { nested = 1 }")
+    with pytest.raises(ManifestError, match="must be a scalar"):
+        load(_write(tmp_path, body))
+
+
+def test_a_relative_workdir_is_refused(tmp_path: Path) -> None:
+    body = ENV_SAMPLE.replace('workdir = "/repo"', 'workdir = "repo"')
+    with pytest.raises(ManifestError, match="absolute"):
+        load(_write(tmp_path, body))
+
+
+def test_a_workdir_inside_bosns_own_namespace_is_refused(tmp_path: Path) -> None:
+    body = ENV_SAMPLE.replace('workdir = "/repo"', 'workdir = "/bosn/target"')
+    with pytest.raises(ManifestError, match="reserved"):
+        load(_write(tmp_path, body))
+
+
+def test_editing_env_rolls_the_generation(tmp_path: Path) -> None:
+    """`env` is baked into the persistent container at create time -- see the comment on
+    `generation_digest` for why an env edit must roll the generation rather than silently
+    leaving an already-warm container serving its old environment forever."""
+    before = load(_write(tmp_path, ENV_SAMPLE))
+    after = load(_write(tmp_path, ENV_SAMPLE.replace('"/target"', '"/elsewhere"')))
+
+    assert generation_digest(before, before.stacks["test"]) != generation_digest(
+        after, after.stacks["test"]
+    )
+
+
+def test_editing_workdir_does_not_roll_the_generation(tmp_path: Path) -> None:
+    """`workdir` is supplied fresh on every `docker exec`, never baked into the container
+    at create time -- see the comment on `generation_digest` for why it deliberately sits
+    on the opposite side of the digest boundary from `env`."""
+    before = load(_write(tmp_path, ENV_SAMPLE))
+    after = load(
+        _write(tmp_path, ENV_SAMPLE.replace('workdir = "/repo"', 'workdir = "/elsewhere"'))
+    )
+
+    assert generation_digest(before, before.stacks["test"]) == generation_digest(
+        after, after.stacks["test"]
+    )
+
+
 # -- examples/soldr.toml expresses soldr's actual perf-local mount table (#75) ----------
 #
 # `Runner.volumes`/`create_command()` in soldr's `ci/perf_local.py` mount six paths: one


### PR DESCRIPTION
Closes #105.

## The gap

`converge.py` passed **no `-e`** at `docker create` and **no `-w`** at `docker exec`. Everything a container saw came from the image's own `ENV`/`WORKDIR`, and the manifest had no key for either.

Invisible for images bosn builds itself — the Dockerfile bakes in what it needs. It bites when governing an image built for *another* harness, which is exactly what `adopt --legacy` and the soldr integration exist for.

## Why this was worth fixing rather than documenting

Checked line by line against soldr's real `docker/cook-shared-cache/Dockerfile`:

- 6 of soldr's 8 create-time flags are already baked into the image — harmless to omit
- `WORKDIR` was a **visible** gap: commands ran in the wrong directory, which fails loudly, and a task could work around it with `cd /repo &&`
- `CARGO_TARGET_DIR` was a **silent** one: not baked in, so Cargo falls back to `<cwd>/target` and builds *outside* the `/target` volume entirely. Nothing errors. The build succeeds. The cache the stack exists to keep warm is simply never used.

A stack that looks correctly wired quietly builds into the wrong place, and the symptom — "the cache doesn't seem to help" — is a long way from the cause. That is the class of bug worth code rather than a doc note.

## The design decision worth reviewing

`env` and `workdir` look like sibling stack attributes, but they land on opposite sides of the digest boundary, and the deciding question is **`docker create` vs `docker exec`**:

| | digested? | why |
|---|---|---|
| `env` | **yes** | baked into the persistent container at create time; Docker has no verb to change a running container's env |
| `workdir` | **no** | supplied fresh on every `exec`, exactly like a task's `cmd` — which was never digested either |

If `env` were excluded, an env edit would change nothing the digest hashes, `_container_stale_reasons` would see an unchanged generation, and the old container would be reused forever — serving the stale environment indefinitely. That is the same silent-wrongness this issue exists to remove, so the cost (one visible rebuild after an env edit) buys the removal of an invisible, unbounded failure.

Conversely, digesting `workdir` would force container replacement for a change that cannot make the existing container wrong, since no stale value can survive in it.

Both decisions are documented at length in `generation_digest`'s comment — where the next person will look — and pinned by tests, so they stay decisions rather than becoming incidental.

## Tests

Argv-level, not parse-level: they assert `--env` and `--workdir` actually reach the recorded engine `create`/`exec` argv, plus that absence emits no flag. The entire defect was that declared values never reached the engine, which a "the manifest parses" test would not have caught.

Also: manifest validation rejects empty env keys, `=` in a key, non-scalar values, and relative or reserved-namespace workdirs (reusing the existing destination validator rather than duplicating it).

## Follow-through

`examples/soldr.toml` now declares `CARGO_TARGET_DIR = "/target"` and a real `workdir = "/repo"`, dropping the `cd /repo &&` workaround from its task. `docs/soldr-integration.md` stops listing both under "what it does not govern" — that text was true when written and is now wrong.

Deliberately **not** implemented: the speculative "warn when a well-known cache env var points outside every mount destination" idea from the issue. It needs its own design and was not allowed to ride along on this one.

## Verification

- `ci/lint.py` → `LINT OK` (pyright 0 errors)
- `pytest tests/ -q -m "not docker"` → 992 passed, 2 skipped (on a tree that also carried a concurrent agent's #106 work; CI verifies this branch in isolation)
