### PR TITLE
fix: recover lifecycle session and volume interruptions

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -830,6 +830,7 @@ def cmd_cancel(opts: Options) -> int:
 
 
 def cmd_status(opts: Options) -> int:
+    from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
     from bosn.config import load as load_config
     from bosn.gc import status
@@ -839,6 +840,30 @@ def cmd_status(opts: Options) -> int:
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
     if not db_path.exists():
         print(json.dumps({"registered": 0, "storage": "not initialized"}, indent=2))
+        return 0
+    # A foreground execution session is a small daemon-owned control-plane record.  Report
+    # it before the direct engine inventory below: on a loaded Docker Desktop host that
+    # inventory can be slow, while the session is the exact fact an operator needs to
+    # understand why an otherwise terminal-only `jobs` list still blocks the stack (#119).
+    # Do not autostart merely to optimize a read-only status command.
+    try:
+        daemon_status = daemon_mod.request("status", state_dir, autostart=False)
+    except (daemon_mod.DaemonError, ipc.TransportError):
+        daemon_status = None
+    if daemon_status and daemon_status.get("execution_sessions"):
+        print(
+            json.dumps(
+                {
+                    "registry_id": daemon_status.get("registry_id"),
+                    "execution_sessions": daemon_status["execution_sessions"],
+                    "next": (
+                        "a live session remains protected; if its client is dead, retry "
+                        "after Bosn safely reaps its exact container"
+                    ),
+                },
+                indent=2,
+            )
+        )
         return 0
     try:
         with Registry(db_path, read_only=True) as registry:

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -468,7 +468,11 @@ class Converger:
                 family=stack.family,
             )
             created.append(name)
+            expected_labels = self._resource_labels(
+                stack, "volume", digest, volume.scope, workspace
+            )
             if self.engine.run(["volume", "inspect", name]).ok:
+                self._recover_interrupted_volume(name, expected_labels)
                 self._reconcile_reused_resource(
                     stack,
                     kind="volume",
@@ -479,14 +483,67 @@ class Converger:
                     workspace=workspace,
                 )
                 continue
-            label_args = self._resource_labels(
-                stack, "volume", digest, volume.scope, workspace
-            ).to_docker_args()
+            # Record the exact intended identity before Docker creation.  If the process
+            # dies after Docker created a partially labelled volume but before registry
+            # registration, a later `ensure` can prove and repair this one object (#120).
+            from bosn.registry import VolumeCreationIntent
+
+            self.registry.save_volume_creation_intent(
+                VolumeCreationIntent(
+                    name, expected_labels.to_dict(), stack.name, digest, volume.scope, workspace
+                )
+            )
+            label_args = expected_labels.to_docker_args()
             result = self.engine.run(["volume", "create", *label_args, name])
             if not result.ok:
                 raise EngineError(f"creating volume {name} failed: {result.stderr}")
             self._register(stack, "volume", name, digest, volume.scope, workspace)
+            self.registry.delete_volume_creation_intent(name)
         return created
