### PR TITLE
fix: make execution-session recovery observable and bounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,11 +464,11 @@ bosn shell                   # interactive session in the persistent container
 bosn ensure                  # converge and register without running anything
 
 bosn tasks --json            # tasks, stacks, content digests, registration state
-bosn status                  # tiers, leases, bytes vs ceiling, foreign registries
+bosn status --json           # bounded daemon/registry state; never scans the engine
 bosn jobs / bosn attach <j>  # daemon-owned builds that survive a killed CLI
 bosn cancel <j>              # stop a build you no longer want
 bosn done                    # this workspace is finished; its caches become collectable
-bosn gc                      # dry-run by default; --apply to reclaim (there is no --force)
+bosn gc --dry-run --json     # rich engine/storage inventory; --apply reclaims (no --force)
 bosn doctor                  # engine reachability, registry integrity, recovery commands
 bosn adopt --legacy <family> # import pre-bosn volumes; --yes to apply
 
@@ -476,12 +476,13 @@ bosn __daemon --autostart    # install the login launcher (also --no-autostart)
 bosn daemon-stop             # stop the daemon — needed after upgrading bosn
 ```
 
-`tasks` and `doctor` read the SQLite registry directly. `status` first makes a short, read-only
-daemon query so it can show live foreground ownership without an engine scan. If that control
-stream is unavailable and the registry contains a persisted foreground session, `status --json`
-returns a bounded `mode: "degraded"` report from the registry instead of falling through to a
-slow Docker inventory. `gc` and `jobs` are read-only but go through the daemon and fail closed
-if it is unreachable.
+`tasks` and `doctor` read the SQLite registry directly. `status --json` is always a short,
+control-plane/registry-only report: it returns stable `mode`, `registry_id`, `registered`,
+`execution_sessions`, and `daemon` fields without touching the container engine. A healthy
+daemon returns `mode: "online"`; an absent daemon returns `mode: "offline"`; and a lost control
+stream returns `mode: "degraded"` with persisted session diagnostics. For the rich engine,
+ownership, and storage inventory, use `bosn gc --dry-run --json` instead. `gc` and `jobs` are
+read-only but go through the daemon and fail closed if it is unreachable.
 
 When ordinary `status` can reach the daemon and says the client is dead, run `bosn daemon-stop`:
 Bosn first proves the owner is dead, then removes only that session's exact immutable container

--- a/README.md
+++ b/README.md
@@ -476,9 +476,19 @@ bosn __daemon --autostart    # install the login launcher (also --no-autostart)
 bosn daemon-stop             # stop the daemon — needed after upgrading bosn
 ```
 
-`status`, `tasks`, and `doctor` read the sqlite registry directly, so they keep working when
-the daemon is wedged. `gc` and `jobs` are read-only but go through the daemon and fail closed
+`tasks` and `doctor` read the SQLite registry directly. `status` first makes a short, read-only
+daemon query so it can show live foreground ownership without an engine scan. If that control
+stream is unavailable and the registry contains a persisted foreground session, `status --json`
+returns a bounded `mode: "degraded"` report from the registry instead of falling through to a
+slow Docker inventory. `gc` and `jobs` are read-only but go through the daemon and fail closed
 if it is unreachable.
+
+If that degraded report says the client is still live, leave it alone. If it says the client is
+dead, run `bosn daemon-stop`: Bosn first proves the owner is dead, then removes only that
+session's exact immutable container and releases its leases. A `last_orphan_reap_error` field
+means that safe cleanup could not be proved or completed; resolve the named engine/database
+error and retry `bosn daemon-stop`. Do not delete registry rows or use a blind Docker force
+operation.
 
 **After you upgrade bosn, stop the daemon.** A running daemon refuses every mutating verb
 whose client reports a different version, so the next `bosn run` fails until you restart it.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Then:
 ```bash
 bosn ensure                    # converge and register without running anything (pre-warm)
 bosn unit                      # run the task
-bosn status                    # what exists, what holds it, bytes vs ceiling
+bosn status --json             # bounded daemon/registry state; use gc for engine/storage details
 ```
 
 Nothing needs starting — the first command lazily spawns the daemon.
@@ -192,8 +192,8 @@ images will not work.
 | `docker build` + `docker run` | `bosn run -- <cmd>` | rebuilds only if the *content digest* changed |
 | `docker compose up` | `bosn-docker compose up` | service **containers** get labeled and tracked; volumes do not (see below) |
 | `docker system prune` | *(nothing — automatic)* | never needed, and bosn never runs it |
-| `docker volume ls` + guesswork | `bosn status` | tiers, leases, managed bytes vs ceiling |
-| "is this cache still needed?" | `bosn gc` | dry-run by default; shows exactly what would be reclaimed |
+| `docker volume ls` + guesswork | `bosn gc --dry-run --json` | rich engine/storage inventory plus governed decisions |
+| "is this cache still needed?" | `bosn gc --dry-run --json` | dry-run by default; shows exactly what would be reclaimed |
 | deleting a worktree and hoping | `bosn done` | marks it finished; its caches become collectable |
 
 ### If you already have a compose.yaml
