### PR TITLE
fix(accounting): stop reporting an unmeasurable host as an empty one (#106)

### DIFF
--- a/src/bosn/accounting.py
+++ b/src/bosn/accounting.py
@@ -19,6 +19,25 @@ from bosn.registry import Resource
 _INVENTORY_COMMAND = ["system", "df", "-v", "--format", "{{json .}}"]
 _SIZE = re.compile(r"^([0-9]+(?:\.[0-9]+)?)\s*([kmgtpe]?b)$", re.I)
 
+# `StorageInventory.collect` deliberately does not pass a bespoke `timeout=` to
+# `engine.run` here, unlike `compose-adopt` (#99), which needed one because its 45s figure
+# was measured against a documented failure: the batched scan reliably landed past the
+# shared 10s *IPC client* budget, so a shorter deadline was silently returning stale
+# bookkeeping to the caller while `compose build` still reported success. That specific
+# failure mode does not apply to this call in the same way: `engine.run` already has its
+# own 60s default (`Engine.DEFAULT_TIMEOUT`), and after this issue's fix (#106) a command
+# that runs past *that* deadline lands in `collect`'s `except Exception` branch below,
+# which now returns `measured=False` and is logged by `gc.py` as `gc.inventory_unmeasured`
+# rather than silently reading as "zero bytes, no pressure". The failure changed from
+# silent-fail-open to loud-abstain, which was the actual problem -- a slow `system df -v`
+# no longer needs a bigger deadline to be safe, it needs its slowness to stop lying.
+#
+# A real widening of `ipc.DEFAULT_TIMEOUT` for the `gc` verb specifically (the same
+# category of problem #99 fixed for `compose-adopt`: the CLI's `bosn gc` waits only the
+# shared 10s IPC budget while the daemon-side `Collector.collect` can legitimately run
+# past it, including this call) is a separate, pre-existing gap that lives in
+# `daemon.request`/`cli.py`'s `cmd_gc`, not in this module, and is out of scope here.
+
 
 @dataclass(frozen=True)
 class StorageProbe:
@@ -40,9 +59,27 @@ def _bytes(value: object) -> int | None:
 
 @dataclass(frozen=True)
 class StorageInventory:
-    """One `system df -v` snapshot, avoiding per-resource commands and layer double counting."""
+    """One `system df -v` snapshot, avoiding per-resource commands and layer double counting.
+
+    ``measured`` is the whole point of this dataclass existing separately from a bare dict
+    (issue #106). Before it existed, `collect` returned `cls({})` on every failure path --
+    engine unreachable, non-zero exit, unparseable JSON -- and an *empty-because-nothing-to-
+    measure* host produced exactly the same `sizes == {}` as an *empty-because-the-command-
+    failed* host. Those two situations must never be conflated: an empty dict fed
+    `Pressure.assess` as `managed_bytes=0`, which reads as "measured, and it is zero" --
+    "no byte pressure" -- when what actually happened is "unmeasured, so silence about
+    pressure, not a clean bill of health". The condition GC exists to relieve (a host with
+    hundreds of Docker objects) is also the condition that makes `system df -v` slowest and
+    likeliest to fail or time out, so this is a directional failure: exactly the hosts that
+    most need reclamation are the ones most likely to look, incorrectly, like they don't.
+
+    `measured=True` with `sizes=={}` is a legitimate, common state (a fresh host with no
+    Docker objects at all) and must stay indistinguishable from any other successful-but-
+    small measurement -- it is not itself evidence of a problem.
+    """
 
     sizes: dict[tuple[str, str], int]
+    measured: bool = True
 
     @classmethod
     def collect(cls, engine: Engine) -> StorageInventory:
@@ -51,14 +88,27 @@ class StorageInventory:
         except KeyboardInterrupt:
             raise
         except Exception:  # noqa: BLE001 - status must still expose unknown measurements offline
-            return cls({})
+            return cls({}, measured=False)
         if not result.ok:
-            return cls({})
+            return cls({}, measured=False)
         sizes: dict[tuple[str, str], int] = {}
         try:
             rows = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
         except json.JSONDecodeError:
-            return cls({})
+            return cls({}, measured=False)
+        if not rows:
+            # A healthy `system df -v --format {{json .}}` emits exactly one JSON object per
+            # invocation -- verified live against a real, busy Docker host (a single line,
+            # keys `Images`/`Containers`/`Volumes`/`BuildCache` all present and non-empty
+            # there). That host had objects in every category, so "keys present as empty
+            # arrays when a category is genuinely empty" is inferred from the fixed format
+            # struct rather than observed directly; `test_a_genuinely_empty_host_is_still_
+            # measured` below pins that inferred contract as the assumption this code relies
+            # on. Either way, zero parseable lines on a `returncode == 0` exit is not that
+            # shape -- it is indistinguishable from a client that silently produced no
+            # output -- so treat it as unmeasured rather than trusting an empty result we
+            # cannot explain.
+            return cls({}, measured=False)
         for row in rows:
             if not isinstance(row, dict):
                 continue

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -115,6 +115,17 @@ class Collector:
         # `None` means the engine could not answer (unreachable, non-zero exit, unparseable);
         # that is a reason to protect every container, never a reason to treat none as running.
         running_containers = resources.running_container_names(self.engine)
+        if not inventory.measured:
+            # Visible in the event log, not inferred from GC quietly doing nothing (#106):
+            # `docker system df -v` failed, timed out, or returned output we could not
+            # trust, so every resource this pass attributes to `system df -v` reads as
+            # unmeasured rather than zero. `Pressure.assess(bytes_measured=False)` below is
+            # what keeps that from silently reading as "no byte pressure".
+            self.registry.log_event(
+                "gc.inventory_unmeasured",
+                "docker system df -v failed or returned unusable output; "
+                "byte-based pressure detection is blind this pass",
+            )
         # Pressure is intentionally derived here for every pass. The argument remains only
         # as a compatibility shim for callers from older releases and cannot override policy.
         _ = pressure
@@ -123,6 +134,7 @@ class Collector:
             managed_bytes=sum(size for size in measured.values() if size is not None),
             free_bytes=storage.free_bytes,
             managed_bytes_ceiling=int(config.get("shared_cache_ceiling")),
+            bytes_measured=inventory.measured,
         )
         byte_pressure_started = pressure.bytes_exceeded
 
