### PR TITLE
fix(cli): give gc a budget matching what the daemon actually does (#110)

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -23,6 +23,28 @@ from bosn.options import Options, from_namespace
 
 DAEMON_VERB = "__daemon"
 
+# `gc` waits on a daemon-side `Collector.collect`, whose cost is nothing like the shared
+# `ipc.DEFAULT_TIMEOUT` (10s) that every other verb inherits. Measured on a ~280-object
+# development host: `docker system df -v` alone is 5.2s, the resource scan is 7-11s quiet
+# and ~24s under load (see #99), and removals come on top of both and scale with how much
+# there is to delete. 10s could not cover the *first* step, so `bosn gc` reported failure
+# for collections that were proceeding normally (#110).
+#
+# 120s is sized to cover inventory plus a loaded scan plus a substantial removal pass with
+# room to spare, rather than to the median case -- a `gc` that has real work to do is
+# exactly when this budget matters, and exactly when the host is slowest.
+#
+# It is deliberately a per-call override rather than a bump to `ipc.DEFAULT_TIMEOUT`, for
+# the same reason `compose-adopt` got its own in #99: that constant is shared by every
+# verb, and widening it to fit the slowest one would silently loosen budgets for verbs
+# that answer in milliseconds and should fail fast when they do not.
+#
+# Any fixed number here is ultimately a guess, because `gc`'s runtime scales with how much
+# it deletes. #110 records the alternative -- making `gc` job-backed the way builds already
+# are (`jobs.py`), so progress streams and no budget is needed at all -- as the real fix if
+# this one ever proves too small.
+GC_REQUEST_TIMEOUT_SECONDS = 120.0
+
 NOT_IMPLEMENTED_EXIT = 3
 
 # Long enough to cover a daemon draining a cancelled build (see SHUTDOWN_DRAIN_SECONDS),
@@ -821,13 +843,36 @@ def cmd_gc(opts: Options) -> int:
         flags = _policy_flags(opts)
         load_config(flags=flags)
         reply = daemon_mod.request(
-            "gc", opts.state_dir, engine=opts.engine, dry_run=opts.dry_run, policy_flags=flags
+            "gc",
+            opts.state_dir,
+            engine=opts.engine,
+            dry_run=opts.dry_run,
+            policy_flags=flags,
+            request_timeout=GC_REQUEST_TIMEOUT_SECONDS,
         )
     except ConfigError as exc:
         return _error(
             code="policy.invalid",
             message=str(exc),
             next_step="correct the named policy value and retry",
+            as_json=opts.json,
+        )
+    except ipc.TransportTimeout as exc:
+        # Ordered before the `TransportError` clause below, which it is a subclass of.
+        # A timeout here does not mean the daemon is absent -- it means it is still
+        # collecting -- so it must not inherit that clause's "start or restart the daemon"
+        # remedy. Restarting is the one action that would interrupt the very work being
+        # waited on, and the collection continues regardless of this client giving up.
+        return _error(
+            code="gc.timeout",
+            message=(
+                f"the daemon did not finish collecting within "
+                f"{GC_REQUEST_TIMEOUT_SECONDS:g}s: {exc}"
+            ),
+            next_step=(
+                "the daemon is still collecting -- do not restart it; check `bosn status` "
+                "or the event log, and retry once it settles"
+            ),
             as_json=opts.json,
         )
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:

--- a/src/bosn/ipc.py
+++ b/src/bosn/ipc.py
@@ -34,6 +34,19 @@ class TransportError(RuntimeError):
     """The daemon could not be reached or spoke nonsense."""
 
 
+class TransportTimeout(TransportError):
+    """The daemon was reached but did not answer inside the caller's budget.
+
+    Deliberately a *subclass*, so every existing `except TransportError` keeps catching
+    it and no caller has to learn about this distinction to stay correct. It exists for
+    the callers that should: "the daemon is not there" and "the daemon is busy" have
+    opposite remedies, and conflating them produced actively harmful advice -- `bosn gc`
+    reported "cannot reach the bosn daemon ... start or restart the daemon" for a daemon
+    that was reachable and mid-collection, where restarting is the one thing that would
+    interrupt the work being waited on (#110).
+    """
+
+
 class MessageStream:
     """Reads newline-delimited JSON objects off a socket, buffering across messages."""
 
@@ -49,7 +62,7 @@ class MessageStream:
             try:
                 chunk = self.sock.recv(65536)
             except TimeoutError as exc:
-                raise TransportError("timed out waiting for the daemon") from exc
+                raise TransportTimeout("timed out waiting for the daemon") from exc
             except OSError as exc:
                 raise TransportError(f"connection to the daemon failed: {exc}") from exc
             if not chunk:

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from bosn import cli
+from bosn import cli, ipc
 
 UNIMPLEMENTED = sorted(v for v, (_, phase) in cli.VERBS.items() if phase != "implemented")
 
@@ -126,6 +126,52 @@ def test_gc_json_daemon_error_has_stable_remedy(tmp_path, capsys, monkeypatch) -
     payload = json.loads(capsys.readouterr().out)
     assert payload["code"] == "daemon.unreachable"
     assert payload["next"] == "start or restart the daemon, then retry"
+
+
+def test_gc_timeout_is_not_reported_as_an_unreachable_daemon(tmp_path, capsys, monkeypatch) -> None:
+    """A busy daemon and an absent one have opposite remedies (#110).
+
+    `ipc.TransportTimeout` subclasses `TransportError`, so before this distinction existed
+    a `gc` that simply took longer than its budget fell into the clause above and told the
+    user to "start or restart the daemon" -- the one action that would interrupt the
+    collection being waited on, which continues regardless of this client giving up. I hit
+    this for real running `bosn gc` on a host with ~280 Docker objects.
+    """
+    from bosn import daemon
+
+    def slow(*_args, **_kwargs):
+        raise ipc.TransportTimeout("timed out waiting for the daemon")
+
+    monkeypatch.setattr(daemon, "request", slow)
+    assert cli.main(["--state-dir", str(tmp_path), "gc", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["code"] == "gc.timeout"
+    assert "do not restart it" in payload["next"]
+    assert "restart the daemon, then retry" not in payload["next"]
+
+
+def test_gc_asks_the_daemon_for_more_than_the_shared_default_budget(tmp_path, monkeypatch) -> None:
+    """`gc`'s daemon-side cost is unrelated to what every other verb needs (#110).
+
+    Measured on a ~280-object host, `docker system df -v` alone is 5.2s and the scan adds
+    7-24s more, so the shared 10s default could not cover even the first step. Asserting on
+    the request rather than on the constant, so the wiring is what is pinned -- defining
+    the constant and forgetting to pass it would leave the bug in place.
+    """
+    from bosn import daemon
+
+    seen: dict[str, object] = {}
+
+    def capture(verb, *_args, **kwargs):
+        seen["verb"] = verb
+        seen["request_timeout"] = kwargs.get("request_timeout")
+        return {"ok": True, "result": {"collected": [], "kept": []}}
+
+    monkeypatch.setattr(daemon, "request", capture)
+    cli.main(["--state-dir", str(tmp_path), "gc", "--dry-run", "--json"])
+    assert seen["verb"] == "gc"
+    assert seen["request_timeout"] == cli.GC_REQUEST_TIMEOUT_SECONDS
+    assert cli.GC_REQUEST_TIMEOUT_SECONDS > ipc.DEFAULT_TIMEOUT
 
 
 def test_done_json_error_uses_the_common_envelope(tmp_path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
Closes #110.

## Two bugs, one symptom

`cmd_gc` sent its request with the shared `ipc.DEFAULT_TIMEOUT` (10s), while the daemon-side `Collector.collect` it waits on runs `docker system df -v`, then a full resource scan, then removals.

Measured on a ~280-object host:

| step | cost |
|---|---|
| `docker system df -v` alone | **5.2s** |
| resource scan | 7–11s quiet, ~24s loaded (#99) |
| removals | on top of both, scaling with how much is deleted |

The 10s budget could not cover the *first step*, so `bosn gc` reported failure for collections proceeding perfectly normally.

**The advice was worse than the number.** `ipc` raised a bare `TransportError` for a timeout, indistinguishable from a genuinely absent daemon, so `gc` fell into the `daemon.unreachable` branch and told the user to *"start or restart the daemon"* — the one action that would interrupt the collection being waited on, which continues regardless of the client giving up.

I hit this firsthand: running `bosn gc` on this host while filing the issue printed exactly that message, for a daemon that was reachable and busy.

## Fix

`ipc.TransportTimeout` marks the reached-but-slow case. Deliberately a **subclass** of `TransportError`, so every existing `except TransportError` keeps catching it and no caller has to learn the distinction to stay correct — it exists only for callers that should care. `gc` catches it ahead of the generic clause and reports `gc.timeout` with an accurate remedy: the daemon is still collecting, do not restart it.

The budget is **120s**, sized against inventory + a loaded scan + a substantial removal pass rather than the median — a `gc` with real work to do is exactly when the budget matters and when the host is slowest. Per-call override, not a bump to `ipc.DEFAULT_TIMEOUT`, for the same reason `compose-adopt` got its own in #99: that constant is inherited by verbs answering in milliseconds, which should keep failing fast.

Any fixed number here is ultimately a guess, since `gc`'s runtime scales with how much it deletes. The constant's comment records the real alternative — making `gc` job-backed the way builds already are via `jobs.py`, so progress streams and no budget is needed — as the fix if this proves too small.

## Tests

Both verified **RED** against unfixed code, failing for the right reasons:

- `AttributeError: module 'bosn.ipc' has no attribute 'TransportTimeout'`
- `assert seen["request_timeout"] == cli.GC_REQUEST_TIMEOUT_SECONDS`

The second asserts on the **request**, not the constant: defining a budget and forgetting to pass it would leave the bug in place while a constant-only test stayed green. (My first draft of that test had an incomplete fake reply and failed with `KeyError: 'result'` — fixed so it fails on the assertion it is actually about.)

## Verification

- `ci/lint.py` → `LINT OK` (pyright 0 errors)
- `pytest tests/ -q -m "not docker"` → **1010 passed**, 2 skipped