@@ -542,8 +542,9 @@ precedence, and invalid values stop the command while naming the bad key. The `[
 accepts `container_idle_stop`, `container_remove`, `warm_volume_ttl`, `superseded_cap`,
 `shared_cache_ceiling` (really the total managed-bytes ceiling), `run_max_duration` (default
 8 h, the wall-clock cap on command execution), `idle_retire_seconds`, `build_ttl_seconds`, and
-`max_builds`; environment overrides are their uppercase `BOSN_` equivalents. `bosn status`
-reports each effective value and its origin.
+`max_builds`; environment overrides are their uppercase `BOSN_` equivalents. Policy provenance
+is not currently exposed as a public CLI report; `bosn gc --dry-run --json` shows the resulting
+governed storage decisions without requiring `status` to touch the engine.
 
 Enforcement is layered: the daemon is the authority but never the only mechanism. The
 persistent container's PID 1 watches the bind-mounted daemon heartbeat and exits once it has

--- a/README.md
+++ b/README.md
@@ -483,12 +483,15 @@ returns a bounded `mode: "degraded"` report from the registry instead of falling
 slow Docker inventory. `gc` and `jobs` are read-only but go through the daemon and fail closed
 if it is unreachable.
 
-If that degraded report says the client is still live, leave it alone. If it says the client is
-dead, run `bosn daemon-stop`: Bosn first proves the owner is dead, then removes only that
-session's exact immutable container and releases its leases. A `last_orphan_reap_error` field
-means that safe cleanup could not be proved or completed; resolve the named engine/database
-error and retry `bosn daemon-stop`. Do not delete registry rows or use a blind Docker force
-operation.
+When ordinary `status` can reach the daemon and says the client is dead, run `bosn daemon-stop`:
+Bosn first proves the owner is dead, then removes only that session's exact immutable container
+and releases its leases. A `last_orphan_reap_error` field means that safe cleanup could not be
+proved or completed; resolve the named engine/database error and retry `bosn daemon-stop`.
+
+Do **not** run `bosn daemon-stop` directly from `mode: "degraded"`: it uses the same unavailable
+daemon control channel. First restore or restart Bosn through its supported launcher/service and
+wait for `bosn status` to respond; then use `bosn daemon-stop` for the exact-container recovery.
+Do not delete registry rows or use a blind Docker force operation.
 
 **After you upgrade bosn, stop the daemon.** A running daemon refuses every mutating verb
 whose client reports a different version, so the next `bosn run` fails until you restart it.

--- a/ci/gen_docker_support.py
+++ b/ci/gen_docker_support.py
@@ -91,7 +91,10 @@ def render() -> str:
 
     lines += _render_compose_flags(payload["compose"])
 
-    return "\n".join(lines) + "\n"
+    # `_render_compose_flags()` ends with an empty separator line. Normalize that internal
+    # layout detail to one POSIX terminal newline instead of emitting a trailing blank
+    # Markdown paragraph, so the committed generated document has a stable ending.
+    return "\n".join(lines).rstrip("\n") + "\n"
 
 
 def _render_flag_table(flags: list[dict]) -> list[str]:

--- a/docs/docker-support.md
+++ b/docs/docker-support.md
@@ -42,11 +42,11 @@ Schema version: `1` (the shape of the `--supported --json` payload this doc refl
 | `push` | upload an image to a registry | not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
 | `tag` | create a new tag pointing at an existing image | creates a new local image reference outside the registry; not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
 | `cp` | copy files into or out of a container | targets a raw container name outside bosn's registry; use `bosn shell` to reach a managed container's filesystem |
-| `network` | manage networks (create/rm/connect/...) | networks are declared implicitly by a stack and labeled by bosn; use `bosn status` to inspect them, `bosn gc` to reclaim them |
-| `volume` | manage volumes (create/rm/prune/...) | volumes are declared in bosn.toml and labeled by bosn; use `bosn status` to inspect them, `bosn gc` to reclaim them |
-| `image` | manage images (build/rm/prune/...) | images are generation-keyed and managed by bosn; use `bosn status`/`bosn gc` instead of the raw image subcommands |
-| `container` | manage containers (create/rm/prune/...) | containers are declared in bosn.toml and labeled by bosn; use `bosn status`/`bosn gc` instead of the raw container subcommands |
-| `system` | manage or inspect the engine (df/prune/events/...) | `system prune` in particular deletes resources bosn did not choose to reclaim; use `bosn gc` for a governed equivalent |
+| `network` | manage networks (create/rm/connect/...) | networks are declared implicitly by a stack and labeled by bosn; use `bosn status --json` for bounded managed-state diagnostics, `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report, or `bosn gc` to reclaim collectable networks |
+| `volume` | manage volumes (create/rm/prune/...) | volumes are declared in bosn.toml and labeled by bosn; use `bosn status --json` for bounded managed-state diagnostics, `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report, or `bosn gc` to reclaim collectable volumes |
+| `image` | manage images (build/rm/prune/...) | images are generation-keyed and managed by bosn; use `bosn status --json` for bounded managed-state diagnostics, `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report, or `bosn gc` to reclaim collectable images |
+| `container` | manage containers (create/rm/prune/...) | containers are declared in bosn.toml and labeled by bosn; use `bosn status --json` for bounded managed-state diagnostics, `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report, or `bosn gc` to reclaim collectable containers |
+| `system` | manage or inspect the engine (df/prune/events/...) | `system prune` in particular deletes resources bosn did not choose to reclaim; use `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report, then `bosn gc` to reclaim collectable resources |
 | `save` | export an image to a tar archive | not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
 | `load` | import an image from a tar archive | creates a local image outside the registry; not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
 | `export` | export a container's filesystem to a tar archive | not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
@@ -54,13 +54,13 @@ Schema version: `1` (the shape of the `--supported --json` payload this doc refl
 | `commit` | create a new image from a container's changes | creates a local image outside the registry; not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
 | `rename` | rename a container | mutates a container's identity outside the registry's naming; not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
 | `attach` | attach local streams to a running container | targets a raw container name outside bosn's registry; use `bosn attach` for a daemon-owned job |
-| `ps` | list containers | lists raw engine state instead of bosn's managed view; use `bosn status` or `bosn tasks` for governed introspection |
+| `ps` | list containers | lists raw engine state instead of Bosn's bounded managed-state diagnostics; use `bosn status --json` for those diagnostics, `bosn tasks` for manifest readiness, or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report |
 | `logs` | fetch a container's logs | targets a raw container name outside bosn's registry; use `bosn-docker compose logs` for a managed stack, or `bosn attach` for a daemon-owned job |
-| `inspect` | show low-level details of an object | targets a raw object name outside bosn's registry; use `bosn status` for governed introspection |
+| `inspect` | show low-level details of an object | targets a raw object name outside bosn's registry; use `bosn status --json` for bounded managed-state diagnostics or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report |
 | `top` | list processes running in a container | targets a raw container name outside bosn's registry; use `bosn jobs` for governed introspection |
-| `stats` | stream resource usage statistics | targets raw container names outside bosn's registry; use `bosn status` for governed introspection |
-| `events` | stream real-time engine events | surfaces raw engine activity outside bosn's registry; use `bosn status` for governed introspection |
-| `port` | list a container's published ports | targets a raw container name outside bosn's registry; use `bosn status` for governed introspection |
+| `stats` | stream resource usage statistics | targets raw container names outside bosn's registry; Bosn does not expose a streaming resource-usage view. Use `bosn status --json` for bounded managed-state diagnostics or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report |
+| `events` | stream real-time engine events | surfaces raw engine activity outside bosn's registry; Bosn does not expose a raw engine event stream. Use `bosn status --json` for bounded managed-state diagnostics or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report |
+| `port` | list a container's published ports | targets a raw container name outside bosn's registry; Bosn does not expose a published-port listing. Use `bosn status --json` only for bounded managed-state diagnostics or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report |
 | `diff` | list changed files in a container's filesystem | targets a raw container name outside bosn's registry; use `bosn shell` to inspect a managed container directly |
 | `wait` | block until a container stops, then print its exit code | targets a raw container name outside bosn's registry; use `bosn jobs`/`bosn attach` to wait on a daemon-owned job |
 | `search` | search Docker Hub for images | not part of the managed subset; use the real `docker` binary directly if you accept the resources it creates will be unmanaged, or add it to bosn.toml so bosn can create it tracked |
@@ -122,4 +122,3 @@ No sub-verb-specific flags are declared; only the global flags above apply.
 ### `compose config`
 
 No sub-verb-specific flags are declared; only the global flags above apply.
-

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -886,21 +886,32 @@ def _persisted_execution_sessions(registry, *, daemon_control_available: bool) -
 
 def cmd_status(opts: Options) -> int:
     from bosn import daemon as daemon_mod
-    from bosn.config import ConfigError
-    from bosn.config import load as load_config
-    from bosn.gc import status
     from bosn.registry import Registry, default_db_path
 
     state_dir = opts.state_dir
     db_path = (state_dir / "registry.sqlite3") if state_dir else default_db_path()
     if not db_path.exists():
-        print(json.dumps({"registered": 0, "storage": "not initialized"}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "mode": "offline",
+                    "registry_id": None,
+                    "registered": 0,
+                    "execution_sessions": [],
+                    "daemon": {"reachable": False, "error": "registry not initialized"},
+                    "next": (
+                        "no Bosn registry or daemon is available yet. Run the desired Bosn "
+                        "command to initialize its managed state; do not create resources with "
+                        "raw Docker."
+                    ),
+                },
+                indent=2,
+            )
+        )
         return 0
