### PR TITLE
chore(release): 0.1.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bosn"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Let your agents use Docker all day without filling the disk"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/bosn/__init__.py
+++ b/src/bosn/__init__.py
@@ -1,5 +1,5 @@
 """bosn - a machine-wide lifecycle supervisor for container development resources."""
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.0a2"
 
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "bosn"
-version = "0.1.0a1"
+version = "0.1.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Version bump only — `pyproject.toml` and `src/bosn/__init__.py`, kept in sync.

## What's in it

27 commits since `0.1.0a1`, spanning new capability and several silent-failure fixes:

**Capability**
- compose `build` / `config` / `exec` / `run` are governed, and a built image now carries the label contract it previously lacked (#47)
- `env` and `workdir` are declarable — closing a gap where a governed image built for another harness could build *outside* its own cache volume with no error at all (#105)
- reversible docker shims, `bosn init`, and a generated verb catalog
- soldr's workload expressed as a reference manifest (#75)

**Fixes, mostly of things that failed silently**
- scanner batches its per-resource `docker inspect` fallback: 121 subprocesses → 8 on a ~280-object host (#99)
- `bosn stop` can no longer stall ~2 minutes on a maintenance pass (#97)
- shutdown no longer closes the registry under a live background thread (#101)
- accounting distinguishes "measured zero" from "could not measure", so a host too full to measure no longer reads as a host under no pressure (#106)
- `gc`'s client budget matches what the daemon actually does, and a busy daemon is no longer reported as an absent one telling you to restart it (#110)
- GC no longer collects a running container (#92); the test suite no longer leaks a volume per test (#85)

## Why still alpha

Pre-1.0 is deliberate: the manifest surface is still moving (`env`/`workdir` landed this cycle), and the live legacy-adoption path has not been exercised against real cache volumes.

## Verification

- `ci/lint.py` → `LINT OK`
- `pytest tests/ -q -m "not docker"` → 1010 passed, 2 skipped
- built both sdist and wheel, then installed the wheel into a clean venv: imports at `0.1.0a2`, `bosn --version` reports `0.1.0a2`, and `bosn-docker --supported --json` returns the verb table

Publishing to PyPI once this merges, so the released artifact corresponds to a commit on `main`.
