### PR TITLE
fix: safely reconcile legacy incomplete volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ attachment check happens again immediately before staged recreation.  `gc --appl
 non-destructive for all incomplete resources; there is no `--force`, and `adopt` is not a
 remedy for incomplete ownership.
 
+When `gc` has a selected `bosn.toml`, its dry-run report also checks only the exact volume
+names derived from that manifest. This makes an otherwise label-free collision visible as a
+protected manifest blocker; the name remains a diagnostic selector, never ownership proof.
+
 Nothing needs starting — the first command lazily spawns the daemon.
 
 **For unattended cleanup, install the login launcher once:**

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ bosn reconcile-volume --stack perf --volume target --apply --yes
 
 `reconcile-volume` accepts the logical volume declared in `bosn.toml`, not an arbitrary
 engine volume name.  It derives the exact target from the current manifest, requires the
-current registry label plus a matching surviving Bosn identity label, and refuses an
+current registry label plus a matching surviving manifest-binding label (`stack`,
+`generation`, `scope`, or `workspace`); every other surviving Bosn label must also agree.
+It refuses an
 unlabeled, foreign, contradictory, attached, or attachment-unknown volume.  The final
 attachment check happens again immediately before staged recreation.  `gc --apply` remains
 non-destructive for all incomplete resources; there is no `--force`, and `adopt` is not a

--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ bosn unit                      # run the task
 bosn status --json             # bounded daemon/registry state; use gc for engine/storage details
 ```
 
+### Recovering an interrupted volume creation
+
+Bosn records a durable creation intent before creating new volumes.  A later `bosn ensure`
+repairs an interrupted intent-backed creation automatically, but it never guesses ownership
+from a name or from an unlabeled Docker volume.  For a legacy partial volume created before
+that intent record existed, inspect the protected decision first:
+
+```bash
+bosn gc --dry-run --json
+bosn reconcile-volume --stack perf --volume target --json
+bosn reconcile-volume --stack perf --volume target --apply --yes
+```
+
+`reconcile-volume` accepts the logical volume declared in `bosn.toml`, not an arbitrary
+engine volume name.  It derives the exact target from the current manifest, requires the
+current registry label plus a matching surviving Bosn identity label, and refuses an
+unlabeled, foreign, contradictory, attached, or attachment-unknown volume.  The final
+attachment check happens again immediately before staged recreation.  `gc --apply` remains
+non-destructive for all incomplete resources; there is no `--force`, and `adopt` is not a
+remedy for incomplete ownership.
+
 Nothing needs starting — the first command lazily spawns the daemon.
 
 **For unattended cleanup, install the login launcher once:**
@@ -469,6 +490,8 @@ bosn jobs / bosn attach <j>  # daemon-owned builds that survive a killed CLI
 bosn cancel <j>              # stop a build you no longer want
 bosn done                    # this workspace is finished; its caches become collectable
 bosn gc --dry-run --json     # rich engine/storage inventory; --apply reclaims (no --force)
+bosn reconcile-volume --stack perf --volume target  # preview one legacy partial target
+bosn reconcile-volume --stack perf --volume target --apply --yes  # explicit repair
 bosn doctor                  # engine reachability, registry integrity, recovery commands
 bosn adopt --legacy <family> # import pre-bosn volumes; --yes to apply
 
@@ -483,6 +506,11 @@ daemon returns `mode: "online"`; an absent daemon returns `mode: "offline"`; and
 stream returns `mode: "degraded"` with persisted session diagnostics. For the rich engine,
 ownership, and storage inventory, use `bosn gc --dry-run --json` instead. `gc` and `jobs` are
 read-only but go through the daemon and fail closed if it is unreachable.
+
+`reconcile-volume` is for incomplete legacy labels only. It derives the engine name from the
+current manifest and refuses arbitrary names, unlabeled volumes, foreign/contradictory labels,
+and anything attached or with unknown attachment state. Ordinary `ensure` auto-recovers only a
+durable intent-backed interruption; it never uses this explicit legacy authority on its own.
 
 When ordinary `status` can reach the daemon and says the client is dead, run `bosn daemon-stop`:
 Bosn first proves the owner is dead, then removes only that session's exact immutable container

--- a/skills/bosn/SKILL.md
+++ b/skills/bosn/SKILL.md
@@ -53,6 +53,9 @@ unless Docker access is intentionally configured.
   `bosn reconcile-volume --stack <stack> --volume <logical-name>` to preview it. Apply needs
   `--apply --yes`; a registry label plus `kind`/`created` alone is insufficient. Never
   substitute `adopt`, a raw engine name, or a force-delete.
+- Run `bosn gc` from the affected workspace or pass `--manifest`: it adds protected
+  diagnostics for exact manifest-derived volume-name collisions, including label-free ones,
+  but never uses the name itself as permission to modify a volume.
 - After changing bosn code during development, restart its daemon before dogfooding so the
   in-memory process runs the updated implementation.
 

--- a/skills/bosn/SKILL.md
+++ b/skills/bosn/SKILL.md
@@ -49,6 +49,9 @@ unless Docker access is intentionally configured.
 - Treat foreign registry warnings as protected state. Bosn intentionally cannot delete
   resources owned by a different registry identity; use explicit adoption only after
   confirming ownership.
+- For an incomplete legacy volume, inspect `bosn gc --dry-run --json` and use only
+  `bosn reconcile-volume --stack <stack> --volume <logical-name>` to preview it. Apply needs
+  `--apply --yes`; never substitute `adopt`, a raw engine name, or a force-delete.
 - After changing bosn code during development, restart its daemon before dogfooding so the
   in-memory process runs the updated implementation.
 

--- a/skills/bosn/SKILL.md
+++ b/skills/bosn/SKILL.md
@@ -51,7 +51,8 @@ unless Docker access is intentionally configured.
   confirming ownership.
 - For an incomplete legacy volume, inspect `bosn gc --dry-run --json` and use only
   `bosn reconcile-volume --stack <stack> --volume <logical-name>` to preview it. Apply needs
-  `--apply --yes`; never substitute `adopt`, a raw engine name, or a force-delete.
+  `--apply --yes`; a registry label plus `kind`/`created` alone is insufficient. Never
+  substitute `adopt`, a raw engine name, or a force-delete.
 - After changing bosn code during development, restart its daemon before dogfooding so the
   in-memory process runs the updated implementation.
 

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -50,6 +50,7 @@ GC_REQUEST_TIMEOUT_SECONDS = 120.0
 # transfer-sized copy legs for every selected volume. Keeping this operation-specific preserves
 # the shared 10-second control-plane budget used by ordinary verbs.
 ADOPT_SCAN_REQUEST_TIMEOUT_SECONDS = 15 * 60.0
+RECONCILE_VOLUME_REQUEST_TIMEOUT_SECONDS = ADOPT_SCAN_REQUEST_TIMEOUT_SECONDS + (2 * 30 * 60.0)
 
 
 def adopt_request_timeout_seconds(transfer_count: int) -> float:
@@ -146,6 +147,7 @@ VERBS: dict[str, tuple[str, str]] = {
     "done": ("mark this workspace finished; its caches become collectable", "implemented"),
     "ensure": ("pre-warm a stack without running a command", "implemented"),
     "adopt": ("recover labeled resources into this registry", "implemented"),
+    "reconcile-volume": ("explicitly repair one incomplete manifest volume", "implemented"),
     "doctor": ("engine health and reachability", "implemented"),
     "daemon-stop": ("stop the running daemon (needed after upgrades)", "implemented"),
     "init": ("translate a Compose file into bosn.toml (alias: bosn-docker init)", "implemented"),
@@ -188,7 +190,7 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
         sub = subparsers.add_parser(verb, help=help_text)
         _add_policy_flags(sub, default=argparse.SUPPRESS)
         sub.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
-        if verb in {"run", "tasks", "shell", "done", "ensure", "adopt"}:
+        if verb in {"run", "tasks", "shell", "done", "ensure", "adopt", "reconcile-volume"}:
             sub.add_argument("--stack", default=None, help="stack to use (default: the default)")
             sub.add_argument("--task", default=None, help="run a manifest task by name")
             sub.add_argument("--manifest", default=None, dest="sub_manifest")
@@ -223,6 +225,21 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
                 action="store_true",
                 default=False,
                 help="apply the adoption; without it, only report what would be adopted",
+            )
+        if verb == "reconcile-volume":
+            sub.add_argument(
+                "--volume", default=None, metavar="LOGICAL_NAME",
+                help=(
+                    "declared volume name from the selected stack; engine names are never accepted"
+                ),
+            )
+            sub.add_argument(
+                "--apply", dest="reconcile_apply", action="store_true", default=False,
+                help="apply the exact recovery after preview and --yes confirmation",
+            )
+            sub.add_argument(
+                "--yes", dest="yes", action="store_true", default=False,
+                help="confirm the explicit legacy recovery when used with --apply",
             )
         if verb == "init":
             # Matches `bosn-docker init`'s flag surface (see docker_cli._parse_init_args)
@@ -1049,6 +1066,7 @@ def cmd_gc(opts: Options) -> int:
                     "removed": reply.get("removed", []),
                     "image_dependency_deferred": reply.get("image_dependency_deferred", []),
                     "image_decisions": reply.get("image_decisions", []),
+                    "unproven_resources": reply.get("unproven_resources", []),
                     "errors": reply.get("errors", []),
                     "advisories": reply.get("advisories", []),
                 },
@@ -1281,6 +1299,71 @@ def cmd_adopt(opts: Options) -> int:
     return 0
 
 