-    # A foreground execution session is a small daemon-owned control-plane record.  Report
-    # it before the direct engine inventory below: on a loaded Docker Desktop host that
-    # inventory can be slow, while the session is the exact fact an operator needs to
-    # understand why an otherwise terminal-only `jobs` list still blocks the stack (#119).
-    # Do not autostart merely to optimize a read-only status command.
+    # Status is deliberately a bounded control-plane and registry diagnostic, never an engine
+    # inventory.  That keeps it useful exactly when Docker Desktop or a foreground stream is
+    # stuck; `gc --dry-run --json` remains the explicit rich engine/storage report.
     daemon_error: str | None = None
     daemon_control_lost = False
     try:
@@ -914,71 +925,62 @@ def cmd_status(opts: Options) -> int:
         daemon_status = None
         daemon_error = str(exc)
         daemon_control_lost = isinstance(exc, ipc.TransportError)
-    if daemon_status and daemon_status.get("execution_sessions"):
+    if daemon_status and daemon_status.get("ok", True):
         print(
             json.dumps(
                 {
+                    "mode": "online",
                     "registry_id": daemon_status.get("registry_id"),
-                    "execution_sessions": daemon_status["execution_sessions"],
+                    "registered": daemon_status.get("resources", 0),
+                    "execution_sessions": daemon_status.get("execution_sessions", []),
+                    "daemon": {
+                        "reachable": True,
+                        "pid": daemon_status.get("pid"),
+                        "version": daemon_status.get("version"),
+                    },
                     "next": (
-                        "a live session remains protected; if its client is dead, retry "
-                        "after Bosn safely reaps its exact container"
+                        "a live session remains protected; for a dead owner, `bosn daemon-stop` "
+                        "safely reaps only its exact container"
+                        if daemon_status.get("execution_sessions")
+                        else "no foreground execution session is blocking the daemon"
                     ),
                 },
                 indent=2,
             )
         )
         return 0