@@ -133,12 +145,14 @@ class Collector:
                 managed_bytes=sum(size for size in measured.values() if size is not None),
                 free_bytes=storage.free_bytes,
                 managed_bytes_ceiling=int(config.get("shared_cache_ceiling")),
+                bytes_measured=inventory.measured,
             )
             if storage.vhdx_slack_bytes is not None and storage.vhdx_slack_bytes > reclaimable:
                 updated = Pressure(
                     under_pressure=updated.count_exceeded or updated.bytes_exceeded,
                     count_exceeded=updated.count_exceeded,
                     bytes_exceeded=updated.bytes_exceeded,
+                    bytes_unknown=updated.bytes_unknown,
                 )
             if any(size is None for size in measured.values()):
                 # Unknown resources cannot prove that a byte target is now satisfied.
@@ -148,6 +162,7 @@ class Collector:
                     or byte_pressure_started,
                     count_exceeded=updated.count_exceeded,
                     bytes_exceeded=updated.bytes_exceeded or byte_pressure_started,
+                    bytes_unknown=updated.bytes_unknown,
                 )
             return updated
 
@@ -174,6 +189,7 @@ class Collector:
                 under_pressure=pressure.count_exceeded or pressure.bytes_exceeded,
                 count_exceeded=pressure.count_exceeded,
                 bytes_exceeded=pressure.bytes_exceeded,