+def cmd_reconcile_volume(opts: Options) -> int:
+    """Preview or explicitly repair one incomplete volume derived from bosn.toml."""
+    from bosn import daemon as daemon_mod
+    from bosn.manifest import ManifestError, find_manifest, load
+
+    if not opts.stack or not opts.volume:
+        return _error(
+            code="reconcile-volume.stack_required",
+            message="reconcile-volume requires --stack and --volume for an unambiguous target",
+            next_step="pass the stack and logical volume declared by bosn.toml",
+            as_json=opts.json,
+        )
+    try:
+        manifest_path = opts.manifest or find_manifest()
+        if manifest_path is None:
+            raise ManifestError("no bosn.toml found; create one or pass --manifest")
+        manifest = load(manifest_path)
+        # Validate client-side too, so a typo never starts a daemon merely to be refused.
+        stack = manifest.stack(opts.stack)
+        if not any(volume.name == opts.volume for volume in stack.volumes):
+            raise ManifestError(f"volume {opts.volume!r} is not declared by stack {stack.name!r}")
+    except ManifestError as exc:
+        return _error(
+            code="reconcile-volume.invalid_manifest",
+            message=str(exc),
+            next_step="select a declared stack and logical volume",
+            as_json=opts.json,
+        )
+    try:
+        reply = daemon_mod.request(
+            "reconcile-volume",
+            opts.state_dir,
+            manifest=str(manifest.path),
+            stack=opts.stack,
+            volume=opts.volume,
+            apply=opts.reconcile_apply,
+            yes=opts.yes,
+            engine=opts.engine,
+            request_timeout=RECONCILE_VOLUME_REQUEST_TIMEOUT_SECONDS,
+        )
+    except ipc.TransportTimeout as exc:
+        return _error(
+            code="reconcile-volume.timeout",
+            message=f"the daemon did not finish volume reconciliation: {exc}",
+            next_step=(
+                "do not retry a transfer yet; inspect the preserved staging volume and status"
+            ),
+            as_json=opts.json,
+        )
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        return _error(
+            code="daemon.unreachable",
+            message=f"cannot reach the bosn daemon: {exc}",
+            next_step="start or restart the daemon, then retry",
+            as_json=opts.json,
+        )
+    if opts.json:
+        print(json.dumps(reply, indent=2))
+    elif reply.get("plan"):
+        print(json.dumps(reply["plan"], indent=2))
+    elif not reply.get("ok"):
+        print(str(reply.get("error") or "reconcile-volume failed"), file=sys.stderr)
+    return 0 if reply.get("ok") else 1
+
+
 def cmd_shell(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.converge import workspace_of
@@ -1442,6 +1525,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "gc": cmd_gc,
         "done": cmd_done,
         "adopt": cmd_adopt,
+        "reconcile-volume": cmd_reconcile_volume,
         "init": cmd_init,
     }
     handler = handlers.get(opts.verb)

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -228,17 +228,25 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
             )
         if verb == "reconcile-volume":
             sub.add_argument(
-                "--volume", default=None, metavar="LOGICAL_NAME",
+                "--volume",
+                default=None,
+                metavar="LOGICAL_NAME",
                 help=(
                     "declared volume name from the selected stack; engine names are never accepted"
                 ),
             )
             sub.add_argument(
-                "--apply", dest="reconcile_apply", action="store_true", default=False,
+                "--apply",
+                dest="reconcile_apply",
+                action="store_true",
+                default=False,
                 help="apply the exact recovery after preview and --yes confirmation",
             )
             sub.add_argument(
-                "--yes", dest="yes", action="store_true", default=False,
+                "--yes",
+                dest="yes",
+                action="store_true",
+                default=False,
                 help="confirm the explicit legacy recovery when used with --apply",
             )
         if verb == "init":

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -1011,16 +1011,21 @@ def cmd_gc(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
     from bosn.config import load as load_config
+    from bosn.manifest import find_manifest
 
     try:
         flags = _policy_flags(opts)
         load_config(flags=flags)
+        # GC stays global when no manifest is present.  When one is available, the daemon
+        # can additionally inspect the exact volume names it derives from this contract.
+        manifest_path = opts.manifest or find_manifest()
         reply = daemon_mod.request(
             "gc",
             opts.state_dir,
             engine=opts.engine,
             dry_run=opts.dry_run,
             policy_flags=flags,
+            manifest=str(manifest_path) if manifest_path is not None else None,
             request_timeout=GC_REQUEST_TIMEOUT_SECONDS,
         )
     except ConfigError as exc:

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -264,6 +264,7 @@ class _Handler(socketserver.StreamRequestHandler):
             "done",
             "adopt",
             "compose-adopt",
+            "reconcile-volume",
             "execution-acquire",
             "execution-release",
             "compose-acquire",

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -1036,12 +1036,20 @@ class Daemon:
         from bosn.config import load as load_config
         from bosn.engine import Engine
         from bosn.gc import Collector
+        from bosn.manifest import ManifestError, load
 
         flags = request.get("policy_flags")
         config = load_config(flags=flags if isinstance(flags, dict) else None)
+        manifest = None
+        manifest_text = str(request.get("manifest") or "")
+        if manifest_text:
+            try:
+                manifest = load(Path(manifest_text))
+            except ManifestError as exc:
+                return {"ok": False, "error": f"gc manifest diagnostics unavailable: {exc}"}
         result = Collector(
             self.registry, Engine(str(request.get("engine") or self.engine_binary)), config=config
-        ).collect(dry_run=bool(request.get("dry_run", True)))
+        ).collect(dry_run=bool(request.get("dry_run", True)), manifest=manifest)
         return {
             "ok": True,
             "result": result.summary(),

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -294,7 +294,14 @@ class _Handler(socketserver.StreamRequestHandler):
             raise
         except Exception as exc:  # noqa: BLE001 - every failure is observable, none fatal
             response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
-        ipc.send_response(self.connection, response)
+        try:
+            ipc.send_response(self.connection, response)
+        except (ipc.TransportError, OSError) as exc:
+            # A GC/status client can time out after the daemon has completed its work.
+            # Its disconnected socket is not authority to stop the shared daemon.
+            daemon_ref.registry.log_event(
+                "ipc.response_disconnected", f"{verb}: {type(exc).__name__}: {exc}"
+            )
 
     def _stream(self, daemon_ref: Daemon, verb: str, request: dict[str, Any]) -> None:
         """Hold the connection open and write events until the job reaches a terminal one.

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -1057,9 +1057,9 @@ class Daemon:
         """
         from pathlib import Path
 
-        from bosn.converge import volume_name_for, workspace_of
+        from bosn.converge import resolved_generation, volume_name_for, workspace_of
         from bosn.engine import Engine
-        from bosn.manifest import ManifestError, generation_digest, load
+        from bosn.manifest import ManifestError, load
         from bosn.recovery import (
             apply_legacy_volume_reconciliation,
             legacy_expected_labels,
@@ -1085,7 +1085,8 @@ class Daemon:
             return {"ok": False, "error": detail}
 
         workspace = workspace_of(manifest)
-        digest = generation_digest(manifest, stack)
+        engine = Engine(str(request.get("engine") or self.engine_binary))
+        digest, _ = resolved_generation(manifest, stack, engine)
         name = volume_name_for(
             stack,
             volume.scope,
@@ -1094,7 +1095,6 @@ class Daemon:
             workspace=workspace,
             family=stack.family,
         )
-        engine = Engine(str(request.get("engine") or self.engine_binary))
 
         def current_plan():
             raw = ResourceScanner(engine).inspect_labels("volume", name)

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -1137,8 +1137,12 @@ class Daemon:
                     return {"ok": False, "error": final_plan.reason, "plan": final_plan.to_dict()}
                 apply_legacy_volume_reconciliation(engine, final_plan)
                 self.registry.reconcile_resource(
-                    kind="volume", name=name, stack=stack.name, generation=digest,
-                    scope=volume.scope, workspace=workspace,
+                    kind="volume",
+                    name=name,
+                    stack=stack.name,
+                    generation=digest,
+                    scope=volume.scope,
+                    workspace=workspace,
                 )
                 self.registry.log_event("volume.legacy_reconciled", name)
         except TransferError as exc:

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -932,6 +932,7 @@ class Daemon:
             "jobs": self._verb_jobs,
             "cancel": self._verb_cancel,
             "gc": self._verb_gc,
+            "reconcile-volume": self._verb_reconcile_volume,
             "done": self._verb_done,
             "adopt": self._verb_adopt,
             "compose-adopt": self._verb_compose_adopt,
@@ -1044,7 +1045,105 @@ class Daemon:
             "image_decisions": result.image_decisions,
             "errors": result.errors,
             "advisories": result.advisories,
+            "unproven_resources": result.unproven_resources,
         }
+
+    def _verb_reconcile_volume(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Explicitly repair one manifest-derived, legacy partial volume (#120).
+
+        This is deliberately not part of normal convergence.  Schema-v3 durable intents
+        remain the only automatic recovery authority; this verb consumes a human's exact
+        stack/volume selection and still refuses anything that lacks corroborating labels.
+        """
+        from pathlib import Path
+
+        from bosn.converge import volume_name_for, workspace_of
+        from bosn.engine import Engine
+        from bosn.manifest import ManifestError, generation_digest, load
+        from bosn.recovery import (
+            apply_legacy_volume_reconciliation,
+            legacy_expected_labels,
+            plan_legacy_volume_reconciliation,
+        )
+        from bosn.resources import ResourceScanner, TransferError
+
+        manifest_text = str(request.get("manifest") or "")
+        stack_name = str(request.get("stack") or "")
+        logical_name = str(request.get("volume") or "")
+        if not manifest_text or not stack_name or not logical_name:
+            return {"ok": False, "error": "reconcile-volume requires manifest, stack, and volume"}
+        try:
+            manifest = load(Path(manifest_text))
+            stack = manifest.stack(stack_name)
+            volume = next(item for item in stack.volumes if item.name == logical_name)
+        except (ManifestError, StopIteration) as exc:
+            detail = (
+                str(exc)
+                if isinstance(exc, ManifestError)
+                else "volume is not declared by the selected stack"
+            )
+            return {"ok": False, "error": detail}
+
+        workspace = workspace_of(manifest)
+        digest = generation_digest(manifest, stack)
+        name = volume_name_for(
+            stack,
+            volume.scope,
+            volume.name,
+            digest=digest,
+            workspace=workspace,
+            family=stack.family,
+        )
+        engine = Engine(str(request.get("engine") or self.engine_binary))
+
+        def current_plan():
+            raw = ResourceScanner(engine).inspect_labels("volume", name)
+            expected = legacy_expected_labels(
+                registry_id=self.registry.registry_id,
+                stack=stack.name,
+                generation=digest,
+                scope=volume.scope,
+                workspace=workspace,
+                raw_labels=raw,
+            )
+            return plan_legacy_volume_reconciliation(
+                name=name,
+                raw_labels=raw,
+                expected=expected,
+                registry_id=self.registry.registry_id,
+                engine=engine,
+            )
+
+        plan = current_plan()
+        if not bool(request.get("apply")):
+            return {"ok": True, "applied": False, "plan": plan.to_dict()}
+        if not bool(request.get("yes")):
+            return {
+                "ok": False,
+                "error": "reconcile-volume requires --yes together with --apply",
+                "plan": plan.to_dict(),
+            }
+        if plan.action == "already-owned":
+            return {"ok": True, "applied": False, "plan": plan.to_dict()}
+        if plan.action != "would-recreate":
+            return {"ok": False, "error": plan.reason, "plan": plan.to_dict()}
+        final_plan = plan
+        try:
+            # The preview's engine state is advisory.  The mutation boundary repeats both
+            # identity and attachment proof under the registry lifecycle lock.
+            with self.registry.lifecycle_guard():
+                final_plan = current_plan()
+                if final_plan.action != "would-recreate":
+                    return {"ok": False, "error": final_plan.reason, "plan": final_plan.to_dict()}
+                apply_legacy_volume_reconciliation(engine, final_plan)
+                self.registry.reconcile_resource(
+                    kind="volume", name=name, stack=stack.name, generation=digest,
+                    scope=volume.scope, workspace=workspace,
+                )
+                self.registry.log_event("volume.legacy_reconciled", name)
+        except TransferError as exc:
+            return {"ok": False, "error": str(exc), "plan": plan.to_dict()}
+        return {"ok": True, "applied": True, "plan": final_plan.to_dict()}
 
     def _verb_done(self, request: dict[str, Any]) -> dict[str, Any]:
         from bosn.gc import mark_done

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -23,6 +23,7 @@ from bosn import labels, resources
 from bosn.accounting import StorageInventory, probe, resource_bytes
 from bosn.config import Config
 from bosn.engine import Engine
+from bosn.manifest import Manifest
 from bosn.registry import Registry
 from bosn.resources import ResourceScanner
 from bosn.retention import (
@@ -84,6 +85,59 @@ class GCResult:
         }
 
 
+def manifest_volume_collisions(
+    registry: Registry, engine: Engine, manifest: Manifest
+) -> list[dict[str, object]]:
+    """Report existing incomplete volumes selected by a manifest, never claim them.
+
+    Generic engine enumeration cannot establish that an unlabeled object blocks a stack.
+    This narrow supplement derives only names that the selected manifest itself declares,
+    using the same resolved generation and naming contract as convergence.  It is purely
+    diagnostic and is intentionally called only by ``gc``, not bounded ``status``.
+    """
+    from bosn.converge import resolved_generation, volume_name_for, workspace_of
+    from bosn.recovery import plan_manifest_volume_collision
+
+    scanner = ResourceScanner(engine)
+    workspace = workspace_of(manifest)
+    collisions: list[dict[str, object]] = []
+    for stack_name in sorted(manifest.stacks):
+        stack = manifest.stacks[stack_name]
+        digest, _ = resolved_generation(manifest, stack, engine)
+        for volume in stack.volumes:
+            name = volume_name_for(
+                stack,
+                volume.scope,
+                volume.name,
+                digest=digest,
+                workspace=workspace,
+                family=stack.family,
+            )
+            # Inspect existence separately from labels: an unlabeled existing volume and
+            # a nonexistent volume both render as ``{}`` through the label-only API.
+            if not engine.run(["volume", "inspect", name]).ok:
+                continue
+            raw_labels = scanner.inspect_labels("volume", name)
+            collision = plan_manifest_volume_collision(
+                name, raw_labels, registry.registry_id, engine
+            )
+            if collision is not None:
+                collisions.append(collision)
+    return collisions
+
+
+def _dedupe_unproven_resources(
+    generic: list[dict[str, object]], manifest_selected: list[dict[str, object]]
+) -> list[dict[str, object]]:
+    """Merge generic and manifest views; the latter has the more specific diagnosis."""
+    merged: dict[tuple[str, str], dict[str, object]] = {}
+    for resource in [*generic, *manifest_selected]:
+        kind = str(resource.get("kind") or "")
+        name = str(resource.get("name") or "")
+        merged[(kind, name)] = resource
+    return [merged[key] for key in sorted(merged)]
+
+
 class Collector:
     def __init__(
         self, registry: Registry, engine: Engine | None = None, *, config: Config | None = None
@@ -107,6 +161,7 @@ class Collector:
         *,
         dry_run: bool = True,
         pressure: Pressure | None = None,
+        manifest: Manifest | None = None,
     ) -> GCResult:
         from bosn.config import load as load_config
 
@@ -183,10 +238,18 @@ class Collector:
             self.registry, pressure=pressure, config=config, running_containers=running_containers
         )
         result = GCResult(dry_run=dry_run)
-        result.unproven_resources = [
+        generic_unproven = [
             plan_unproven_resource(resource, self.registry.registry_id, self.engine)
             for resource in scan.unlabeled
         ]
+        manifest_selected = (
+            manifest_volume_collisions(self.registry, self.engine, manifest)
+            if manifest is not None
+            else []
+        )
+        result.unproven_resources = _dedupe_unproven_resources(
+            generic_unproven, manifest_selected
+        )
         reclaimable = sum(
             measured.get(verdict.resource.id, 0) or 0 for verdict in collectable(verdicts)
         )

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -469,9 +469,7 @@ def status(
     from bosn.recovery import plan_unproven_resource
 
     unproven_resources = [
-        plan_unproven_resource(
-            resource, registry.registry_id, engine, include_attachment=False
-        )
+        plan_unproven_resource(resource, registry.registry_id, engine, include_attachment=False)
         for resource in scan.unlabeled
     ]
     inventory = StorageInventory.collect(engine)

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -64,6 +64,7 @@ class GCResult:
     removed: list[str] = field(default_factory=list)
     kept: list[str] = field(default_factory=list)
     skipped_unproven: list[str] = field(default_factory=list)
+    unproven_resources: list[dict[str, object]] = field(default_factory=list)
     image_dependency_deferred: list[str] = field(default_factory=list)
     image_decisions: list[dict[str, object]] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
@@ -76,6 +77,7 @@ class GCResult:
             "removed": len(self.removed),
             "kept": len(self.kept),
             "skipped_unproven": len(self.skipped_unproven),
+            "unproven_resources": len(self.unproven_resources),
             "image_dependency_deferred": len(self.image_dependency_deferred),
             "errors": len(self.errors),
             "advisories": len(self.advisories),
@@ -109,6 +111,12 @@ class Collector:
         from bosn.config import load as load_config
 
         config = self.config or load_config()
+        # Incomplete engine labels never become collection candidates.  They are scanned
+        # here solely to make a dry-run explain each protected object rather than hiding it
+        # behind an aggregate ``kept`` count (#120).
+        from bosn.recovery import plan_unproven_resource
+
+        scan = self.scanner.scan(self.registry.registry_id)
         inventory = StorageInventory.collect(self.engine)
         resource_rows = self.registry.list_resources()
         measured = {
@@ -175,6 +183,10 @@ class Collector:
             self.registry, pressure=pressure, config=config, running_containers=running_containers
         )
         result = GCResult(dry_run=dry_run)
+        result.unproven_resources = [
+            plan_unproven_resource(resource, self.registry.registry_id, self.engine)
+            for resource in scan.unlabeled
+        ]
         reclaimable = sum(
             measured.get(verdict.resource.id, 0) or 0 for verdict in collectable(verdicts)
         )
@@ -451,16 +463,15 @@ def status(
                 ),
             }
         )
-    # Incomplete labels are not ownership proof and therefore are never candidates for
-    # automatic collection.  They must nevertheless be named: a generic count leaves an
-    # operator unable to tell which resource is blocking convergence (#120).
+    # Status intentionally skips attachment probes for every unproven volume.  The scan
+    # is already bounded, while a probe per foreign/unlabeled object is not; `gc --dry-run
+    # --json` owns the full attachment-aware decision surface.
+    from bosn.recovery import plan_unproven_resource
+
     unproven_resources = [
-        {
-            "kind": resource.kind,
-            "name": resource.name,
-            "registry_id": resource.registry,
-            "reason": "incomplete ownership labels; protected from automatic recovery",
-        }
+        plan_unproven_resource(
+            resource, registry.registry_id, engine, include_attachment=False
+        )
         for resource in scan.unlabeled
     ]
     inventory = StorageInventory.collect(engine)

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -247,9 +247,7 @@ class Collector:
             if manifest is not None
             else []
         )
-        result.unproven_resources = _dedupe_unproven_resources(
-            generic_unproven, manifest_selected
-        )
+        result.unproven_resources = _dedupe_unproven_resources(generic_unproven, manifest_selected)
         reclaimable = sum(
             measured.get(verdict.resource.id, 0) or 0 for verdict in collectable(verdicts)
         )

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -34,7 +34,9 @@ class Options:
     source_registry: str | None = None
     transfer: tuple[str, ...] = ()
     legacy: str | None = None
+    volume: str | None = None
     yes: bool = False
+    reconcile_apply: bool = False
     args: tuple[str, ...] = ()
     json: bool = False
 
@@ -136,7 +138,9 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         source_registry=_as_str(get("source_registry")),
         transfer=get_list("transfer"),
         legacy=_as_str(get("legacy")),
+        volume=_as_str(get("volume")),
         yes=bool(get("yes", False)),
+        reconcile_apply=bool(get("reconcile_apply", False)),
         args=get_list("args"),
         json=bool(get("json", False)),
         compose=_as_str(get("compose")),

--- a/src/bosn/recovery.py
+++ b/src/bosn/recovery.py
@@ -104,9 +104,8 @@ def plan_unproven_resource(
         if include_attachment:
             attachment = volume_attachments(engine, resource.name)
             result["attachment"] = attachment.to_dict()
-        if (
-            raw.get(labels.REGISTRY) == registry_id
-            and any(key != labels.REGISTRY for key in namespaced)
+        if raw.get(labels.REGISTRY) == registry_id and any(
+            key != labels.REGISTRY for key in namespaced
         ):
             result["decision"] = {
                 "action": "protected",

--- a/src/bosn/recovery.py
+++ b/src/bosn/recovery.py
@@ -149,6 +149,36 @@ def plan_unproven_resource(
     return result
 
 
+def plan_manifest_volume_collision(
+    name: str, raw_labels: dict[str, str], registry_id: str, engine: Engine
+) -> dict[str, object] | None:
+    """Describe an existing manifest-derived volume without treating its name as proof.
+
+    The caller has already proved that this exact name exists in the engine.  A complete
+    label contract belongs to normal ownership/foreign-registry reporting; only incomplete
+    and unlabeled collisions appear here, and they remain protected in both GC modes.
+    """
+    if labels.is_complete(raw_labels):
+        return None
+    if raw_labels:
+        return plan_unproven_resource(
+            DiscoveredResource("volume", name, raw_labels), registry_id, engine
+        )
+    return {
+        "kind": "volume",
+        "name": name,
+        "registry_id": None,
+        "label_keys": [],
+        "decision": {
+            "action": "protected",
+            "eligible": False,
+            "reason": "manifest-derived name collision has no Bosn ownership labels",
+            "recovery": "refused",
+        },
+        "attachment": volume_attachments(engine, name).to_dict(),
+    }
+
+
 def plan_legacy_volume_reconciliation(
     *,
     name: str,

--- a/src/bosn/recovery.py
+++ b/src/bosn/recovery.py
@@ -1,0 +1,237 @@
+"""Fail-closed recovery plans for incomplete Bosn resources.
+
+An incomplete label set is deliberately not ownership proof.  The durable creation
+intent introduced in schema v3 is the only basis for automatic recovery.  This module
+models the narrower legacy escape hatch: an operator may explicitly reconcile one
+manifest-derived volume when the engine still carries corroborating Bosn labels.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from bosn import labels
+from bosn.engine import Engine
+from bosn.resources import DiscoveredResource, TransferError, recreate_volume_with_labels
+
+
+def _now_iso() -> str:
+    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class AttachmentReport:
+    state: str
+    containers: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {"state": self.state, "containers": list(self.containers)}
+
+
+def volume_attachments(engine: Engine, name: str) -> AttachmentReport:
+    """Return exact attached container ids, or ``unknown`` without guessing."""
+    result = engine.run(["ps", "--all", "--filter", f"volume={name}", "--quiet"])
+    if not result.ok:
+        return AttachmentReport("unknown")
+    containers = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+    return AttachmentReport("attached" if containers else "detached", containers)
+
+
+@dataclass(frozen=True)
+class VolumeRecoveryPlan:
+    """A serializable, non-mutating decision for one incomplete engine resource."""
+
+    name: str
+    raw_labels: dict[str, str]
+    action: str
+    reason: str
+    recovery: str
+    attachment: AttachmentReport | None = None
+    expected: labels.ResourceLabels | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        decision: dict[str, object] = {
+            "action": self.action,
+            "eligible": self.action == "would-recreate",
+            "reason": self.reason,
+            "recovery": self.recovery,
+        }
+        result: dict[str, object] = {
+            "kind": "volume",
+            "name": self.name,
+            "registry_id": self.raw_labels.get(labels.REGISTRY),
+            "label_keys": sorted(
+                key for key in self.raw_labels if key.startswith(labels.NAMESPACE)
+            ),
+            "decision": decision,
+        }
+        if self.attachment is not None:
+            result["attachment"] = self.attachment.to_dict()
+        return result
+
+
+def plan_unproven_resource(
+    resource: DiscoveredResource,
+    registry_id: str,
+    engine: Engine,
+    *,
+    include_attachment: bool = True,
+) -> dict[str, object]:
+    """Describe an incomplete resource for GC without granting ownership.
+
+    GC intentionally does not derive a manifest identity: it only reports that an
+    operator may inspect the exact resource through ``reconcile-volume``.  This keeps
+    collection non-mutating and avoids a broad name-based recovery surface.
+    """
+    raw = resource.raw_labels
+    namespaced = sorted(key for key in raw if key.startswith(labels.NAMESPACE))
+    reason = "incomplete ownership labels; protected from automatic recovery"
+    recovery = "refused"
+    result: dict[str, object] = {
+        "kind": resource.kind,
+        "name": resource.name,
+        "registry_id": raw.get(labels.REGISTRY),
+        "label_keys": namespaced,
+        "decision": {
+            "action": "protected",
+            "eligible": False,
+            "reason": reason,
+            "recovery": recovery,
+        },
+    }
+    if resource.kind == "volume":
+        if include_attachment:
+            attachment = volume_attachments(engine, resource.name)
+            result["attachment"] = attachment.to_dict()
+        if (
+            raw.get(labels.REGISTRY) == registry_id
+            and any(key != labels.REGISTRY for key in namespaced)
+        ):
+            result["decision"] = {
+                "action": "protected",
+                "eligible": False,
+                "reason": reason,
+                "recovery": "explicit-reconcile-available",
+            }
+    return result
+
+
+def plan_legacy_volume_reconciliation(
+    *,
+    name: str,
+    raw_labels: dict[str, str],
+    expected: labels.ResourceLabels,
+    registry_id: str,
+    engine: Engine,
+) -> VolumeRecoveryPlan:
+    """Plan one explicit legacy recovery, never inferring authority from a name alone."""
+    if labels.is_owned_by(raw_labels, registry_id):
+        if any(expected.to_dict().get(key) != value for key, value in raw_labels.items()):
+            return VolumeRecoveryPlan(
+                name,
+                raw_labels,
+                "refused",
+                "complete ownership labels belong to another manifest identity",
+                "refused",
+            )
+        return VolumeRecoveryPlan(
+            name,
+            raw_labels,
+            "already-owned",
+            "complete ownership labels already match this registry",
+            "none",
+        )
+
+    namespaced = {
+        key: value for key, value in raw_labels.items() if key.startswith(labels.NAMESPACE)
+    }
+    if not namespaced:
+        return VolumeRecoveryPlan(
+            name, raw_labels, "refused", "volume has no Bosn ownership labels", "refused"
+        )
+    if raw_labels.get(labels.REGISTRY) != registry_id:
+        return VolumeRecoveryPlan(
+            name,
+            raw_labels,
+            "refused",
+            "volume registry label is absent or belongs to another registry",
+            "refused",
+        )
+    if len(namespaced) < 2:
+        return VolumeRecoveryPlan(
+            name,
+            raw_labels,
+            "refused",
+            "volume has only a registry label; no independent Bosn identity survives",
+            "refused",
+        )
+
+    expected_values = expected.to_dict()
+    if any(expected_values.get(key) != value for key, value in namespaced.items()):
+        return VolumeRecoveryPlan(
+            name,
+            raw_labels,
+            "refused",
+            "surviving Bosn labels contradict the selected manifest identity",
+            "refused",
+        )
+
+    attachment = volume_attachments(engine, name)
+    if attachment.state == "unknown":
+        return VolumeRecoveryPlan(
+            name,
+            raw_labels,
+            "refused",
+            "could not prove whether the volume is attached",
+            "refused",
+            attachment,
+        )
+    if attachment.state == "attached":
+        return VolumeRecoveryPlan(
+            name,
+            raw_labels,
+            "refused",
+            "volume is attached to a live or stopped container",
+            "refused",
+            attachment,
+        )
+    return VolumeRecoveryPlan(
+        name,
+        raw_labels,
+        "would-recreate",
+        "explicit legacy reconciliation is safe for this detached exact candidate",
+        "explicit-reconcile-required",
+        attachment,
+        expected,
+    )
+
+
+def legacy_expected_labels(
+    *,
+    registry_id: str,
+    stack: str,
+    generation: str,
+    scope: str,
+    workspace: str,
+    raw_labels: dict[str, str],
+) -> labels.ResourceLabels:
+    """Preserve a surviving creation timestamp; otherwise mark this reconciliation now."""
+    return labels.ResourceLabels(
+        registry=registry_id,
+        kind="volume",
+        stack=stack,
+        generation=generation,
+        scope=scope,
+        workspace=workspace,
+        created=raw_labels.get(labels.CREATED) or _now_iso(),
+    )
+
+
+def apply_legacy_volume_reconciliation(engine: Engine, plan: VolumeRecoveryPlan) -> str:
+    """Apply a previously planned candidate after its caller has re-planned it."""
+    if plan.action != "would-recreate" or plan.expected is None:
+        raise TransferError(plan.reason)
+    return recreate_volume_with_labels(
+        engine, DiscoveredResource("volume", plan.name, plan.raw_labels), plan.expected
+    )

--- a/src/bosn/recovery.py
+++ b/src/bosn/recovery.py
@@ -16,6 +16,17 @@ from bosn.engine import Engine
 from bosn.resources import DiscoveredResource, TransferError, recreate_volume_with_labels
 
 
+# ``kind`` and ``created`` describe an object but do not bind it to the selected manifest
+# target.  Legacy reconciliation needs one surviving identity discriminator in addition to
+# the registry id; names are never evidence of ownership.
+_MANIFEST_DISCRIMINATORS = (
+    labels.STACK,
+    labels.GENERATION,
+    labels.SCOPE,
+    labels.WORKSPACE,
+)
+
+
 def _now_iso() -> str:
     return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -36,6 +47,29 @@ def volume_attachments(engine: Engine, name: str) -> AttachmentReport:
         return AttachmentReport("unknown")
     containers = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
     return AttachmentReport("attached" if containers else "detached", containers)
+
+
+def has_legacy_corroboration(
+    raw_labels: dict[str, str], registry_id: str, expected: labels.ResourceLabels | None = None
+) -> bool:
+    """Return whether surviving labels carry the minimum legacy recovery evidence.
+
+    With a manifest-derived expected contract this is the strict mutation predicate:
+    registry match, all surviving Bosn labels agree, and one surviving manifest-binding
+    discriminator agrees.  GC deliberately has no expected contract, so it can only
+    advertise that explicit inspection is available when a discriminator key survives.
+    """
+    if raw_labels.get(labels.REGISTRY) != registry_id:
+        return False
+    if expected is None:
+        return any(raw_labels.get(key) for key in _MANIFEST_DISCRIMINATORS)
+    expected_values = expected.to_dict()
+    surviving = {
+        key: value for key, value in raw_labels.items() if key.startswith(labels.NAMESPACE)
+    }
+    return bool(surviving) and all(
+        expected_values.get(key) == value for key, value in surviving.items()
+    ) and any(raw_labels.get(key) == expected_values[key] for key in _MANIFEST_DISCRIMINATORS)
 
 
 @dataclass(frozen=True)
@@ -104,14 +138,12 @@ def plan_unproven_resource(
         if include_attachment:
             attachment = volume_attachments(engine, resource.name)
             result["attachment"] = attachment.to_dict()
-        if raw.get(labels.REGISTRY) == registry_id and any(
-            key != labels.REGISTRY for key in namespaced
-        ):
+        if has_legacy_corroboration(raw, registry_id):
             result["decision"] = {
                 "action": "protected",
                 "eligible": False,
                 "reason": reason,
-                "recovery": "explicit-reconcile-available",
+                "recovery": "explicit-reconcile-inspection-available",
             }
     return result
 
@@ -126,7 +158,7 @@ def plan_legacy_volume_reconciliation(
 ) -> VolumeRecoveryPlan:
     """Plan one explicit legacy recovery, never inferring authority from a name alone."""
     if labels.is_owned_by(raw_labels, registry_id):
-        if any(expected.to_dict().get(key) != value for key, value in raw_labels.items()):
+        if not has_legacy_corroboration(raw_labels, registry_id, expected):
             return VolumeRecoveryPlan(
                 name,
                 raw_labels,
@@ -157,22 +189,12 @@ def plan_legacy_volume_reconciliation(
             "volume registry label is absent or belongs to another registry",
             "refused",
         )
-    if len(namespaced) < 2:
+    if not has_legacy_corroboration(raw_labels, registry_id, expected):
         return VolumeRecoveryPlan(
             name,
             raw_labels,
             "refused",
-            "volume has only a registry label; no independent Bosn identity survives",
-            "refused",
-        )
-
-    expected_values = expected.to_dict()
-    if any(expected_values.get(key) != value for key, value in namespaced.items()):
-        return VolumeRecoveryPlan(
-            name,
-            raw_labels,
-            "refused",
-            "surviving Bosn labels contradict the selected manifest identity",
+            "surviving Bosn labels lack a matching manifest-binding identity or contradict it",
             "refused",
         )
 

--- a/src/bosn/recovery.py
+++ b/src/bosn/recovery.py
@@ -15,7 +15,6 @@ from bosn import labels
 from bosn.engine import Engine
 from bosn.resources import DiscoveredResource, TransferError, recreate_volume_with_labels
 
-
 # ``kind`` and ``created`` describe an object but do not bind it to the selected manifest
 # target.  Legacy reconciliation needs one surviving identity discriminator in addition to
 # the registry id; names are never evidence of ownership.
@@ -67,9 +66,11 @@ def has_legacy_corroboration(
     surviving = {
         key: value for key, value in raw_labels.items() if key.startswith(labels.NAMESPACE)
     }
-    return bool(surviving) and all(
-        expected_values.get(key) == value for key, value in surviving.items()
-    ) and any(raw_labels.get(key) == expected_values[key] for key in _MANIFEST_DISCRIMINATORS)
+    return (
+        bool(surviving)
+        and all(expected_values.get(key) == value for key, value in surviving.items())
+        and any(raw_labels.get(key) == expected_values[key] for key in _MANIFEST_DISCRIMINATORS)
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -442,6 +442,26 @@ def test_gc_asks_the_daemon_for_more_than_the_shared_default_budget(tmp_path, mo
     assert cli.GC_REQUEST_TIMEOUT_SECONDS > ipc.DEFAULT_TIMEOUT
 
 
+def test_gc_passes_an_available_manifest_for_exact_collision_diagnostics(
+    tmp_path, monkeypatch
+) -> None:
+    from bosn import daemon
+
+    manifest = tmp_path / "bosn.toml"
+    manifest.write_text("[stack.perf]\nimage = 'alpine:3.20'\n", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    def capture(verb, *_args, **kwargs):
+        seen["verb"] = verb
+        seen.update(kwargs)
+        return {"ok": True, "result": {}, "errors": []}
+
+    monkeypatch.setattr(daemon, "request", capture)
+    assert cli.main(["--manifest", str(manifest), "gc", "--json"]) == 0
+    assert seen["verb"] == "gc"
+    assert seen["manifest"] == str(manifest)
+
+
 def test_gc_json_reports_images_deferred_by_container_dependencies(
     tmp_path, capsys, monkeypatch
 ) -> None:

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -91,6 +91,46 @@ def test_builtin_verb_name_is_reserved_from_task_dispatch(monkeypatch) -> None:
     assert seen == ["status"]
 
 
+def test_reconcile_volume_derives_a_manifest_target_before_requesting_daemon(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    from bosn import daemon
+
+    manifest = tmp_path / "bosn.toml"
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+    manifest.write_text(
+        "[stack.perf]\ndockerfile = 'Dockerfile'\n\n[stack.perf.volumes]\n"
+        "target = { scope = 'stack' }\n",
+        encoding="utf-8",
+    )
+    requests = []
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda verb, *_args, **kwargs: requests.append((verb, kwargs)) or {
+            "ok": True,
+            "applied": kwargs["apply"],
+            "plan": {"name": "derived", "decision": {"action": "would-recreate"}},
+        },
+    )
+
+    preview = [
+        "--manifest",
+        str(manifest),
+        "--json",
+        "reconcile-volume",
+        "--stack",
+        "perf",
+        "--volume",
+        "target",
+    ]
+    assert cli.main(preview) == 0
+    assert cli.main([*preview, "--apply", "--yes"]) == 0
+    assert [entry[1]["apply"] for entry in requests] == [False, True]
+    assert all(entry[1]["volume"] == "target" for entry in requests)
+    assert '"applied": true' in capsys.readouterr().out.lower()
+
+
 def test_status_surfaces_a_foreground_session_without_waiting_for_engine_scan(
     tmp_path, monkeypatch, capsys
 ) -> None:

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -107,11 +107,14 @@ def test_reconcile_volume_derives_a_manifest_target_before_requesting_daemon(
     monkeypatch.setattr(
         daemon,
         "request",
-        lambda verb, *_args, **kwargs: requests.append((verb, kwargs)) or {
-            "ok": True,
-            "applied": kwargs["apply"],
-            "plan": {"name": "derived", "decision": {"action": "would-recreate"}},
-        },
+        lambda verb, *_args, **kwargs: (
+            requests.append((verb, kwargs))
+            or {
+                "ok": True,
+                "applied": kwargs["apply"],
+                "plan": {"name": "derived", "decision": {"action": "would-recreate"}},
+            }
+        ),
     )
 
     preview = [

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -303,6 +303,26 @@ def test_interrupted_volume_recovery_refuses_an_unlabeled_collision(tmp_path: Pa
         assert registry.volume_creation_intent(name) is not None
 
 
+def test_no_intent_partial_volume_is_never_automatically_recovered(
+    project: Path, registry: Registry
+) -> None:
+    """#120: legacy recovery is an explicit CLI action, never an ensure side effect."""
+    engine = FakeEngine()
+    converger = Converger(load(project), registry, engine)  # type: ignore[arg-type]
+    stack = converger.manifest.stack("test")
+    workspace = workspace_of(converger.manifest)
+    name = volume_name_for(
+        stack, "spec", "target", digest="sha256:g", workspace=workspace, family=stack.family
+    )
+    partial = converger._resource_labels(stack, "volume", "sha256:g", "spec", workspace).to_dict()
+    del partial[labels.CREATED]
+    engine.existing.add(name)
+    engine.resource_labels[("volume", name)] = partial
+
+    with pytest.raises(EngineError, match="refusing to reuse"):
+        converger._ensure_volumes(stack, "sha256:g", workspace)
+
+
 def test_first_converge_registers_then_reuses(converger: Converger) -> None:
     """The same command is correct on the 1st and the 500th invocation."""
     first = converger.converge()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -122,6 +122,51 @@ def test_disconnected_non_streaming_response_does_not_escape_handler(
     assert any(row["kind"] == "ipc.response_disconnected" for row in served.registry.events())
 
 
+def test_reconcile_volume_version_mismatch_is_rejected_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even a preview must match: the same verb may later perform an apply."""
+
+    class NoRegistryMutation:
+        def log_event(self, *_args: object) -> None:
+            raise AssertionError("the version gate must not mutate the registry")
+
+    class NoDispatch:
+        secret = "test-secret"
+        registry = NoRegistryMutation()
+
+        def note_activity(self) -> None:
+            return None
+
+        def dispatch(self, *_args: object) -> dict[str, object]:
+            raise AssertionError("the version gate must reject before dispatch or engine use")
+
+    handler = object.__new__(daemon_mod._Handler)
+    handler.connection = object()
+    handler.server = SimpleNamespace(daemon_ref=NoDispatch())  # type: ignore[assignment]
+    responses: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        ipc,
+        "read_request",
+        lambda _conn: {
+            "auth": "test-secret",
+            "verb": "reconcile-volume",
+            "version": "a-client-version-that-does-not-match",
+            # Intentionally omit apply: preview is gated with the mutating verb too.
+        },
+    )
+    monkeypatch.setattr(ipc, "send_response", lambda _conn, reply: responses.append(reply))
+
+    handler.handle()
+
+    assert responses == [
+        {
+            "ok": False,
+            "error": "daemon version differs; restart the daemon before destructive use",
+        }
+    ]
+
+
 def test_default_state_dir_uses_the_fixed_default_port(monkeypatch) -> None:
     monkeypatch.delenv("BOSN_PORT", raising=False)
     from bosn.registry import default_state_dir

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -110,12 +110,14 @@ def test_disconnected_non_streaming_response_does_not_escape_handler(
     handler.server = SimpleNamespace(daemon_ref=served)
     monkeypatch.setattr(ipc, "read_request", lambda _conn: {"auth": served.secret, "verb": "gc"})
     monkeypatch.setattr(served, "dispatch", lambda *_args: {"ok": True, "unproven_resources": [{}]})
+    real_send_response = ipc.send_response
     monkeypatch.setattr(
         ipc, "send_response", lambda *_args: (_ for _ in ()).throw(OSError("reset"))
     )
 
     handler.handle()
 
+    monkeypatch.setattr(ipc, "send_response", real_send_response)
     assert daemon_mod.is_serving(served.state_dir)
     assert any(row["kind"] == "ipc.response_disconnected" for row in served.registry.events())
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -16,6 +16,7 @@ import threading
 import time
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -98,6 +99,25 @@ def test_port_is_deterministic_not_random(tmp_path: Path) -> None:
     other = tmp_path / "elsewhere"
     other.mkdir()
     assert daemon_mod.port_for(other) != daemon_mod.port_for(tmp_path)
+
+
+def test_disconnected_non_streaming_response_does_not_escape_handler(
+    served: Daemon, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A client timing out on a large GC response cannot take down the daemon (#120)."""
+    handler = object.__new__(daemon_mod._Handler)
+    handler.connection = object()
+    handler.server = SimpleNamespace(daemon_ref=served)
+    monkeypatch.setattr(ipc, "read_request", lambda _conn: {"auth": served.secret, "verb": "gc"})
+    monkeypatch.setattr(served, "dispatch", lambda *_args: {"ok": True, "unproven_resources": [{}]})
+    monkeypatch.setattr(
+        ipc, "send_response", lambda *_args: (_ for _ in ()).throw(OSError("reset"))
+    )
+
+    handler.handle()
+
+    assert daemon_mod.is_serving(served.state_dir)
+    assert any(row["kind"] == "ipc.response_disconnected" for row in served.registry.events())
 
 
 def test_default_state_dir_uses_the_fixed_default_port(monkeypatch) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -107,7 +107,7 @@ def test_disconnected_non_streaming_response_does_not_escape_handler(
     """A client timing out on a large GC response cannot take down the daemon (#120)."""
     handler = object.__new__(daemon_mod._Handler)
     handler.connection = object()
-    handler.server = SimpleNamespace(daemon_ref=served)
+    handler.server = SimpleNamespace(daemon_ref=served)  # type: ignore[assignment]
     monkeypatch.setattr(ipc, "read_request", lambda _conn: {"auth": served.secret, "verb": "gc"})
     monkeypatch.setattr(served, "dispatch", lambda *_args: {"ok": True, "unproven_resources": [{}]})
     real_send_response = ipc.send_response

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -118,7 +118,7 @@ def test_disconnected_non_streaming_response_does_not_escape_handler(
     handler.handle()
 
     monkeypatch.setattr(ipc, "send_response", real_send_response)
-    assert daemon_mod.is_serving(served.state_dir)
+    assert _wait_until(lambda: daemon_mod.is_serving(served.state_dir)), "daemon stopped serving"
     assert any(row["kind"] == "ipc.response_disconnected" for row in served.registry.events())
 
 

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -7,6 +7,7 @@ import os
 import threading
 from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -15,7 +16,7 @@ from bosn import labels
 from bosn.accounting import StorageInventory, StorageProbe
 from bosn.clock import FakeClock
 from bosn.config import load as load_config
-from bosn.engine import EngineResult
+from bosn.engine import Engine, EngineResult
 from bosn.gc import Collector, done_workspaces, mark_done, status
 from bosn.registry import Registry
 from bosn.retention import (
@@ -360,9 +361,7 @@ def test_manifest_gc_reports_exact_unlabeled_collision_but_omits_safe_or_missing
         {target: {}, owned: label_dict(registry=registry.registry_id)}, {target, owned}
     )
 
-    result = Collector(registry, engine).collect(
-        dry_run=True, manifest=manifest
-    )  # type: ignore[arg-type]
+    result = Collector(registry, cast(Engine, engine)).collect(dry_run=True, manifest=manifest)
 
     assert calls == ["perf"]
     assert result.unproven_resources == [
@@ -382,9 +381,7 @@ def test_manifest_gc_reports_exact_unlabeled_collision_but_omits_safe_or_missing
     ]
     assert owned not in {entry["name"] for entry in result.unproven_resources}
 
-    Collector(registry, engine).collect(
-        dry_run=False, manifest=manifest
-    )  # type: ignore[arg-type]
+    Collector(registry, cast(Engine, engine)).collect(dry_run=False, manifest=manifest)
     assert calls == ["perf", "perf"]
     assert target not in engine.removals()
 
@@ -397,9 +394,7 @@ def test_manifest_gc_deduplicates_a_partial_volume_seen_by_generic_scan(
     from bosn.manifest import Manifest, StackSpec, VolumeSpec
     from bosn.resources import DiscoveredResource, ScanResult
 
-    stack = StackSpec(
-        name="perf", image="alpine", volumes=(VolumeSpec("target", "stack"),)
-    )
+    stack = StackSpec(name="perf", image="alpine", volumes=(VolumeSpec("target", "stack"),))
     manifest = Manifest(root=tmp_path, stacks={"perf": stack})
     monkeypatch.setattr(
         converge_mod, "resolved_generation", lambda *_args: ("sha256:resolved", None)
@@ -422,9 +417,7 @@ def test_manifest_gc_deduplicates_a_partial_volume_seen_by_generic_scan(
     )
     engine = ManifestCollisionEngine({name: partial}, {name})
 
-    result = Collector(registry, engine).collect(
-        dry_run=True, manifest=manifest
-    )  # type: ignore[arg-type]
+    result = Collector(registry, cast(Engine, engine)).collect(dry_run=True, manifest=manifest)
 
     assert len(result.unproven_resources) == 1
     assert result.unproven_resources[0]["name"] == name

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -231,13 +231,17 @@ def test_status_names_unproven_resources_and_execution_sessions(
     ]
 
 
-def test_gc_dry_run_lists_each_unproven_resource_without_mutating(
-    registry: Registry, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("extra_key", "extra_value"),
+    [(labels.KIND, "volume"), (labels.CREATED, "2026-08-26T00:00:00Z")],
+)
+def test_gc_dry_run_does_not_offer_inspection_for_nonbinding_labels(
+    registry: Registry, monkeypatch: pytest.MonkeyPatch, extra_key: str, extra_value: str
 ) -> None:
     """#120: apply and preview both protect incomplete engine resources."""
     from bosn.resources import DiscoveredResource, ScanResult
 
-    partial = {labels.REGISTRY: registry.registry_id, labels.KIND: "volume"}
+    partial = {labels.REGISTRY: registry.registry_id, extra_key: extra_value}
     monkeypatch.setattr(
         gc_mod.ResourceScanner,
         "scan",
@@ -255,17 +259,43 @@ def test_gc_dry_run_lists_each_unproven_resource_without_mutating(
             "kind": "volume",
             "name": "partial",
             "registry_id": registry.registry_id,
-            "label_keys": [labels.KIND, labels.REGISTRY],
+            "label_keys": sorted([extra_key, labels.REGISTRY]),
             "decision": {
                 "action": "protected",
                 "eligible": False,
                 "reason": "incomplete ownership labels; protected from automatic recovery",
-                "recovery": "explicit-reconcile-available",
+                "recovery": "refused",
             },
             "attachment": {"state": "detached", "containers": []},
         }
     ]
     assert "partial" not in engine.removals()
+
+
+def test_gc_only_advertises_legacy_inspection_for_a_manifest_discriminator(
+    registry: Registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    partial = {labels.REGISTRY: registry.registry_id, labels.STACK: "perf"}
+    monkeypatch.setattr(
+        gc_mod.ResourceScanner,
+        "scan",
+        lambda *_args, **_kwargs: ScanResult(
+            unlabeled=[DiscoveredResource("volume", "partial", partial)],
+            scanned_kinds={"volume"},
+        ),
+    )
+    result = Collector(
+        registry, FakeEngine({"partial": partial})
+    ).collect(dry_run=True)  # type: ignore[arg-type]
+
+    assert result.unproven_resources[0]["decision"] == {
+        "action": "protected",
+        "eligible": False,
+        "reason": "incomplete ownership labels; protected from automatic recovery",
+        "recovery": "explicit-reconcile-inspection-available",
+    }
 
 
 def test_gc_never_issues_a_system_prune(registry: Registry, clock: FakeClock) -> None:

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -109,6 +109,22 @@ class FakeEngine:
         return [c[-1] for c in self.commands if "rm" in c]
 
 
+class ManifestCollisionEngine(FakeEngine):
+    """Makes volume existence distinct from label inspection for manifest diagnostics."""
+
+    def __init__(self, label_map: dict[str, dict[str, str]], existing: set[str]) -> None:
+        super().__init__(label_map)
+        self.existing = existing
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        if args[:2] == ["volume", "inspect"]:
+            self.commands.append(list(args))
+            if args[-1] not in self.existing:
+                return EngineResult(1, "", "no such volume")
+            return EngineResult(0, json.dumps(self.label_map.get(args[-1], {})), "")
+        return super().run(args, check=check)
+
+
 def label_dict(registry: str = OURS, kind: str = "volume", **overrides: str) -> dict[str, str]:
     base = labels.ResourceLabels(
         registry=registry,
@@ -295,6 +311,123 @@ def test_gc_only_advertises_legacy_inspection_for_a_manifest_discriminator(
         "reason": "incomplete ownership labels; protected from automatic recovery",
         "recovery": "explicit-reconcile-inspection-available",
     }
+
+
+def test_manifest_gc_reports_exact_unlabeled_collision_but_omits_safe_or_missing_volumes(
+    registry: Registry, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#120: a selected manifest names its collision without making that name ownership."""
+    from bosn import converge as converge_mod
+    from bosn.converge import volume_name_for, workspace_of
+    from bosn.manifest import Manifest, StackSpec, VolumeSpec
+
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    stack = StackSpec(
+        name="perf",
+        dockerfile="Dockerfile",
+        volumes=(
+            VolumeSpec("target", "spec"),
+            VolumeSpec("owned", "stack"),
+            VolumeSpec("missing", "stack"),
+        ),
+    )
+    manifest = Manifest(root=tmp_path, stacks={"perf": stack})
+    workspace = workspace_of(manifest)
+    calls: list[str] = []
+
+    def resolved(_manifest, selected, _engine):
+        calls.append(selected.name)
+        return "sha256:resolved", None
+
+    monkeypatch.setattr(converge_mod, "resolved_generation", resolved)
+    target = volume_name_for(
+        stack,
+        "spec",
+        "target",
+        digest="sha256:resolved",
+        workspace=workspace,
+        family=None,
+    )
+    owned = volume_name_for(
+        stack,
+        "stack",
+        "owned",
+        digest="sha256:resolved",
+        workspace=workspace,
+        family=None,
+    )
+    engine = ManifestCollisionEngine(
+        {target: {}, owned: label_dict(registry=registry.registry_id)}, {target, owned}
+    )
+
+    result = Collector(registry, engine).collect(
+        dry_run=True, manifest=manifest
+    )  # type: ignore[arg-type]
+
+    assert calls == ["perf"]
+    assert result.unproven_resources == [
+        {
+            "kind": "volume",
+            "name": target,
+            "registry_id": None,
+            "label_keys": [],
+            "decision": {
+                "action": "protected",
+                "eligible": False,
+                "reason": "manifest-derived name collision has no Bosn ownership labels",
+                "recovery": "refused",
+            },
+            "attachment": {"state": "detached", "containers": []},
+        }
+    ]
+    assert owned not in {entry["name"] for entry in result.unproven_resources}
+
+    Collector(registry, engine).collect(
+        dry_run=False, manifest=manifest
+    )  # type: ignore[arg-type]
+    assert calls == ["perf", "perf"]
+    assert target not in engine.removals()
+
+
+def test_manifest_gc_deduplicates_a_partial_volume_seen_by_generic_scan(
+    registry: Registry, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from bosn import converge as converge_mod
+    from bosn.converge import volume_name_for, workspace_of
+    from bosn.manifest import Manifest, StackSpec, VolumeSpec
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    stack = StackSpec(
+        name="perf", image="alpine", volumes=(VolumeSpec("target", "stack"),)
+    )
+    manifest = Manifest(root=tmp_path, stacks={"perf": stack})
+    monkeypatch.setattr(
+        converge_mod, "resolved_generation", lambda *_args: ("sha256:resolved", None)
+    )
+    name = volume_name_for(
+        stack,
+        "stack",
+        "target",
+        digest="sha256:resolved",
+        workspace=workspace_of(manifest),
+        family=None,
+    )
+    partial = {labels.REGISTRY: registry.registry_id, labels.STACK: "perf"}
+    monkeypatch.setattr(
+        gc_mod.ResourceScanner,
+        "scan",
+        lambda *_args, **_kwargs: ScanResult(
+            unlabeled=[DiscoveredResource("volume", name, partial)], scanned_kinds={"volume"}
+        ),
+    )
+    engine = ManifestCollisionEngine({name: partial}, {name})
+
+    result = Collector(registry, engine).collect(
+        dry_run=True, manifest=manifest
+    )  # type: ignore[arg-type]
+
+    assert len(result.unproven_resources) == 1
+    assert result.unproven_resources[0]["name"] == name
 
 
 def test_gc_never_issues_a_system_prune(registry: Registry, clock: FakeClock) -> None:

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -208,7 +208,13 @@ def test_status_names_unproven_resources_and_execution_sessions(
             "kind": "volume",
             "name": "partial",
             "registry_id": registry.registry_id,
-            "reason": "incomplete ownership labels; protected from automatic recovery",
+            "label_keys": [labels.REGISTRY],
+            "decision": {
+                "action": "protected",
+                "eligible": False,
+                "reason": "incomplete ownership labels; protected from automatic recovery",
+                "recovery": "refused",
+            },
         }
     ]
     assert report["execution_sessions"] == [
@@ -223,6 +229,43 @@ def test_status_names_unproven_resources_and_execution_sessions(
             "blocking_reason": "client is dead; awaiting safe exact-container reap",
         }
     ]
+
+
+def test_gc_dry_run_lists_each_unproven_resource_without_mutating(
+    registry: Registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#120: apply and preview both protect incomplete engine resources."""
+    from bosn.resources import DiscoveredResource, ScanResult
+
+    partial = {labels.REGISTRY: registry.registry_id, labels.KIND: "volume"}
+    monkeypatch.setattr(
+        gc_mod.ResourceScanner,
+        "scan",
+        lambda *_args, **_kwargs: ScanResult(
+            unlabeled=[DiscoveredResource("volume", "partial", partial)],
+            scanned_kinds={"volume"},
+        ),
+    )
+    engine = FakeEngine({"partial": partial})
+    result = Collector(registry, engine).collect(dry_run=True)  # type: ignore[arg-type]
+
+    assert result.removed == []
+    assert result.unproven_resources == [
+        {
+            "kind": "volume",
+            "name": "partial",
+            "registry_id": registry.registry_id,
+            "label_keys": [labels.KIND, labels.REGISTRY],
+            "decision": {
+                "action": "protected",
+                "eligible": False,
+                "reason": "incomplete ownership labels; protected from automatic recovery",
+                "recovery": "explicit-reconcile-available",
+            },
+            "attachment": {"state": "detached", "containers": []},
+        }
+    ]
+    assert "partial" not in engine.removals()
 
 
 def test_gc_never_issues_a_system_prune(registry: Registry, clock: FakeClock) -> None:

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -286,9 +286,8 @@ def test_gc_only_advertises_legacy_inspection_for_a_manifest_discriminator(
             scanned_kinds={"volume"},
         ),
     )
-    result = Collector(
-        registry, FakeEngine({"partial": partial})
-    ).collect(dry_run=True)  # type: ignore[arg-type]
+    collector = Collector(registry, FakeEngine({"partial": partial}))  # type: ignore[arg-type]
+    result = collector.collect(dry_run=True)
 
     assert result.unproven_resources[0]["decision"] == {
         "action": "protected",

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -152,3 +152,11 @@ def test_adopt_yes_defaults_to_false() -> None:
 
 def test_adopt_yes_flag_is_captured() -> None:
     assert opts(["adopt", "--legacy", "clud", "--yes"]).yes is True
+
+
+def test_reconcile_volume_accepts_only_a_logical_manifest_volume() -> None:
+    parsed = opts(["reconcile-volume", "--stack", "perf", "--volume", "target", "--apply", "--yes"])
+    assert parsed.stack == "perf"
+    assert parsed.volume == "target"
+    assert parsed.reconcile_apply is True
+    assert parsed.yes is True

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -105,6 +105,41 @@ def test_legacy_recovery_allows_no_registry_history_but_refuses_unlabeled_or_con
     assert conflicting.action == "refused"
 
 
+def test_legacy_recovery_requires_a_manifest_binding_discriminator() -> None:
+    registry_and_kind = {labels.REGISTRY: "ours", labels.KIND: "volume"}
+    kind_only = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=registry_and_kind,
+        expected=expected(registry_and_kind),
+        registry_id="ours",
+        engine=FakeEngine(registry_and_kind),  # type: ignore[arg-type]
+    )
+    assert kind_only.action == "refused"
+
+    registry_and_created = {
+        labels.REGISTRY: "ours",
+        labels.CREATED: "2026-08-26T00:00:00Z",
+    }
+    created_only = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=registry_and_created,
+        expected=expected(registry_and_created),
+        registry_id="ours",
+        engine=FakeEngine(registry_and_created),  # type: ignore[arg-type]
+    )
+    assert created_only.action == "refused"
+
+    registry_and_stack = {labels.REGISTRY: "ours", labels.STACK: "perf"}
+    stack_bound = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=registry_and_stack,
+        expected=expected(registry_and_stack),
+        registry_id="ours",
+        engine=FakeEngine(registry_and_stack),  # type: ignore[arg-type]
+    )
+    assert stack_bound.action == "would-recreate"
+
+
 def test_legacy_recovery_refuses_attached_or_unknown_volume() -> None:
     raw = partial()
     attached = plan_legacy_volume_reconciliation(

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,151 @@
+"""Regression coverage for #120's explicit legacy-volume recovery boundary."""
+
+from __future__ import annotations
+
+import json
+
+from bosn import labels
+from bosn.engine import EngineResult
+from bosn.recovery import (
+    apply_legacy_volume_reconciliation,
+    legacy_expected_labels,
+    plan_legacy_volume_reconciliation,
+)
+
+
+class FakeEngine:
+    def __init__(
+        self, raw: dict[str, str], *, attached: str = "", attachment_ok: bool = True
+    ) -> None:
+        self.raw = raw
+        self.attached = attached
+        self.attachment_ok = attachment_ok
+        self.commands: list[list[str]] = []
+
+    def run(
+        self, args: list[str], *, check: bool = False, timeout: float | None = None
+    ) -> EngineResult:
+        self.commands.append(list(args))
+        if args[:3] == ["ps", "--all", "--filter"]:
+            return EngineResult(0 if self.attachment_ok else 1, self.attached, "unavailable")
+        if args[:2] == ["volume", "inspect"]:
+            return EngineResult(0, json.dumps(self.raw), "")
+        if args[:2] == ["volume", "create"]:
+            self.raw = {
+                args[index + 1].split("=", 1)[0]: args[index + 1].split("=", 1)[1]
+                for index, item in enumerate(args[:-1])
+                if item == "--label"
+            }
+        return EngineResult(0, "", "")
+
+
+def expected(raw: dict[str, str]) -> labels.ResourceLabels:
+    return legacy_expected_labels(
+        registry_id="ours",
+        stack="perf",
+        generation="sha256:current",
+        scope="stack",
+        workspace="/workspace",
+        raw_labels=raw,
+    )
+
+
+def partial() -> dict[str, str]:
+    raw = expected({}).to_dict()
+    del raw[labels.CREATED]
+    return raw
+
+
+def test_explicit_legacy_preview_then_apply_recreates_matching_detached_volume() -> None:
+    raw = partial()
+    engine = FakeEngine(raw)
+    plan = plan_legacy_volume_reconciliation(
+        name="bosn-s-perf-target",
+        raw_labels=raw,
+        expected=expected(raw),
+        registry_id="ours",
+        engine=engine,  # type: ignore[arg-type]
+    )
+    assert plan.action == "would-recreate"
+    assert plan.to_dict()["attachment"] == {"state": "detached", "containers": []}
+
+    apply_legacy_volume_reconciliation(engine, plan)  # type: ignore[arg-type]
+    assert labels.is_owned_by(engine.raw, "ours")
+
+
+def test_legacy_recovery_allows_no_registry_history_but_refuses_unlabeled_or_conflicting() -> None:
+    raw = partial()
+    matching = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=raw,
+        expected=expected(raw),
+        registry_id="ours",
+        engine=FakeEngine(raw),  # type: ignore[arg-type]
+    )
+    assert matching.action == "would-recreate"
+
+    unlabeled = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels={},
+        expected=expected({}),
+        registry_id="ours",
+        engine=FakeEngine({}),  # type: ignore[arg-type]
+    )
+    assert unlabeled.action == "refused"
+
+    conflicting_raw = partial()
+    conflicting_raw[labels.STACK] = "other"
+    conflicting = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=conflicting_raw,
+        expected=expected(conflicting_raw),
+        registry_id="ours",
+        engine=FakeEngine(conflicting_raw),  # type: ignore[arg-type]
+    )
+    assert conflicting.action == "refused"
+
+
+def test_legacy_recovery_refuses_attached_or_unknown_volume() -> None:
+    raw = partial()
+    attached = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=raw,
+        expected=expected(raw),
+        registry_id="ours",
+        engine=FakeEngine(raw, attached="container-id\n"),  # type: ignore[arg-type]
+    )
+    assert attached.action == "refused"
+    assert attached.attachment is not None and attached.attachment.state == "attached"
+
+    unknown = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=raw,
+        expected=expected(raw),
+        registry_id="ours",
+        engine=FakeEngine(raw, attachment_ok=False),  # type: ignore[arg-type]
+    )
+    assert unknown.action == "refused"
+    assert unknown.attachment is not None and unknown.attachment.state == "unknown"
+
+
+def test_already_owned_legacy_candidate_is_idempotent() -> None:
+    raw = expected({}).to_dict()
+    plan = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=raw,
+        expected=expected(raw),
+        registry_id="ours",
+        engine=FakeEngine(raw),  # type: ignore[arg-type]
+    )
+    assert plan.action == "already-owned"
+
+    wrong_identity = dict(raw)
+    wrong_identity[labels.STACK] = "other"
+    refused = plan_legacy_volume_reconciliation(
+        name="target",
+        raw_labels=wrong_identity,
+        expected=expected(wrong_identity),
+        registry_id="ours",
+        engine=FakeEngine(wrong_identity),  # type: ignore[arg-type]
+    )
+    assert refused.action == "refused"

--- a/tests/test_recovery_docker.py
+++ b/tests/test_recovery_docker.py
@@ -1,0 +1,86 @@
+"""Real-engine safety boundary for the explicit #120 legacy volume recovery."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from bosn import labels
+from bosn.engine import Engine
+from bosn.recovery import (
+    apply_legacy_volume_reconciliation,
+    legacy_expected_labels,
+    plan_legacy_volume_reconciliation,
+)
+from bosn.resources import ResourceScanner
+
+pytestmark = pytest.mark.docker
+
+
+def test_exact_detached_partial_volume_is_recreated_but_attached_sibling_is_refused(
+    engine: Engine,
+) -> None:
+    registry = f"recovery-{uuid.uuid4()}"
+    name = f"bosn-recovery-{uuid.uuid4().hex[:12]}"
+    sibling = f"bosn-recovery-attached-{uuid.uuid4().hex[:12]}"
+    holder = f"recovery-holder-{uuid.uuid4().hex[:8]}"
+    expected = legacy_expected_labels(
+        registry_id=registry,
+        stack="proof",
+        generation="sha256:proof",
+        scope="stack",
+        workspace="/proof",
+        raw_labels={},
+    )
+    partial = expected.to_dict()
+    del partial[labels.CREATED]
+    partial_args = [
+        item for key, value in partial.items() for item in ("--label", f"{key}={value}")
+    ]
+    try:
+        engine.run(
+            ["volume", "create", *partial_args, name],
+            check=True,
+        )
+        engine.run(
+            [
+                "volume",
+                "create",
+                *partial_args,
+                sibling,
+            ],
+            check=True,
+        )
+
+        preview = plan_legacy_volume_reconciliation(
+            name=name,
+            raw_labels=ResourceScanner(engine).inspect_labels("volume", name),
+            expected=expected,
+            registry_id=registry,
+            engine=engine,
+        )
+        assert preview.action == "would-recreate"
+        assert ResourceScanner(engine).inspect_labels("volume", name) == partial
+        apply_legacy_volume_reconciliation(engine, preview)
+        assert labels.is_owned_by(ResourceScanner(engine).inspect_labels("volume", name), registry)
+
+        # An attachment is deliberately a refusal boundary; no sibling is mutated by recovery.
+        engine.run(
+            ["create", "--name", holder, "--volume", f"{sibling}:/data", "alpine:3.20", "true"],
+            check=True,
+        )
+        attached = plan_legacy_volume_reconciliation(
+            name=sibling,
+            raw_labels=ResourceScanner(engine).inspect_labels("volume", sibling),
+            expected=expected,
+            registry_id=registry,
+            engine=engine,
+        )
+        assert attached.action == "refused"
+        assert attached.attachment is not None and attached.attachment.state == "attached"
+        assert ResourceScanner(engine).inspect_labels("volume", sibling) == partial
+    finally:
+        engine.run(["container", "rm", "--force", holder])
+        for volume in (name, sibling):
+            engine.run(["volume", "rm", "--force", volume])

--- a/tests/test_recovery_docker.py
+++ b/tests/test_recovery_docker.py
@@ -7,7 +7,10 @@ import uuid
 import pytest
 
 from bosn import labels
+from bosn.converge import resolved_generation, volume_name_for, workspace_of
+from bosn.daemon import Daemon
 from bosn.engine import Engine
+from bosn.manifest import load
 from bosn.recovery import (
     apply_legacy_volume_reconciliation,
     legacy_expected_labels,
@@ -84,3 +87,74 @@ def test_exact_detached_partial_volume_is_recreated_but_attached_sibling_is_refu
         engine.run(["container", "rm", "--force", holder])
         for volume in (name, sibling):
             engine.run(["volume", "rm", "--force", volume])
+
+
+def test_daemon_reconcile_volume_replans_registers_and_audits_real_engine(
+    engine: Engine, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The daemon path, rather than the helper alone, owns the mutation boundary."""
+    manifest_path = tmp_path / "bosn.toml"
+    manifest_path.write_text(
+        "[stack.proof]\nimage = 'alpine:3.20'\n\n[stack.proof.volumes]\n"
+        "target = { scope = 'stack', destination = '/target' }\n",
+        encoding="utf-8",
+    )
+    daemon = Daemon(state_dir=tmp_path / "state")
+    manifest = load(manifest_path)
+    stack = manifest.stack("proof")
+    workspace = workspace_of(manifest)
+    digest, _ = resolved_generation(manifest, stack, engine)
+    name = volume_name_for(
+        stack, "stack", "target", digest=digest, workspace=workspace, family=stack.family
+    )
+    expected = legacy_expected_labels(
+        registry_id=daemon.registry.registry_id,
+        stack="proof",
+        generation=digest,
+        scope="stack",
+        workspace=workspace,
+        raw_labels={},
+    )
+    partial = expected.to_dict()
+    del partial[labels.CREATED]
+    partial_args = [
+        item for key, value in partial.items() for item in ("--label", f"{key}={value}")
+    ]
+    request = {
+        "manifest": str(manifest_path),
+        "stack": "proof",
+        "volume": "target",
+        "engine": "docker",
+    }
+    monkeypatch.setattr("bosn.engine.Engine", lambda _binary: engine)
+    holder = f"recovery-daemon-holder-{uuid.uuid4().hex[:8]}"
+    try:
+        engine.run(["volume", "create", *partial_args, name], check=True)
+        preview = daemon._verb_reconcile_volume(request)
+        assert preview["ok"] is True and preview["applied"] is False
+        assert preview["plan"]["decision"]["action"] == "would-recreate"
+        applied = daemon._verb_reconcile_volume({**request, "apply": True, "yes": True})
+        assert applied["ok"] is True and applied["applied"] is True
+        assert labels.is_owned_by(
+            ResourceScanner(engine).inspect_labels("volume", name), daemon.registry.registry_id
+        )
+        assert daemon.registry.get_resource_by_engine_identity("volume", name) is not None
+        assert any(
+            row["kind"] == "volume.legacy_reconciled" and row["detail"] == name
+            for row in daemon.registry.events()
+        )
+
+        engine.run(["volume", "rm", "--force", name], check=True)
+        engine.run(["volume", "create", *partial_args, name], check=True)
+        engine.run(
+            ["create", "--name", holder, "--volume", f"{name}:/data", "alpine:3.20", "true"],
+            check=True,
+        )
+        refused = daemon._verb_reconcile_volume({**request, "apply": True, "yes": True})
+        assert refused["ok"] is False
+        assert refused["plan"]["decision"]["action"] == "refused"
+        assert ResourceScanner(engine).inspect_labels("volume", name) == partial
+    finally:
+        engine.run(["container", "rm", "--force", holder])
+        engine.run(["volume", "rm", "--force", name])
+        daemon.registry.close()


### PR DESCRIPTION
## Summary

- add explicit manifest-derived `reconcile-volume` preview/apply for legacy partially labelled volumes
- preserve durable-intent-only automatic recovery and refuse fully unlabeled, foreign, contradictory, attached, or attachment-unknown candidates
- require registry identity plus a surviving manifest discriminator; `kind`, `created`, and deterministic names never grant authority
- report structured per-resource protected decisions through GC dry-run, including exact fully unlabeled manifest-name collisions, without allowing GC apply to repair/delete them
- recheck identity and attachment under the lifecycle guard before staged recreation, then reconcile registry state and emit an audit event
- version-gate the mutating reconciliation verb and contain disconnected clients while sending large daemon responses

Fixes #120

## Validation

- focused recovery/GC/CLI/options/converge: 193 passed, 1 skipped
- final targeted daemon/version/reconcile set: 8 passed
- full non-Docker suite after final changes: 1,067 passed, 2 skipped, 37 deselected
- lint: passed
- two real Docker recovery tests: passed
- daemon-level Docker path proves preview non-mutation, apply confirmation, final recheck, staged recreation, registry row, audit event, and attached sibling refusal/survival
- disconnected large-response regression proves the daemon remains serving and records `ipc.response_disconnected`
- one-agent pre-push review: clean

## Exact zccache evidence

Read-only source preview:

```json
{"ok":true,"applied":false,"plan":{"kind":"volume","name":"bosn-s-perf-8a5bed67b0-target","registry_id":null,"label_keys":[],"decision":{"action":"refused","eligible":false,"reason":"volume has no Bosn ownership labels","recovery":"refused"}}}
```

Read-only source GC dry-run (exit 0) reports the same exact target:

```json
{"kind":"volume","name":"bosn-s-perf-8a5bed67b0-target","registry_id":null,"label_keys":[],"decision":{"action":"protected","eligible":false,"reason":"manifest-derived name collision has no Bosn ownership labels","recovery":"refused"},"attachment":{"state":"detached","containers":[]}}
```

No apply, adoption, deletion, or ensure was performed. Final source status was offline with `execution_sessions: []`, matching the short-lived daemon lifecycle.

## Merge policy

Hosted CI is intentionally not the merge gate; this PR was validated locally plus real Docker/Bosn lifecycle tests and independent review.