-    try:
-        with Registry(db_path, read_only=True) as registry:
-            # The daemon may be alive enough to own a socket but unable to serve its control
-            # stream.  A persisted session is sufficient evidence to explain the block, and
-            # is intentionally *not* sufficient evidence to touch Docker.  Returning this
-            # bounded report avoids turning a control-plane failure into an unbounded engine
-            # inventory while retaining fail-closed ownership.
-            persisted_sessions = _persisted_execution_sessions(
-                registry, daemon_control_available=not daemon_control_lost
-            )
-            if daemon_control_lost:
-                print(
-                    json.dumps(
-                        {
-                            "mode": "degraded",
-                            "registry_id": registry.registry_id,
-                            "daemon": {
-                                "reachable": False,
-                                "error": daemon_error,
-                                "status_timeout_seconds": STATUS_DAEMON_TIMEOUT_SECONDS,
-                            },
-                            "execution_sessions": persisted_sessions,
-                            "next": (
-                                "the daemon control channel is unavailable, so do not run "
-                                "`bosn daemon-stop` yet: it uses that same channel. Restore or "
-                                "restart Bosn through its supported launcher/service first; once "
-                                "`bosn status` responds, `bosn daemon-stop` can attempt safe "
-                                "exact-container recovery. Do not delete registry rows or use a "
-                                "blind Docker force operation."
-                                if persisted_sessions
-                                else "no execution session is persisted. Restart the daemon "
-                                "before retrying a mutating command."
-                            ),
-                        },
-                        indent=2,
-                    )
-                )
-                return 0
-            print(
-                json.dumps(
-                    status(
-                        registry, Engine(opts.engine), config=load_config(flags=_policy_flags(opts))
+    if daemon_status is not None:
+        daemon_error = str(daemon_status.get("error") or "daemon did not return status")
+    with Registry(db_path, read_only=True) as registry:
+        persisted_sessions = _persisted_execution_sessions(
+            registry, daemon_control_available=False
+        )
+        print(
+            json.dumps(
+                {
+                    "mode": "degraded" if daemon_control_lost else "offline",
+                    "registry_id": registry.registry_id,
+                    "registered": len(registry.list_resources()),
+                    "execution_sessions": persisted_sessions,
+                    "daemon": {
+                        "reachable": False,
+                        "error": daemon_error,
+                        "status_timeout_seconds": STATUS_DAEMON_TIMEOUT_SECONDS,
+                    },
+                    "next": (
+                        "the daemon control channel is unavailable, so do not run `bosn "
+                        "daemon-stop` yet: it uses that same channel. Restore or restart Bosn "
+                        "through its supported launcher/service first; once `bosn status` "
+                        "responds, `bosn daemon-stop` can attempt safe exact-container recovery."
+                        if persisted_sessions
+                        else "no execution session is persisted. Restore or restart Bosn through "
+                        "its supported launcher/service before retrying a mutating command."
                     ),
-                    indent=2,
-                )
+                },
+                indent=2,
             )
-        return 0
-    except ConfigError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+        )
+    return 0
 
 
 def cmd_gc(opts: Options) -> int:

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -69,6 +69,10 @@ DAEMON_STOP_TIMEOUT = 45.0
 # That bounded recovery legitimately exceeds the generic 10-second IPC control timeout on
 # Docker Desktop, while the preceding image build already has its own streamed job timeout.
 EXECUTION_ACQUIRE_TIMEOUT = 120.0
+# `status` is a diagnostic, not an engine inventory request.  When the daemon control plane
+# has lost a stream, wait only long enough to distinguish that failure, then read the durable
+# registry proof rather than starting the slow Docker scan that made #119 look like a hang.
+STATUS_DAEMON_TIMEOUT_SECONDS = 2.0
 
 
 def _policy_flags(opts: Options) -> dict[str, float | None]:
@@ -829,6 +833,51 @@ def cmd_cancel(opts: Options) -> int:
     return 0
 
 
+def _persisted_execution_sessions(registry) -> list[dict]:
+    """Describe durable foreground ownership without contacting the engine or daemon.
+
+    The registry proves that a session is protected, but never authorizes removal.  In
+    particular, a dead owner remains blocking until the daemon's documented recovery path
+    has removed the exact immutable container and released its leases.
+    """
+    from bosn.resources import process_alive
+
+    sessions = []
+    for session in registry.execution_sessions():
+        alive = process_alive(session.client_pid, session.client_start)
+        last_reap_error = registry.latest_event(
+            "execution.orphan_reap.error", detail_prefix=f"session={session.id} "
+        )
+        sessions.append(
+            {
+                "id": session.id,
+                "container_id": session.container_id,
+                "engine": session.engine_binary,
+                "client_pid": session.client_pid,
+                "client_start": session.client_start,
+                "client_alive": alive,
+                "lease_ids": list(session.lease_ids),
+                "blocking_reason": (
+                    "client is live"
+                    if alive
+                    else "client is dead; awaiting safe exact-container reap"
+                ),
+                "last_orphan_reap_error": (
+                    {"at": last_reap_error["at"], "detail": last_reap_error["detail"]}
+                    if last_reap_error is not None
+                    else None
+                ),
+                "recovery": (
+                    "do not interrupt the live client"
+                    if alive
+                    else "run `bosn daemon-stop`; it reaps only this exact container after "
+                    "confirming the client is dead"
+                ),
+            }
+        )
+    return sessions
+
+
 def cmd_status(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
@@ -846,10 +895,17 @@ def cmd_status(opts: Options) -> int:
     # inventory can be slow, while the session is the exact fact an operator needs to
     # understand why an otherwise terminal-only `jobs` list still blocks the stack (#119).
     # Do not autostart merely to optimize a read-only status command.
+    daemon_error: str | None = None
     try:
-        daemon_status = daemon_mod.request("status", state_dir, autostart=False)
-    except (daemon_mod.DaemonError, ipc.TransportError):
+        daemon_status = daemon_mod.request(
+            "status",
+            state_dir,
+            autostart=False,
+            request_timeout=STATUS_DAEMON_TIMEOUT_SECONDS,
+        )
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         daemon_status = None
+        daemon_error = str(exc)
     if daemon_status and daemon_status.get("execution_sessions"):
         print(
             json.dumps(
@@ -867,6 +923,35 @@ def cmd_status(opts: Options) -> int:
         return 0
     try:
         with Registry(db_path, read_only=True) as registry:
+            # The daemon may be alive enough to own a socket but unable to serve its control
+            # stream.  A persisted session is sufficient evidence to explain the block, and
+            # is intentionally *not* sufficient evidence to touch Docker.  Returning this
+            # bounded report avoids turning a control-plane failure into an unbounded engine
+            # inventory while retaining fail-closed ownership.
+            persisted_sessions = _persisted_execution_sessions(registry)
+            if daemon_error is not None and persisted_sessions:
+                print(
+                    json.dumps(
+                        {
+                            "mode": "degraded",
+                            "registry_id": registry.registry_id,
+                            "daemon": {
+                                "reachable": False,
+                                "error": daemon_error,
+                                "status_timeout_seconds": STATUS_DAEMON_TIMEOUT_SECONDS,
+                            },
+                            "execution_sessions": persisted_sessions,
+                            "next": (
+                                "a live session remains protected. For a dead client, run "
+                                "`bosn daemon-stop`; it attempts safe exact-container recovery "
+                                "and reports any remaining error. Do not delete registry rows or "
+                                "use a blind Docker force operation."
+                            ),
+                        },
+                        indent=2,
+                    )
+                )
+                return 0
             print(
                 json.dumps(
                     status(

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -920,6 +920,7 @@ def cmd_status(opts: Options) -> int:
             state_dir,
             autostart=False,
             request_timeout=STATUS_DAEMON_TIMEOUT_SECONDS,
+            diagnostic=True,
         )
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         daemon_status = None

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -896,6 +896,7 @@ def cmd_status(opts: Options) -> int:
     # understand why an otherwise terminal-only `jobs` list still blocks the stack (#119).
     # Do not autostart merely to optimize a read-only status command.
     daemon_error: str | None = None
+    daemon_control_lost = False
     try:
         daemon_status = daemon_mod.request(
             "status",
@@ -906,6 +907,7 @@ def cmd_status(opts: Options) -> int:
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         daemon_status = None
         daemon_error = str(exc)
+        daemon_control_lost = isinstance(exc, ipc.TransportError)
     if daemon_status and daemon_status.get("execution_sessions"):
         print(
             json.dumps(
@@ -929,7 +931,7 @@ def cmd_status(opts: Options) -> int:
             # bounded report avoids turning a control-plane failure into an unbounded engine
             # inventory while retaining fail-closed ownership.
             persisted_sessions = _persisted_execution_sessions(registry)
-            if daemon_error is not None and persisted_sessions:
+            if daemon_control_lost:
                 print(
                     json.dumps(
                         {
@@ -946,6 +948,9 @@ def cmd_status(opts: Options) -> int:
                                 "`bosn daemon-stop`; it attempts safe exact-container recovery "
                                 "and reports any remaining error. Do not delete registry rows or "
                                 "use a blind Docker force operation."
+                                if persisted_sessions
+                                else "no execution session is persisted. Restart the daemon "
+                                "before retrying a mutating command."
                             ),
                         },
                         indent=2,

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -952,9 +952,7 @@ def cmd_status(opts: Options) -> int:
     if daemon_status is not None:
         daemon_error = str(daemon_status.get("error") or "daemon did not return status")
     with Registry(db_path, read_only=True) as registry:
-        persisted_sessions = _persisted_execution_sessions(
-            registry, daemon_control_available=False
-        )
+        persisted_sessions = _persisted_execution_sessions(registry, daemon_control_available=False)
         print(
             json.dumps(
                 {

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -833,7 +833,7 @@ def cmd_cancel(opts: Options) -> int:
     return 0
 
 
-def _persisted_execution_sessions(registry) -> list[dict]:
+def _persisted_execution_sessions(registry, *, daemon_control_available: bool) -> list[dict]:
     """Describe durable foreground ownership without contacting the engine or daemon.
 
     The registry proves that a session is protected, but never authorizes removal.  In
@@ -870,8 +870,14 @@ def _persisted_execution_sessions(registry) -> list[dict]:
                 "recovery": (
                     "do not interrupt the live client"
                     if alive
-                    else "run `bosn daemon-stop`; it reaps only this exact container after "
-                    "confirming the client is dead"
+                    else (
+                        "run `bosn daemon-stop`; it reaps only this exact container after "
+                        "confirming the client is dead"
+                        if daemon_control_available
+                        else "the daemon control channel is unavailable; restore or restart "
+                        "Bosn through its supported launcher/service first. Once `bosn "
+                        "status` responds, run `bosn daemon-stop` for exact-container reap"
+                    )
                 ),
             }
         )
@@ -930,7 +936,9 @@ def cmd_status(opts: Options) -> int:
             # is intentionally *not* sufficient evidence to touch Docker.  Returning this
             # bounded report avoids turning a control-plane failure into an unbounded engine
             # inventory while retaining fail-closed ownership.
-            persisted_sessions = _persisted_execution_sessions(registry)
+            persisted_sessions = _persisted_execution_sessions(
+                registry, daemon_control_available=not daemon_control_lost
+            )
             if daemon_control_lost:
                 print(
                     json.dumps(
@@ -944,10 +952,12 @@ def cmd_status(opts: Options) -> int:
                             },
                             "execution_sessions": persisted_sessions,
                             "next": (
-                                "a live session remains protected. For a dead client, run "
-                                "`bosn daemon-stop`; it attempts safe exact-container recovery "
-                                "and reports any remaining error. Do not delete registry rows or "
-                                "use a blind Docker force operation."
+                                "the daemon control channel is unavailable, so do not run "
+                                "`bosn daemon-stop` yet: it uses that same channel. Restore or "
+                                "restart Bosn through its supported launcher/service first; once "
+                                "`bosn status` responds, `bosn daemon-stop` can attempt safe "
+                                "exact-container recovery. Do not delete registry rows or use a "
+                                "blind Docker force operation."
                                 if persisted_sessions
                                 else "no execution session is persisted. Restart the daemon "
                                 "before retrying a mutating command."

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -188,12 +188,26 @@ class DaemonState:
             return None
 
 
-def is_serving(state_dir: Path | None = None, *, timeout: float = 2.0) -> bool:
-    """True when something answers the ping on this state dir's port."""
+def is_serving(
+    state_dir: Path | None = None,
+    *,
+    timeout: float = 2.0,
+    preserve_timeout: bool = False,
+) -> bool:
+    """True when something answers the ping on this state dir's port.
+
+    Normal callers want a Boolean for spawn/stop decisions. A bounded diagnostic is different:
+    a timeout proves that a listener was contacted but did not answer, which must not be
+    flattened into absence before the caller can report a degraded control plane.
+    """
     try:
         reply = ipc.send_request(
             port_for(state_dir), {"verb": "ping", "auth": _secret(state_dir)}, timeout=timeout
         )
+    except ipc.TransportTimeout:
+        if preserve_timeout:
+            raise
+        return False
     except ipc.TransportError:
         return False
     return bool(reply.get("ok"))
@@ -1609,15 +1623,23 @@ def request(
     *,
     autostart: bool = True,
     request_timeout: float = ipc.DEFAULT_TIMEOUT,
+    diagnostic: bool = False,
     **payload: Any,
 ) -> dict[str, Any]:
     """Send a verb to the daemon, spawning it first when allowed.
 
     Fails closed when the daemon is unreachable and autostart is off -- a fallback to raw
     Docker would recreate exactly the unregistered resources bosn exists to eliminate.
+    ``diagnostic`` is intentionally opt-in for bounded read-only probes: it preserves a ping
+    timeout as ``TransportTimeout`` instead of flattening it into "not serving". Normal
+    autostart and every mutating call retain the historical Boolean liveness behavior.
     """
     state_dir = state_dir or default_state_dir()
-    if not is_serving(state_dir):
+    if not is_serving(
+        state_dir,
+        timeout=request_timeout if diagnostic else 2.0,
+        preserve_timeout=diagnostic,
+    ):
         if not autostart:
             raise DaemonError("no bosn daemon is running")
         spawn(state_dir)

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -948,6 +948,9 @@ class Daemon:
             sessions = []
             for session, owner in self._execution_owners.items():
                 alive = process_alive(*owner)
+                last_reap_error = self.registry.latest_event(
+                    "execution.orphan_reap.error", detail_prefix=f"session={session} "
+                )
                 sessions.append(
                     {
                         "id": session,
@@ -961,6 +964,20 @@ class Daemon:
                             "client is live"
                             if alive
                             else "client is dead; awaiting safe exact-container reap"
+                        ),
+                        "last_orphan_reap_error": (
+                            {
+                                "at": last_reap_error["at"],
+                                "detail": last_reap_error["detail"],
+                            }
+                            if last_reap_error is not None
+                            else None
+                        ),
+                        "recovery": (
+                            "do not interrupt the live client"
+                            if alive
+                            else "run `bosn daemon-stop`; it reaps only this exact "
+                            "container after confirming the client is dead"
                         ),
                     }
                 )

--- a/src/bosn/frontdoor.py
+++ b/src/bosn/frontdoor.py
@@ -250,35 +250,41 @@ _REFUSE: tuple[VerbSpec, ...] = (
         Category.REFUSE,
         "manage networks (create/rm/connect/...)",
         "networks are declared implicitly by a stack and labeled by bosn; use "
-        "`bosn status` to inspect them, `bosn gc` to reclaim them",
+        "`bosn status --json` for bounded managed-state diagnostics, "
+        "`bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report, or "
+        "`bosn gc` to reclaim collectable networks",
     ),
     VerbSpec(
         "volume",
         Category.REFUSE,
         "manage volumes (create/rm/prune/...)",
-        "volumes are declared in bosn.toml and labeled by bosn; use `bosn status` to "
-        "inspect them, `bosn gc` to reclaim them",
+        "volumes are declared in bosn.toml and labeled by bosn; use `bosn status --json` "
+        "for bounded managed-state diagnostics, `bosn gc --dry-run --json` for a rich "
+        "Bosn-owned engine/storage report, or `bosn gc` to reclaim collectable volumes",
     ),
     VerbSpec(
         "image",
         Category.REFUSE,
         "manage images (build/rm/prune/...)",
-        "images are generation-keyed and managed by bosn; use `bosn status`/`bosn gc` "
-        "instead of the raw image subcommands",
+        "images are generation-keyed and managed by bosn; use `bosn status --json` for "
+        "bounded managed-state diagnostics, `bosn gc --dry-run --json` for a rich "
+        "Bosn-owned engine/storage report, or `bosn gc` to reclaim collectable images",
     ),
     VerbSpec(
         "container",
         Category.REFUSE,
         "manage containers (create/rm/prune/...)",
-        "containers are declared in bosn.toml and labeled by bosn; use "
-        "`bosn status`/`bosn gc` instead of the raw container subcommands",
+        "containers are declared in bosn.toml and labeled by bosn; use `bosn status --json` "
+        "for bounded managed-state diagnostics, `bosn gc --dry-run --json` for a rich "
+        "Bosn-owned engine/storage report, or `bosn gc` to reclaim collectable containers",
     ),
     VerbSpec(
         "system",
         Category.REFUSE,
         "manage or inspect the engine (df/prune/events/...)",
         "`system prune` in particular deletes resources bosn did not choose to reclaim; "
-        "use `bosn gc` for a governed equivalent",
+        "use `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report, then "
+        "`bosn gc` to reclaim collectable resources",
     ),
     VerbSpec(
         "save",
@@ -327,8 +333,9 @@ _REFUSE: tuple[VerbSpec, ...] = (
         "ps",
         Category.REFUSE,
         "list containers",
-        "lists raw engine state instead of bosn's managed view; use `bosn status` or "
-        "`bosn tasks` for governed introspection",
+        "lists raw engine state instead of Bosn's bounded managed-state diagnostics; use "
+        "`bosn status --json` for those diagnostics, `bosn tasks` for manifest readiness, or "
+        "`bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report",
     ),
     VerbSpec(
         "logs",
@@ -341,8 +348,9 @@ _REFUSE: tuple[VerbSpec, ...] = (
         "inspect",
         Category.REFUSE,
         "show low-level details of an object",
-        "targets a raw object name outside bosn's registry; use `bosn status` for "
-        "governed introspection",
+        "targets a raw object name outside bosn's registry; use `bosn status --json` for "
+        "bounded managed-state diagnostics or `bosn gc --dry-run --json` for a rich "
+        "Bosn-owned engine/storage report",
     ),
     VerbSpec(
         "top",
@@ -355,22 +363,25 @@ _REFUSE: tuple[VerbSpec, ...] = (
         "stats",
         Category.REFUSE,
         "stream resource usage statistics",
-        "targets raw container names outside bosn's registry; use `bosn status` for "
-        "governed introspection",
+        "targets raw container names outside bosn's registry; Bosn does not expose a "
+        "streaming resource-usage view. Use `bosn status --json` for bounded managed-state "
+        "diagnostics or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report",
     ),
     VerbSpec(
         "events",
         Category.REFUSE,
         "stream real-time engine events",
-        "surfaces raw engine activity outside bosn's registry; use `bosn status` for "
-        "governed introspection",
+        "surfaces raw engine activity outside bosn's registry; Bosn does not expose a raw "
+        "engine event stream. Use `bosn status --json` for bounded managed-state diagnostics "
+        "or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report",
     ),
     VerbSpec(
         "port",
         Category.REFUSE,
         "list a container's published ports",
-        "targets a raw container name outside bosn's registry; use `bosn status` for "
-        "governed introspection",
+        "targets a raw container name outside bosn's registry; Bosn does not expose a "
+        "published-port listing. Use `bosn status --json` only for bounded managed-state "
+        "diagnostics or `bosn gc --dry-run --json` for a rich Bosn-owned engine/storage report",
     ),
     VerbSpec(
         "diff",

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -963,6 +963,24 @@ class Registry:
     def events(self, limit: int = 100) -> list[sqlite3.Row]:
         return self._exec("SELECT * FROM events ORDER BY id DESC LIMIT ?", (limit,)).fetchall()
 
+    def latest_event(self, kind: str, *, detail_prefix: str = "") -> sqlite3.Row | None:
+        """Return the newest event of ``kind``, optionally scoped to one durable identity.
+
+        Diagnostic callers use this to explain a protected state without treating an event
+        as authority to change it.  Prefix matching is deliberately parameterized: execution
+        recovery events begin with ``session=<uuid> `` and a report for one session must not
+        accidentally attribute another session's engine error to it.
+        """
+        if detail_prefix:
+            return self._exec(
+                "SELECT * FROM events WHERE kind = ? AND detail LIKE ? "
+                "ORDER BY id DESC LIMIT 1",
+                (kind, f"{detail_prefix}%"),
+            ).fetchone()
+        return self._exec(
+            "SELECT * FROM events WHERE kind = ? ORDER BY id DESC LIMIT 1", (kind,)
+        ).fetchone()
+
 
 def _resource_from_row(row: sqlite3.Row) -> Resource:
     return Resource(

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -973,8 +973,7 @@ class Registry:
         """
         if detail_prefix:
             return self._exec(
-                "SELECT * FROM events WHERE kind = ? AND detail LIKE ? "
-                "ORDER BY id DESC LIMIT 1",
+                "SELECT * FROM events WHERE kind = ? AND detail LIKE ? ORDER BY id DESC LIMIT 1",
                 (kind, f"{detail_prefix}%"),
             ).fetchone()
         return self._exec(

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -222,6 +222,65 @@ def test_status_is_bounded_when_a_daemon_stream_is_lost_without_a_session(
     assert "Restore or restart Bosn" in report["next"]
 
 
+@pytest.mark.parametrize("timeout_verb", ["ping", "status"])
+def test_status_preserves_a_real_diagnostic_request_timeout_as_degraded(
+    tmp_path, monkeypatch, capsys, timeout_verb
+) -> None:
+    """#119: request's liveness probe must not hide a contacted-but-stuck daemon.
+
+    This deliberately invokes the real ``daemon.request`` and real ``is_serving`` rather
+    than replacing either: the fake transport models the two wire positions where a timeout
+    can occur. A dead port still raises ordinary ``TransportError`` and is reported offline.
+    """
+    from bosn import daemon
+    from bosn.registry import Registry
+
+    state = tmp_path / "state"
+    with Registry(state / "registry.sqlite3"):
+        pass
+    calls = []
+
+    def transport(_port, request, *, timeout, **_kwargs):
+        calls.append((request["verb"], timeout))
+        if request["verb"] == timeout_verb:
+            raise ipc.TransportTimeout("timed out waiting for the daemon")
+        return {"ok": True}
+
+    monkeypatch.setattr(ipc, "send_request", transport)
+    monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["mode"] == "degraded"
+    assert calls == [("ping", cli.STATUS_DAEMON_TIMEOUT_SECONDS)] + (
+        [("status", cli.STATUS_DAEMON_TIMEOUT_SECONDS)] if timeout_verb == "status" else []
+    )
+
+
+def test_status_actual_diagnostic_request_reports_a_dead_port_offline(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """A refused ping is absence, unlike a ping that reaches its timeout budget."""
+    from bosn.registry import Registry
+
+    state = tmp_path / "state"
+    with Registry(state / "registry.sqlite3"):
+        pass
+    monkeypatch.setattr(
+        ipc,
+        "send_request",
+        lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(ipc.TransportError("connection refused")),
+    )
+    monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["mode"] == "offline"
+    assert report["daemon"]["reachable"] is False
+
+
 def test_status_returns_an_offline_empty_session_report_without_engine_inventory(
     tmp_path, monkeypatch, capsys
 ) -> None:

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -186,7 +186,13 @@ def test_status_uses_persisted_session_proof_when_daemon_control_stream_is_lost(
 
     assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
     report = json.loads(capsys.readouterr().out)
-    assert calls == [{"autostart": False, "request_timeout": cli.STATUS_DAEMON_TIMEOUT_SECONDS}]
+    assert calls == [
+        {
+            "autostart": False,
+            "request_timeout": cli.STATUS_DAEMON_TIMEOUT_SECONDS,
+            "diagnostic": True,
+        }
+    ]
     assert report["mode"] == "degraded"
     assert report["execution_sessions"][0]["id"] == "orphan"
     assert report["execution_sessions"][0]["last_orphan_reap_error"]["detail"].endswith("busy")
@@ -232,7 +238,6 @@ def test_status_preserves_a_real_diagnostic_request_timeout_as_degraded(
     than replacing either: the fake transport models the two wire positions where a timeout
     can occur. A dead port still raises ordinary ``TransportError`` and is reported offline.
     """
-    from bosn import daemon
     from bosn.registry import Registry
 
     state = tmp_path / "state"
@@ -269,9 +274,7 @@ def test_status_actual_diagnostic_request_reports_a_dead_port_offline(
     monkeypatch.setattr(
         ipc,
         "send_request",
-        lambda *_args, **_kwargs: (
-            _ for _ in ()
-        ).throw(ipc.TransportError("connection refused")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ipc.TransportError("connection refused")),
     )
     monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -156,6 +156,33 @@ def test_status_uses_persisted_session_proof_when_daemon_control_stream_is_lost(
     assert "daemon-stop" in report["execution_sessions"][0]["recovery"]
 
 
+def test_status_is_bounded_when_a_daemon_stream_is_lost_without_a_session(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """#119: a completed foreground command must not send status into engine inventory."""
+    from bosn import daemon
+    from bosn.registry import Registry
+
+    state = tmp_path / "state"
+    with Registry(state / "registry.sqlite3"):
+        pass
+
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ipc.TransportTimeout("timed out waiting for the daemon")
+        ),
+    )
+    monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["mode"] == "degraded"
+    assert report["execution_sessions"] == []
+    assert "Restart the daemon" in report["next"]
+
+
 def test_tasks_json_reports_unregistered_readiness(tmp_path, capsys) -> None:
     (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     manifest = tmp_path / "bosn.toml"

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -116,6 +116,48 @@ def test_status_surfaces_a_foreground_session_without_waiting_for_engine_scan(
     assert report["execution_sessions"][0]["id"] == "session"
 
 
+def test_status_uses_persisted_session_proof_when_daemon_control_stream_is_lost(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """#119: terminal-only jobs must not hide a disconnected foreground client.
+
+    This deliberately uses the durable session record rather than a daemon fake response:
+    it is the path available when the control RPC itself has timed out.  Constructing an
+    Engine would prove a regression to slow inventory fallback.
+    """
+    from bosn import daemon, resources
+    from bosn.registry import ExecutionSession, Registry
+
+    state = tmp_path / "state"
+    with Registry(state / "registry.sqlite3") as registry:
+        registry.save_execution_session(
+            ExecutionSession("orphan", "immutable-id", "podman", 4242, 9.0, ("lease",))
+        )
+        registry.log_event(
+            "execution.orphan_reap.error",
+            "session=orphan container=immutable-id RuntimeError: busy",
+        )
+    calls = []
+
+    def lost_stream(*_args, **kwargs):
+        calls.append(kwargs)
+        raise ipc.TransportTimeout("timed out waiting for the daemon")
+
+    monkeypatch.setattr(daemon, "request", lost_stream)
+    monkeypatch.setattr(resources, "process_alive", lambda *_args: False)
+    monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert calls == [
+        {"autostart": False, "request_timeout": cli.STATUS_DAEMON_TIMEOUT_SECONDS}
+    ]
+    assert report["mode"] == "degraded"
+    assert report["execution_sessions"][0]["id"] == "orphan"
+    assert report["execution_sessions"][0]["last_orphan_reap_error"]["detail"].endswith("busy")
+    assert "daemon-stop" in report["execution_sessions"][0]["recovery"]
+
+
 def test_tasks_json_reports_unregistered_readiness(tmp_path, capsys) -> None:
     (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     manifest = tmp_path / "bosn.toml"

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -104,6 +104,7 @@ def test_status_surfaces_a_foreground_session_without_waiting_for_engine_scan(
         "request",
         lambda *_args, **_kwargs: {
             "registry_id": "registry",
+            "resources": 3,
             "execution_sessions": [
                 {"id": "session", "client_alive": False, "blocking_reason": "awaiting reap"}
             ],
@@ -113,7 +114,43 @@ def test_status_surfaces_a_foreground_session_without_waiting_for_engine_scan(
 
     assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
     report = json.loads(capsys.readouterr().out)
+    assert report["mode"] == "online"
+    assert report["registered"] == 3
     assert report["execution_sessions"][0]["id"] == "session"
+
+
+def test_status_returns_a_healthy_empty_session_report_without_engine_inventory(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """#119: an idle healthy daemon is a complete status answer, not a Docker scan."""
+    from bosn import daemon
+
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "registry.sqlite3").touch()
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda *_args, **_kwargs: {
+            "ok": True,
+            "registry_id": "registry",
+            "resources": 0,
+            "execution_sessions": [],
+            "pid": 42,
+            "version": "test",
+        },
+    )
+    monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "mode": "online",
+        "registry_id": "registry",
+        "registered": 0,
+        "execution_sessions": [],
+        "daemon": {"reachable": True, "pid": 42, "version": "test"},
+        "next": "no foreground execution session is blocking the daemon",
+    }
 
 
 def test_status_uses_persisted_session_proof_when_daemon_control_stream_is_lost(
@@ -180,8 +217,34 @@ def test_status_is_bounded_when_a_daemon_stream_is_lost_without_a_session(
     assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
     report = json.loads(capsys.readouterr().out)
     assert report["mode"] == "degraded"
+    assert report["registered"] == 0
     assert report["execution_sessions"] == []
-    assert "Restart the daemon" in report["next"]
+    assert "Restore or restart Bosn" in report["next"]
+
+
+def test_status_returns_an_offline_empty_session_report_without_engine_inventory(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """#119: no daemon is still a bounded registry report, never an engine scan."""
+    from bosn import daemon
+    from bosn.registry import Registry
+
+    state = tmp_path / "state"
+    with Registry(state / "registry.sqlite3"):
+        pass
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(daemon.DaemonError("no daemon")),
+    )
+    monkeypatch.setattr(cli, "Engine", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["mode"] == "offline"
+    assert report["registered"] == 0
+    assert report["execution_sessions"] == []
+    assert report["daemon"]["reachable"] is False
 
 
 def test_tasks_json_reports_unregistered_readiness(tmp_path, capsys) -> None:

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -153,7 +153,8 @@ def test_status_uses_persisted_session_proof_when_daemon_control_stream_is_lost(
     assert report["mode"] == "degraded"
     assert report["execution_sessions"][0]["id"] == "orphan"
     assert report["execution_sessions"][0]["last_orphan_reap_error"]["detail"].endswith("busy")
-    assert "daemon-stop" in report["execution_sessions"][0]["recovery"]
+    assert "control channel is unavailable" in report["execution_sessions"][0]["recovery"]
+    assert "do not run `bosn daemon-stop` yet" in report["next"]
 
 
 def test_status_is_bounded_when_a_daemon_stream_is_lost_without_a_session(

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -149,9 +149,7 @@ def test_status_uses_persisted_session_proof_when_daemon_control_stream_is_lost(
 
     assert cli.main(["--state-dir", str(state), "status", "--json"]) == 0
     report = json.loads(capsys.readouterr().out)
-    assert calls == [
-        {"autostart": False, "request_timeout": cli.STATUS_DAEMON_TIMEOUT_SECONDS}
-    ]
+    assert calls == [{"autostart": False, "request_timeout": cli.STATUS_DAEMON_TIMEOUT_SECONDS}]
     assert report["mode"] == "degraded"
     assert report["execution_sessions"][0]["id"] == "orphan"
     assert report["execution_sessions"][0]["last_orphan_reap_error"]["detail"].endswith("busy")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -665,6 +665,38 @@ def test_dead_execution_owner_is_stopped_and_reaped_before_next_acquire(
         daemon.registry.close()
 
 
+def test_status_reports_the_exact_dead_session_recovery_error(tmp_path: Path, monkeypatch) -> None:
+    """#119: status must name the failed safe-reap action, not just say "blocked"."""
+    from bosn import resources
+    from bosn.registry import ExecutionSession
+
+    daemon = Daemon(state_dir=tmp_path / "state")
+    try:
+        session = ExecutionSession("orphan", "immutable-id", "podman", 111, 10.0, ("lease",))
+        daemon.registry.save_execution_session(session)
+        daemon._execution_sessions[session.id] = session.lease_ids
+        daemon._execution_containers[session.id] = session.container_id
+        daemon._execution_owners[session.id] = (session.client_pid, session.client_start)
+        daemon._execution_engines[session.id] = session.engine_binary
+        daemon.registry.log_event(
+            "execution.orphan_reap.error",
+            "session=orphan container=immutable-id RuntimeError: busy",
+        )
+        monkeypatch.setattr(resources, "process_alive", lambda *_args: False)
+
+        report = daemon.dispatch("status", {})
+
+        [reported] = report["execution_sessions"]
+        assert reported["id"] == "orphan"
+        assert reported["container_id"] == "immutable-id"
+        assert reported["client_alive"] is False
+        assert reported["blocking_reason"] == "client is dead; awaiting safe exact-container reap"
+        assert reported["last_orphan_reap_error"]["detail"].endswith("busy")
+        assert "daemon-stop" in reported["recovery"]
+    finally:
+        daemon.registry.close()
+
+
 def test_execution_session_survives_daemon_restart_and_still_serializes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- make `bosn status --json` a bounded, engine-independent control-plane/registry diagnostic in online, offline, and degraded modes
- preserve diagnostic transport timeouts instead of misclassifying a wedged daemon as absent
- expose persisted session liveness, exact container/leases, and scoped orphan-reap errors with fail-closed recovery guidance
- keep live sessions protected and route rich Bosn-owned engine/storage inspection to `gc --dry-run --json`
- align README, front-door guidance, and generated Docker support documentation

Fixes #119

## Local validation

- issue-focused daemon/status/transport tests: 13 passed
- generated-doc/front-door tests: 335 passed
- `bash ./lint`: passed
- full non-Docker suite: 1,051 passed, 2 skipped, 35 deselected
- isolated runtime: offline status 0.304s; online status 0.376s; zero execution sessions

## Bosn Linux dogfood

- unique isolated `ensure`: live Docker output, exit 0
- unique isolated `lint`: live output, exit 0
- unique isolated `test`: live output, exit 0
- post-task status: prompt, zero execution sessions
- `done`, `gc --dry-run`, and `daemon-stop`: completed without errors or unsafe resource mutation

## Review

- one-agent pre-push review: clean
- hosted CI intentionally not used as the merge gate; validation was local plus isolated Bosn/Linux dogfood