+                bytes_unknown=pressure.bytes_unknown,
             )
             verdicts = plan(
                 self.registry,
@@ -320,11 +336,18 @@ def status(
             bucket["bytes"] += size
     managed_bytes = sum(size for size in measured.values() if size is not None)
     storage = probe(engine, registry.path.parent)
+    # `status` is read-only (works with the daemon dead, opens the registry
+    # `read_only=True`) so it cannot `log_event` the way `Collector.collect` does when the
+    # inventory is unmeasured -- there is no writer available here. `pressure.bytes_unknown`
+    # below is this function's equivalent visibility: a caller inspecting `status()` output
+    # sees explicitly that byte pressure is unproven this pass, rather than reading
+    # `bytes_exceeded: false` as a clean, confirmed "under ceiling".
     pressure = Pressure.assess(
         resource_count=len(measured),
         managed_bytes=managed_bytes,
         free_bytes=storage.free_bytes,
         managed_bytes_ceiling=int(config.get("shared_cache_ceiling")),
+        bytes_measured=inventory.measured,
     )
     running_containers = resources.running_container_names(engine)
     verdicts = plan(
@@ -365,6 +388,7 @@ def status(
             "count_exceeded": pressure.count_exceeded,
             "bytes_exceeded": pressure.bytes_exceeded,
             "free_space_exceeded": pressure.free_space_exceeded,
+            "bytes_unknown": pressure.bytes_unknown,
         },
         "storage": {
             "free_bytes": storage.free_bytes,

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -74,6 +74,40 @@ class Pressure:
     count_exceeded: bool = False
     bytes_exceeded: bool = False
     free_space_exceeded: bool = False
+    # True when `managed_bytes` was not a real measurement (`accounting.StorageInventory`
+    # could not run/parse `docker system df -v` -- issue #106). Kept separate from
+    # `bytes_exceeded` rather than folded into it: three designs were considered for what an
+    # unmeasurable byte total should do to pressure, and this field is the artifact of
+    # picking the third one.
+    #
+    #   1. Unknown-as-pressure (`bytes_exceeded=True` when unmeasured). Rejected: GC deletes
+    #      things. This would start reclaiming warm caches on a host that is not actually
+    #      short on space, purely because `docker system df -v` had a slow or flaky moment --
+    #      trading a false negative for a false positive that does real, irreversible damage.
+    #      The task's own doctrine is explicit about this direction being off-limits.
+    #   2. Unknown-as-zero (`bytes_exceeded=False`, nothing else changes). This is *today's
+    #      bug*: an unmeasurable inventory reads identically to "measured, and it is zero",
+    #      so `bytes_exceeded` silently settles on "no pressure" for the one signal most
+    #      likely to be genuinely true on exactly the hosts where measurement is likeliest to
+    #      fail (object-heavy hosts are both the ones GC exists to relieve and the ones
+    #      `system df -v` is slowest and flakiest on).
+    #   3. Unknown-as-a-distinct-state (chosen). `bytes_exceeded` stays `False` -- still no
+    #      invented pressure, still no aggressive deletion -- but that `False` is now
+    #      distinguishable from a real "confirmed under ceiling" via `bytes_unknown=True`.
+    #      `count_exceeded` and `free_space_exceeded` come from independent sources
+    #      (`len(resource_rows)` and `shutil.disk_usage`/engine `info`, not `system df -v`)
+    #      and keep deciding `under_pressure` on their own merits, exactly as they already do
+    #      for each other -- this mirrors the existing deliberate separation of the three
+    #      `_exceeded` flags rather than introducing a new mechanism.
+    #
+    # This does *not* make `under_pressure` swing to True on an unmeasured inventory by
+    # itself -- the formula below is unchanged, so a caller that only reads `under_pressure`
+    # gets exactly today's conservative behavior. `bytes_unknown` exists for callers who must
+    # not treat "no byte pressure detected" as "byte pressure ruled out": `gc.py` logs an
+    # event so the condition is visible instead of inferred from GC quietly doing nothing,
+    # and status output surfaces it so an operator watching a busy host does not mistake
+    # silence for a clean bill of health.
+    bytes_unknown: bool = False
 
     @classmethod
     def assess(
@@ -85,16 +119,28 @@ class Pressure:
         resource_ceiling: int = DEFAULT_RESOURCE_CEILING,
         managed_bytes_ceiling: int = DEFAULT_MANAGED_BYTES_CEILING,
         min_free_bytes: int = DEFAULT_MIN_FREE_BYTES,
+        bytes_measured: bool = True,
     ) -> Pressure:
-        """Evaluate all three pressure signals without conflating bytes and free space."""
+        """Evaluate all three pressure signals without conflating bytes and free space.
+
+        ``bytes_measured=False`` means ``managed_bytes`` is not a real measurement (the
+        inventory it was summed from could not be collected -- see
+        ``accounting.StorageInventory.measured``). In that case ``managed_bytes`` is not
+        trusted at all: `bytes_exceeded` is forced `False` (never invent pressure from a
+        number that might be entirely wrong) and `bytes_unknown` records that this `False`
+        is an abstention, not a confirmation. `count_exceeded` and `free_space_exceeded` are
+        computed exactly as usual -- they are read from different sources and remain valid
+        even when the byte measurement is not.
+        """
         count_exceeded = resource_count > resource_ceiling
-        bytes_exceeded = managed_bytes > managed_bytes_ceiling
+        bytes_exceeded = bytes_measured and managed_bytes > managed_bytes_ceiling
         free_space_exceeded = free_bytes < min_free_bytes
         return cls(
             under_pressure=count_exceeded or bytes_exceeded or free_space_exceeded,
             count_exceeded=count_exceeded,
             bytes_exceeded=bytes_exceeded,
             free_space_exceeded=free_space_exceeded,
+            bytes_unknown=not bytes_measured,
         )
 
 

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -41,6 +41,39 @@ class Engine:
         )
 
 
+class FailingEngine:
+    """Simulates `docker system df -v` failing outright (non-zero exit)."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(self, args: list[str]) -> EngineResult:
+        self.calls.append(args)
+        return EngineResult(1, "", "Cannot connect to the Docker daemon")
+
+
+class RaisingEngine:
+    """Simulates the engine call itself raising (e.g. `EngineError` on timeout)."""
+
+    def run(self, args: list[str]) -> EngineResult:
+        raise RuntimeError("docker system df -v exceeded its 60-second deadline")
+
+
+class UnparseableEngine:
+    """Simulates `ok` output that is not valid JSON."""
+
+    def run(self, args: list[str]) -> EngineResult:
+        return EngineResult(0, "not json", "")
+
+
+class EmptyOutputEngine:
+    """Simulates a successful exit with no output at all -- not the documented healthy
+    shape (one JSON line, even on an empty host), so it must not be trusted either."""
+
+    def run(self, args: list[str]) -> EngineResult:
+        return EngineResult(0, "", "")
+
+
 class RootEngine:
     def __init__(self, root: str) -> None:
         self.root = root
@@ -61,6 +94,56 @@ def test_system_df_inventory_attributes_volume_without_a_positional_argument() -
         == 20_000_000
     )
     assert inventory.sizes[("container", "c")] == 4_000
+
+
+def test_a_successful_measurement_is_marked_measured() -> None:
+    """Regression guard: the common, healthy path must not start reporting `measured=False`."""
+    inventory = StorageInventory.collect(Engine())  # type: ignore[arg-type]
+    assert inventory.measured is True
+
+
+def test_a_nonzero_exit_is_unmeasured_not_zero_bytes() -> None:
+    """Issue #106: `docker system df -v` failing must not read as "measured, and it is
+    zero" -- an empty `sizes` dict on failure was indistinguishable from a healthy, empty
+    host until `measured` existed to tell them apart."""
+    inventory = StorageInventory.collect(FailingEngine())  # type: ignore[arg-type]
+    assert inventory.sizes == {}
+    assert inventory.measured is False
+
+
+def test_an_engine_exception_is_unmeasured() -> None:
+    inventory = StorageInventory.collect(RaisingEngine())  # type: ignore[arg-type]
+    assert inventory.sizes == {}
+    assert inventory.measured is False
+
+
+def test_unparseable_output_is_unmeasured() -> None:
+    inventory = StorageInventory.collect(UnparseableEngine())  # type: ignore[arg-type]
+    assert inventory.sizes == {}
+    assert inventory.measured is False
+
+
+def test_a_successful_exit_with_no_output_at_all_is_unmeasured() -> None:
+    """A `returncode == 0` exit that produced zero parseable lines is not the documented
+    healthy shape (one JSON object per invocation, even on an empty host) -- treat it as
+    unmeasured rather than trusting a result that cannot be explained."""
+    inventory = StorageInventory.collect(EmptyOutputEngine())  # type: ignore[arg-type]
+    assert inventory.sizes == {}
+    assert inventory.measured is False
+
+
+def test_a_genuinely_empty_host_is_still_measured() -> None:
+    """The legitimate "nothing to report" case (a fresh host, or every category empty)
+    must stay indistinguishable from any other successful small measurement -- it is not
+    itself evidence of a problem, and must not be conflated with collection failure."""
+
+    class EmptyHostEngine:
+        def run(self, args: list[str]) -> EngineResult:
+            return EngineResult(0, json.dumps({"Volumes": [], "Containers": [], "Images": []}), "")
+
+    inventory = StorageInventory.collect(EmptyHostEngine())  # type: ignore[arg-type]
+    assert inventory.sizes == {}
+    assert inventory.measured is True
 
 
 def test_engine_storage_path_prefers_the_engine_root_over_registry_state(tmp_path) -> None:

--- a/tests/test_accounting_docker.py
+++ b/tests/test_accounting_docker.py
@@ -16,6 +16,11 @@ def test_system_df_attributes_a_real_named_volume(engine: Engine) -> None:
     engine.run(["volume", "create", name], check=True)
     try:
         inventory = StorageInventory.collect(engine)
+        # Assert `measured` first (#106): on a busy host `system df -v` can fail or return
+        # unusable output, and the resulting empty `sizes` reads identically to "the volume
+        # is missing" unless the failure is checked separately. This turns that failure mode
+        # from a confusing `None is not None` into an explicit "measurement failed".
+        assert inventory.measured, "system df -v failed or returned unusable output"
         assert inventory.sizes.get(("volume", name)) is not None
     finally:
         engine.run(["volume", "rm", "--force", name])

--- a/tests/test_accounting_pressure.py
+++ b/tests/test_accounting_pressure.py
@@ -1,0 +1,142 @@
+"""Issue #106: an unmeasurable byte inventory must not read as "zero bytes, no pressure".
+
+`accounting.StorageInventory.collect` failing (or returning unusable output) used to come
+back as an empty `sizes` dict indistinguishable from a genuinely empty, healthy host. That
+fed `gc.Collector.collect`/`gc.status`'s `Pressure.assess` a `managed_bytes=0`, so byte
+pressure silently read as absent on exactly the busy hosts most likely to need it detected.
+
+These tests exercise the whole path -- fake engine -> `Collector`/`status` -> `Pressure` --
+rather than just the accounting or retention units in isolation, since the bug was in how
+those two pieces were wired together, not in either one alone. `FakeEngine` and `label_dict`
+are reused from `test_gc.py` (same directory, no package boundary) rather than reimplemented,
+since getting the label namespace (`com.zackees.bosn.*`) and ownership shape wrong here would
+just be a second copy of a fixture that already exists and is exercised elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bosn.accounting import StorageInventory
+from bosn.clock import FakeClock
+from bosn.config import load as load_config
+from bosn.gc import Collector, status
+from bosn.registry import Registry
+from test_gc import OURS, FakeEngine, label_dict
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def registry(tmp_path: Path, clock: FakeClock):
+    with Registry(tmp_path / "r.sqlite3", clock=clock) as reg:
+        yield reg
+
+
+def add(registry: Registry, name: str = "cache"):
+    return registry.register_resource(
+        kind="volume", name=name, stack="s", generation="g", scope="spec", workspace="/w"
+    )
+
+
+def failing_df_engine() -> FakeEngine:
+    """A `FakeEngine` whose `system df -v` call fails; every other call it needs succeeds
+    via `FakeEngine`'s existing fallback (`return EngineResult(0, "", "")` for anything not
+    explicitly handled), which for `system df -v` gives an *empty but ok* result -- exactly
+    the "ok exit, zero parseable rows" shape `StorageInventory.collect` now also treats as
+    unmeasured, so the default `FakeEngine` already exercises this bug without modification.
+    """
+    return FakeEngine({"cache": label_dict(registry=OURS)})
+
+
+@pytest.fixture(autouse=True)
+def _matching_registry_id(registry: Registry) -> None:
+    # `label_dict`'s default owner is the fixed string `OURS` ("our-registry"); make the
+    # registry under test agree, so ownership proof in `Collector._ownership_proven`
+    # succeeds without every test having to thread a matching id through by hand.
+    registry.set_meta("registry_id", OURS)
+
+
+def test_inventory_collection_failure_is_logged_as_an_event(registry: Registry) -> None:
+    """Visibility: an unmeasurable inventory must be visible in the event log, not inferred
+    from GC quietly doing nothing."""
+    add(registry)
+    engine = failing_df_engine()
+
+    Collector(registry, engine).collect(dry_run=True)  # type: ignore[arg-type]
+
+    kinds = [row["kind"] for row in registry.events()]
+    assert "gc.inventory_unmeasured" in kinds
+
+
+def test_a_successful_pass_never_logs_the_unmeasured_event(registry: Registry, monkeypatch) -> None:
+    """Regression guard for the event itself: a healthy measurement must stay silent."""
+    add(registry)
+    engine = failing_df_engine()
+    monkeypatch.setattr(
+        "bosn.gc.StorageInventory.collect",
+        classmethod(lambda _cls, _engine: StorageInventory({("volume", "cache"): 10})),
+    )
+
+    Collector(registry, engine).collect(dry_run=True)  # type: ignore[arg-type]
+
+    kinds = [row["kind"] for row in registry.events()]
+    assert "gc.inventory_unmeasured" not in kinds
+
+
+def test_an_unmeasurable_inventory_does_not_present_as_zero_bytes_no_pressure(
+    registry: Registry,
+) -> None:
+    """The distinction survives into `Pressure`: assert on the resulting decision (via
+    `gc.status`'s reported pressure), not just on the `StorageInventory` object -- the
+    inventory is an internal detail, the decision is what actually governs deletion."""
+    add(registry)
+    engine = failing_df_engine()
+    config = load_config(flags={"shared_cache_ceiling": 1})
+
+    report = status(registry, engine, config=config)  # type: ignore[arg-type]
+
+    # Not zero-confirmed-under-ceiling: the byte signal must read as abstained, not cleared.
+    assert report["pressure"]["bytes_exceeded"] is False
+    assert report["pressure"]["bytes_unknown"] is True
+    assert report["managed_bytes"] == 0
+
+
+def test_an_unmeasurable_inventory_never_triggers_a_deletion_a_measured_zero_would_not(
+    registry: Registry,
+) -> None:
+    """The safe direction is "refuse to conclude no pressure", never "assume there is
+    pressure and start deleting": with a tiny ceiling that a real byte measurement would
+    have exceeded, an *unmeasured* inventory must not manufacture that same eviction."""
+    add(registry)
+    engine = failing_df_engine()
+    config = load_config(flags={"shared_cache_ceiling": 1})
+
+    result = Collector(registry, engine, config=config).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.removed == []
+
+
+def test_a_successful_measurement_over_ceiling_still_evicts_exactly_as_before(
+    registry: Registry, monkeypatch
+) -> None:
+    """The regression that matters most: existing pressure-driven deletion on a genuinely
+    successful measurement must be unchanged by threading `bytes_measured` through."""
+    add(registry)
+    engine = failing_df_engine()
+    monkeypatch.setattr(
+        "bosn.gc.StorageInventory.collect",
+        classmethod(lambda _cls, _engine: StorageInventory({("volume", "cache"): 100})),
+    )
+    config = load_config(flags={"shared_cache_ceiling": 10})
+
+    result = Collector(registry, engine, config=config).collect(dry_run=False)  # type: ignore[arg-type]
+
+    assert result.removed == ["cache"]
+    report = status(registry, engine, config=config)  # type: ignore[arg-type]
+    assert report["pressure"]["bytes_unknown"] is False

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -216,6 +216,89 @@ def test_pressure_assessment_keeps_count_bytes_and_free_space_distinct() -> None
     assert pressure.free_space_exceeded
 
 
+# -- issue #106: an unmeasurable byte inventory must not read as "zero, no pressure" ------
+
+
+def test_a_successful_measurement_over_ceiling_is_unchanged_by_the_new_flag() -> None:
+    """Regression guard: this is the behavior that matters most, since pressure drives
+    deletion. `bytes_measured` defaults to True, so every existing caller that never
+    mentions it keeps today's exact decision."""
+    pressure = Pressure.assess(
+        resource_count=1,
+        managed_bytes=200,
+        free_bytes=100,
+        min_free_bytes=10,
+        managed_bytes_ceiling=100,
+    )
+    assert pressure.bytes_exceeded
+    assert pressure.under_pressure
+    assert not pressure.bytes_unknown
+
+
+def test_a_successful_measurement_under_ceiling_is_unchanged_by_the_new_flag() -> None:
+    pressure = Pressure.assess(resource_count=1, managed_bytes=5, free_bytes=100, min_free_bytes=10)
+    assert not pressure.bytes_exceeded
+    assert not pressure.under_pressure
+    assert not pressure.bytes_unknown
+
+
+def test_an_unmeasured_byte_total_does_not_read_as_confirmed_under_ceiling() -> None:
+    """The core fix: `managed_bytes` from a failed inventory collection would otherwise sum
+    to 0, which looks exactly like "measured, confirmed zero". `bytes_unknown` is what makes
+    the two distinguishable downstream."""
+    pressure = Pressure.assess(
+        resource_count=1, managed_bytes=0, free_bytes=100, min_free_bytes=10, bytes_measured=False
+    )
+    assert not pressure.bytes_exceeded
+    assert pressure.bytes_unknown
+
+
+def test_an_unmeasured_byte_total_never_invents_pressure() -> None:
+    """The safe direction is "refuse to conclude no pressure", never "assume there is
+    pressure and start deleting" -- even a huge `managed_bytes` figure must be distrusted
+    entirely when `bytes_measured=False`, not just capped at the ceiling."""
+    pressure = Pressure.assess(
+        resource_count=1,
+        managed_bytes=10**12,
+        free_bytes=100,
+        min_free_bytes=10,
+        bytes_measured=False,
+    )
+    assert not pressure.bytes_exceeded
+    assert not pressure.under_pressure
+    assert pressure.bytes_unknown
+
+
+def test_count_and_free_space_signals_still_decide_independently_when_bytes_are_unknown() -> None:
+    """The third design option (see `Pressure.bytes_unknown`'s docstring): an unmeasurable
+    byte signal suppresses itself but must not suppress the other two, since they come from
+    different sources (resource count, `shutil.disk_usage`) and may still be valid."""
+    by_count = Pressure.assess(
+        resource_count=5,
+        managed_bytes=0,
+        free_bytes=100,
+        resource_ceiling=1,
+        min_free_bytes=10,
+        bytes_measured=False,
+    )
+    assert by_count.under_pressure
+    assert by_count.count_exceeded
+    assert by_count.bytes_unknown
+    assert not by_count.bytes_exceeded
+
+    by_free_space = Pressure.assess(
+        resource_count=1,
+        managed_bytes=0,
+        free_bytes=1,
+        min_free_bytes=10,
+        bytes_measured=False,
+    )
+    assert by_free_space.under_pressure
+    assert by_free_space.free_space_exceeded
+    assert by_free_space.bytes_unknown
+    assert not by_free_space.bytes_exceeded
+
+
 def test_done_never_collects_machine_scoped_caches(registry: Registry, clock: FakeClock) -> None:
     """One workspace finishing must not evict the machine-wide cargo registry."""
     resource = make(registry, scope="machine")


### PR DESCRIPTION
Closes #106.

## The bug

`StorageInventory.collect` returned an **empty** inventory when `docker system df -v` failed — and empty is indistinguishable from "measured, and it is zero". Observed for real on a ~280-object host: `StorageInventory(sizes={})`, not "one volume missing".

That feeds `Pressure.assess`, where it reads as `managed_bytes == 0`, so `bytes_exceeded` is False and byte pressure is **never detected**.

The failure is silent and points the wrong way. `system df -v` is slow on object-heavy hosts — precisely the hosts that need reclamation — so the exact condition GC exists to relieve is the condition most likely to convince bosn there is nothing to relieve. This repo's doctrine is fail-closed; this path failed open.

## Fix

`StorageInventory` carries `measured`, set False on an engine exception, a non-zero exit, unparseable JSON, and a zero-exit yielding no parseable rows — the last is not the documented healthy shape either, so it is treated as unmeasured rather than trusted.

`Pressure` gains `bytes_unknown`; `assess` takes `bytes_measured`.

**Unknown deliberately does not become pressure.** `bytes_exceeded` stays False, because inventing pressure makes GC delete things on a host that may be perfectly fine. `bytes_unknown` records that the False is an *abstention* rather than a confirmation, while `count_exceeded` and `free_space_exceeded` — computed from independent sources — go on deciding `under_pressure` themselves. That is the third option the issue floated, and it fits the separation `assess` already maintained between its three signals rather than collapsing them.

## Deletion safety

The dangerous direction here is a change that causes deletions that would not have happened before, so that is the property I checked rather than took on faith:

| scenario | `under_pressure` | notes |
|---|---|---|
| unmeasured + healthy host | `False` | no pressure invented; `bytes_unknown=True` |
| unmeasured + count over ceiling | `True` | independent signal still fires |
| unmeasured + free space low | `True` | independent signal still fires |
| measured + over ceiling | `True` | unchanged; `bytes_unknown=False` |

No path gains a collect verdict it lacked: in every unmeasurable case both old and new code compute `bytes_exceeded=False`, the OR in `under_pressure` is untouched, and `byte_pressure_started` stays False so the "keep byte pressure once started" branch cannot resurrect a pressure state that was never real. Two tests pin this — one that an unmeasurable inventory triggers no deletion a measured zero would not, and one that a successful measurement over the ceiling still evicts exactly as before, which is the regression that would actually cost data.

## Visibility

`Collector.collect` logs `gc.inventory_unmeasured` when measurement fails, so the condition appears in the event log instead of being inferred from GC quietly doing nothing. `status()` cannot log (it opens the registry read-only) so it surfaces `bytes_unknown` in its returned `pressure` dict instead.

Worth knowing: on a host where Docker is down for a long stretch, that is one event per maintenance pass. Intended visibility, but it is volume.

## Timeout, deliberately unchanged

`system df -v` keeps the shared engine default rather than getting a bespoke budget like `compose-adopt` did in #99. After this fix a slow or timed-out call lands in the unmeasured branch and is logged — loud-abstain instead of silent-fail-open — which is exactly what made a dedicated timeout urgent there and not here.

## Verification

- `ci/lint.py` → `LINT OK` (pyright 0 errors)
- `pytest tests/ -q -m "not docker"` → **1008 passed**, 2 skipped, on an isolated tree rebased onto main
- pressure semantics verified empirically against the table above, not just via unit tests

`tests/test_accounting_docker.py` also gained `assert inventory.measured` ahead of its existing assertion, so the flake that exposed this reads as "measurement failed" rather than "volume missing".

## Follow-up found, not fixed here

`bosn gc` (`cli.py::cmd_gc`) calls `daemon.request("gc", ...)` with the shared 10s `ipc.DEFAULT_TIMEOUT`, while daemon-side `Collector.collect` can legitimately run 60s+. That is the same client-budget-shorter-than-daemon-cost shape as #99, pre-existing and outside this change's scope. Filed separately.