+
+    def _recover_interrupted_volume(self, name: str, expected: labels.ResourceLabels) -> None:
+        """Repair only an exactly recorded, partially-labelled Bosn volume.
+
+        The durable intent makes the generated name insufficient on its own: the existing
+        volume must also retain our exact registry label and every surviving Bosn label
+        must agree with the pre-recorded contract.  Any ambiguity stays protected.
+        """
+        intent = self.registry.volume_creation_intent(name)
+        if intent is None:
+            return
+        # `created` is deliberately the resource's creation timestamp, not this retry's
+        # time. Compare the semantic identity only, then restore the original complete
+        # contract from the durable intent.
+        intent_labels = labels.ResourceLabels.from_dict(intent.labels)
+        if (
+            intent_labels.registry != expected.registry
+            or intent_labels.kind != expected.kind
+            or intent_labels.stack != expected.stack
+            or intent_labels.generation != expected.generation
+            or intent_labels.scope != expected.scope
+            or intent_labels.workspace != expected.workspace
+        ):
+            raise EngineError(f"volume {name!r} has a conflicting interrupted creation intent")
+        raw = ResourceScanner(self.engine).inspect_labels("volume", name)
+        if labels.is_owned_by(raw, self.registry.registry_id):
+            self.registry.delete_volume_creation_intent(name)
+            return
+        bosn_labels = {key: value for key, value in raw.items() if key.startswith(labels.NAMESPACE)}
+        if (
+            raw.get(labels.REGISTRY) != self.registry.registry_id
+            or not bosn_labels
+            or any(intent.labels.get(key) != value for key, value in bosn_labels.items())
+        ):
+            raise EngineError(
+                f"existing volume {name!r} has incomplete or contradictory ownership labels; "
+                "refusing unsafe recovery"
+            )
+        from bosn.resources import DiscoveredResource, recreate_volume_with_labels
+
+        recreate_volume_with_labels(
+            self.engine, DiscoveredResource("volume", name, raw), intent_labels
+        )
+        self.registry.delete_volume_creation_intent(name)
 
     def _reconcile_reused_resource(
         self,

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -942,6 +942,28 @@ class Daemon:
         return {"ok": True, "pong": True, "pid": os.getpid(), "version": __version__}
 
     def _verb_status(self, _request: dict[str, Any]) -> dict[str, Any]:
+        from bosn.resources import process_alive
+
+        with self._execution_lock:
+            sessions = []
+            for session, owner in self._execution_owners.items():
+                alive = process_alive(*owner)
+                sessions.append(
+                    {
+                        "id": session,
+                        "container_id": self._execution_containers.get(session),
+                        "engine": self._execution_engines.get(session),
+                        "client_pid": owner[0],
+                        "client_start": owner[1],
+                        "client_alive": alive,
+                        "lease_ids": list(self._execution_sessions.get(session, ())),
+                        "blocking_reason": (
+                            "client is live"
+                            if alive
+                            else "client is dead; awaiting safe exact-container reap"
+                        ),
+                    }
+                )
         return {
             "ok": True,
             "pid": os.getpid(),
@@ -951,6 +973,7 @@ class Daemon:
             "uptime_seconds": time.time() - self.started_at,
             "idle_seconds": self.idle_seconds(),
             "resources": len(self.registry.list_resources()),
+            "execution_sessions": sessions,
             "config": self.config.report() if self.config is not None else None,
         }
 

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -427,6 +427,42 @@ def status(
 
     config = config or load_config()
     scan = ResourceScanner(engine).scan(registry.registry_id)
+    # Foreground commands are deliberately *not* jobs: they execute in a persistent
+    # container and must retain exclusive ownership until the exact client process has
+    # released it (or the daemon has proved that client dead and removed that exact
+    # container).  Expose that separate ledger here; otherwise `jobs` can truthfully say
+    # "nothing running" while a foreground session still protects the stack (#119).
+    execution_sessions = []
+    for session in registry.execution_sessions():
+        alive = resources.process_alive(session.client_pid, session.client_start)
+        execution_sessions.append(
+            {
+                "id": session.id,
+                "container_id": session.container_id,
+                "engine": session.engine_binary,
+                "client_pid": session.client_pid,
+                "client_start": session.client_start,
+                "client_alive": alive,
+                "lease_ids": list(session.lease_ids),
+                "blocking_reason": (
+                    "client is live"
+                    if alive
+                    else "client is dead; awaiting safe exact-container reap"
+                ),
+            }
+        )
+    # Incomplete labels are not ownership proof and therefore are never candidates for
+    # automatic collection.  They must nevertheless be named: a generic count leaves an
+    # operator unable to tell which resource is blocking convergence (#120).
+    unproven_resources = [
+        {
+            "kind": resource.kind,
+            "name": resource.name,
+            "registry_id": resource.registry,
+            "reason": "incomplete ownership labels; protected from automatic recovery",
+        }
+        for resource in scan.unlabeled
+    ]
     inventory = StorageInventory.collect(engine)
 
     attributed: dict[tuple[str, str, str], dict[str, int]] = defaultdict(
@@ -495,6 +531,9 @@ def status(
         "collectable": len(collectable(verdicts)),
         "by_reason": by_reason,
         "engine": scan.counts(),
+        "scanned_kinds": sorted(scan.scanned_kinds),
+        "unproven_resources": unproven_resources,
+        "execution_sessions": execution_sessions,
         "foreign_registries": sorted(scan.foreign_registries),
         "foreign_registry_totals": {
             "count": len(scan.foreign),

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from bosn.clock import Clock, SystemClock
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS meta (
@@ -77,6 +77,15 @@ CREATE TABLE IF NOT EXISTS execution_sessions (
     client_pid     INTEGER NOT NULL,
     client_start   REAL,
     lease_ids      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS volume_creation_intents (
+    name            TEXT PRIMARY KEY,
+    labels          TEXT NOT NULL,
+    stack           TEXT NOT NULL,
+    generation      TEXT NOT NULL,
+    scope           TEXT NOT NULL,
+    workspace       TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS generations (
@@ -151,6 +160,16 @@ class ExecutionSession:
     client_pid: int
     client_start: float | None
     lease_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class VolumeCreationIntent:
+    name: str
+    labels: dict[str, str]
+    stack: str
+    generation: str
+    scope: str
+    workspace: str
 
 
 class RegistryError(RuntimeError):
@@ -297,6 +316,22 @@ class Registry:
             except KeyboardInterrupt:
                 self.conn.execute("ROLLBACK")
                 raise
+            except Exception:
+                self.conn.execute("ROLLBACK")
+                raise
+
+        if version < 3:
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                self.conn.execute(
+                    "CREATE TABLE IF NOT EXISTS volume_creation_intents ("
+                    "name TEXT PRIMARY KEY, labels TEXT NOT NULL, stack TEXT NOT NULL, "
+                    "generation TEXT NOT NULL, scope TEXT NOT NULL, workspace TEXT NOT NULL)"
+                )
+                self.conn.execute(
+                    "UPDATE meta SET value = ? WHERE key = 'schema_version'", ("3",)
+                )
+                self.conn.execute("COMMIT")
             except Exception:
                 self.conn.execute("ROLLBACK")
                 raise
@@ -835,6 +870,40 @@ class Registry:
                 )
             )
         return sessions
+
+    def save_volume_creation_intent(self, intent: VolumeCreationIntent) -> None:
+        self._exec(
+            "INSERT OR REPLACE INTO volume_creation_intents "
+            "(name, labels, stack, generation, scope, workspace) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                intent.name,
+                json.dumps(intent.labels, sort_keys=True),
+                intent.stack,
+                intent.generation,
+                intent.scope,
+                intent.workspace,
+            ),
+        )
+
+    def volume_creation_intent(self, name: str) -> VolumeCreationIntent | None:
+        row = self._exec(
+            "SELECT * FROM volume_creation_intents WHERE name = ?", (name,)
+        ).fetchone()
+        if row is None:
+            return None
+        raw_labels = json.loads(row["labels"])
+        if not isinstance(raw_labels, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in raw_labels.items()
+        ):
+            raise RegistryError(f"volume creation intent {name!r} has invalid labels")
+        return VolumeCreationIntent(
+            name=row["name"], labels=raw_labels, stack=row["stack"],
+            generation=row["generation"], scope=row["scope"], workspace=row["workspace"]
+        )
+
+    def delete_volume_creation_intent(self, name: str) -> None:
+        self._exec("DELETE FROM volume_creation_intents WHERE name = ?", (name,))
 
     def prune_lease(self, lease_id: str) -> None:
         """Delete a confirmed-dead lease found during maintenance.

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -91,6 +91,31 @@ def test_builtin_verb_name_is_reserved_from_task_dispatch(monkeypatch) -> None:
     assert seen == ["status"]
 
 
+def test_status_surfaces_a_foreground_session_without_waiting_for_engine_scan(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    from bosn import daemon
+
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "registry.sqlite3").touch()
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda *_args, **_kwargs: {
+            "registry_id": "registry",
+            "execution_sessions": [
+                {"id": "session", "client_alive": False, "blocking_reason": "awaiting reap"}
+            ],
+        },
+    )
+    monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["execution_sessions"][0]["id"] == "session"
+
+
 def test_tasks_json_reports_unregistered_readiness(tmp_path, capsys) -> None:
     (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     manifest = tmp_path / "bosn.toml"

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -8,6 +8,7 @@ import os
 import sys
 from dataclasses import replace
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -22,9 +23,9 @@ from bosn.converge import (
     volume_name_for,
     workspace_of,
 )
-from bosn.engine import EngineError, EngineResult
-from bosn.manifest import load
-from bosn.registry import Registry
+from bosn.engine import Engine, EngineError, EngineResult
+from bosn.manifest import Manifest, load
+from bosn.registry import Registry, VolumeCreationIntent
 from conftest import live_proc_start
 
 SAMPLE = """
@@ -60,6 +61,8 @@ class FakeEngine:
         self.timeouts.append(timeout)
         if args[:2] == ["version", "--format"]:
             return EngineResult(0, "linux/amd64", "")
+        if args[:3] == ["ps", "--all", "--filter"]:
+            return EngineResult(0, "", "")
         if args[:2] == ["container", "inspect"] and "{{json .}}" in args:
             spec = self.container_specs.get(args[-1])
             return EngineResult(0 if spec else 1, json.dumps(spec) if spec else "", "")
@@ -235,6 +238,69 @@ def converger(project: Path, registry: Registry) -> Converger:
 
 
 # -- convergence is idempotent ---------------------------------------------
+
+
+def test_recorded_partial_volume_is_safely_recreated_on_ensure(tmp_path: Path) -> None:
+    """#120: an interrupted create is recoverable only with durable matching proof."""
+    engine = FakeEngine()
+    with Registry(tmp_path / "registry.sqlite3") as registry:
+        expected = labels.ResourceLabels(
+            registry=registry.registry_id,
+            kind="volume",
+            stack="test",
+            generation="sha256:g",
+            scope="stack",
+            workspace=str(tmp_path),
+            created="2026-08-26T00:00:00Z",
+        )
+        name = "bosn-test-interrupted"
+        partial = expected.to_dict()
+        del partial[labels.STACK]
+        engine.existing.add(name)
+        engine.resource_labels[("volume", name)] = partial
+        registry.save_volume_creation_intent(
+            VolumeCreationIntent(
+                name, expected.to_dict(), "test", "sha256:g", "stack", str(tmp_path)
+            )
+        )
+        converger = Converger(cast(Manifest, None), registry, cast(Engine, engine))
+        # A retry naturally has a different current timestamp; recovery must retain the
+        # original intent's creation label rather than treating that as a conflict.
+        converger._recover_interrupted_volume(
+            name, replace(expected, created="2026-08-26T01:00:00Z")
+        )
+
+        assert engine.resource_labels[("volume", name)] == expected.to_dict()
+        assert registry.volume_creation_intent(name) is None
+
+
+def test_interrupted_volume_recovery_refuses_an_unlabeled_collision(tmp_path: Path) -> None:
+    """An intent plus a generated name never authorizes taking an unlabeled volume."""
+    engine = FakeEngine()
+    with Registry(tmp_path / "registry.sqlite3") as registry:
+        expected = labels.ResourceLabels(
+            registry=registry.registry_id,
+            kind="volume",
+            stack="test",
+            generation="sha256:g",
+            scope="stack",
+            workspace=str(tmp_path),
+            created="2026-08-26T00:00:00Z",
+        )
+        name = "bosn-test-unlabeled"
+        engine.existing.add(name)
+        engine.resource_labels[("volume", name)] = {}
+        registry.save_volume_creation_intent(
+            VolumeCreationIntent(
+                name, expected.to_dict(), "test", "sha256:g", "stack", str(tmp_path)
+            )
+        )
+        converger = Converger(cast(Manifest, None), registry, cast(Engine, engine))
+
+        with pytest.raises(EngineError, match="refusing unsafe recovery"):
+            converger._recover_interrupted_volume(name, expected)
+
+        assert registry.volume_creation_intent(name) is not None
 
 
 def test_first_converge_registers_then_reuses(converger: Converger) -> None:

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -178,6 +178,55 @@ def test_a_resource_with_incomplete_labels_is_never_removed(
     assert result.skipped_unproven == ["partial"]
 
 
+def test_status_names_unproven_resources_and_execution_sessions(
+    registry: Registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#119/#120: neither protected state may be hidden behind aggregate counts."""
+    from bosn.registry import ExecutionSession
+
+    registry.save_execution_session(
+        ExecutionSession("session", "immutable-id", "docker", 4242, 9.0, ("lease",))
+    )
+    engine = FakeEngine({})
+    monkeypatch.setattr(gc_mod.resources, "process_alive", lambda *_args: False)
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    monkeypatch.setattr(
+        gc_mod.ResourceScanner,
+        "scan",
+        lambda *_args, **_kwargs: ScanResult(
+            unlabeled=[
+                DiscoveredResource(
+                    "volume", "partial", {labels.REGISTRY: registry.registry_id}
+                )
+            ],
+            scanned_kinds={"volume"},
+        ),
+    )
+    report = status(registry, engine)  # type: ignore[arg-type]
+
+    assert report["unproven_resources"] == [
+        {
+            "kind": "volume",
+            "name": "partial",
+            "registry_id": registry.registry_id,
+            "reason": "incomplete ownership labels; protected from automatic recovery",
+        }
+    ]
+    assert report["execution_sessions"] == [
+        {
+            "id": "session",
+            "container_id": "immutable-id",
+            "engine": "docker",
+            "client_pid": 4242,
+            "client_start": 9.0,
+            "client_alive": False,
+            "lease_ids": ["lease"],
+            "blocking_reason": "client is dead; awaiting safe exact-container reap",
+        }
+    ]
+
+
 def test_gc_never_issues_a_system_prune(registry: Registry, clock: FakeClock) -> None:
     add(registry, "ours")
     engine = FakeEngine({"ours": label_dict(registry=registry.registry_id)})

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -314,7 +314,7 @@ def test_v1_migration_deduplicates_engine_objects_and_preserves_leases(tmp_path:
         assert resources[0].id == "new"
         assert resources[0].created_at == 1
         assert migrated.leases_for("new")[0].id == "lease-old"
-        assert migrated.meta("schema_version") == "2"
+        assert migrated.meta("schema_version") == "3"
         assert migrated.generation_superseded_at("sha256:g", stack="test", workspace="/w") is None
         index_columns = migrated.conn.execute(
             "PRAGMA index_info(idx_resources_engine_identity)"


### PR DESCRIPTION
## Summary

- expose foreground execution sessions through daemon and CLI status, avoiding a slow engine scan when a session is blocking a stack
- make interrupted volume creation proof-carrying with durable intent and safe staged recovery on a later osn ensure
- name protected incomplete resources in status and preserve unlabeled/contradictory-volume refusal

Fixes #119
Fixes #120

## Validation

- uv run pyright
- uv run pytest tests/test_cli_verbs.py::test_status_surfaces_a_foreground_session_without_waiting_for_engine_scan tests/test_converge.py::test_recorded_partial_volume_is_safely_recreated_on_ensure tests/test_converge.py::test_interrupted_volume_recovery_refuses_an_unlabeled_collision tests/test_daemon.py::test_dead_execution_owner_is_stopped_and_reaped_before_next_acquire tests/test_gc.py::test_status_names_unproven_resources_and_execution_sessions -q
- uv run ruff check src tests ci

The full local suite was also started, but host Docker integration is currently affected by the known phantom-session state; a pre-existing accounting Docker test failed before the new paths completed.