### PR TITLE
ci: run validation on Linux only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,33 +47,3 @@ jobs:
           ls dist/
           test -n "$(ls dist/*-py3-none-any.whl)"
 
-  native:
-    name: ${{ matrix.name }} (lint + unit)
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-            name: Windows
-          - os: macos-latest
-            name: macOS
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Install
-        run: ./install
-
-      - name: Lint
-        run: ./lint
-
-      - name: Test (unit)
-        run: ./test


### PR DESCRIPTION
Run the complete lint, unit, Docker integration, and wheel validation on Linux only. This removes the redundant Windows and macOS hosted-runner matrix.