### PR TITLE
fix: preserve custom manifest sources across daemon handoff

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -1011,21 +1011,23 @@ def cmd_gc(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
     from bosn.config import load as load_config
-    from bosn.manifest import find_manifest
+    from bosn.manifest import ManifestError, find_manifest, load
 
     try:
         flags = _policy_flags(opts)
         load_config(flags=flags)
-        # GC stays global when no manifest is present.  When one is available, the daemon
-        # can additionally inspect the exact volume names it derives from this contract.
+        # GC stays global when no manifest is present. When one is available, load it
+        # before IPC so a relative or custom filename becomes the stable source path the
+        # daemon must inspect, while its manifest root remains the collision context.
         manifest_path = opts.manifest or find_manifest()
+        manifest = load(manifest_path) if manifest_path is not None else None
         reply = daemon_mod.request(
             "gc",
             opts.state_dir,
             engine=opts.engine,
             dry_run=opts.dry_run,
             policy_flags=flags,
-            manifest=str(manifest_path) if manifest_path is not None else None,
+            manifest=str(manifest.path) if manifest is not None else None,
             request_timeout=GC_REQUEST_TIMEOUT_SECONDS,
         )
     except ConfigError as exc:
@@ -1033,6 +1035,13 @@ def cmd_gc(opts: Options) -> int:
             code="policy.invalid",
             message=str(exc),
             next_step="correct the named policy value and retry",
+            as_json=opts.json,
+        )
+    except ManifestError as exc:
+        return _error(
+            code="manifest.invalid",
+            message=str(exc),
+            next_step="create or select a valid bosn.toml with --manifest",
             as_json=opts.json,
         )
     except ipc.TransportTimeout as exc:

--- a/src/bosn/manifest.py
+++ b/src/bosn/manifest.py
@@ -236,10 +236,16 @@ class Manifest:
     root: Path
     stacks: dict[str, StackSpec] = field(default_factory=dict)
     tasks: dict[str, TaskSpec] = field(default_factory=dict)
+    # `root` is deliberately the Docker context/workspace root.  The selected manifest
+    # need not be called bosn.toml, though, and daemon IPC must retain that exact source
+    # path rather than reconstructing a default-named sibling from the context root.
+    # Keeping this after the existing positional fields preserves Manifest(root, stacks,
+    # tasks) callers.
+    source_path: Path | None = None
 
     @property
     def path(self) -> Path:
-        return self.root / MANIFEST_NAME
+        return self.source_path or self.root / MANIFEST_NAME
 
     def default_stack(self) -> StackSpec:
         explicit = [s for s in self.stacks.values() if s.default]
@@ -295,13 +301,18 @@ def load(path: Path | str) -> Manifest:
     path = to_host_path(path)
     if path.is_dir():
         path = path / MANIFEST_NAME
+    # IPC crosses a daemon whose cwd is not the client's cwd.  Canonicalizing the
+    # selected source here makes a relative --manifest stable on both sides while keeping
+    # `root` (and therefore Docker context, digest inputs, and workspace identity) at the
+    # manifest's parent directory.
+    path = path.resolve()
     if not path.is_file():
         raise ManifestError(f"no manifest at {path}")
     try:
         raw = tomllib.loads(path.read_text(encoding="utf-8"))
     except tomllib.TOMLDecodeError as exc:
         raise ManifestError(f"{path} is not valid TOML: {exc}") from exc
-    return parse(raw, root=path.parent)
+    return parse(raw, root=path.parent, source_path=path)
 
 
 def _refuse_duplicate_destinations(
@@ -339,8 +350,8 @@ def _refuse_duplicate_destinations(
         raise ManifestError(f"[stack.{stack}] mounts {duplicated} more than once")
 
 
-def parse(raw: dict, root: Path) -> Manifest:
-    manifest = Manifest(root=root)
+def parse(raw: dict, root: Path, *, source_path: Path | None = None) -> Manifest:
+    manifest = Manifest(root=root, source_path=source_path)
 
     for name, body in (raw.get("stack") or {}).items():
         if not isinstance(body, dict):

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -371,6 +371,168 @@ def test_tasks_json_reports_unregistered_readiness(tmp_path, capsys) -> None:
     assert payload["tasks"]["unit"]["readiness"]["jobs"]["state"] == "unavailable"
 
 
+def test_tasks_reports_the_selected_custom_manifest_path(tmp_path, capsys) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    custom = tmp_path / "development.toml"
+    custom.write_text("[stack.dev]\ndockerfile = 'Dockerfile'\n", encoding="utf-8")
+    # A decoy makes this fail before #126: the loaded custom manifest was displayed as
+    # `<root>/bosn.toml`, despite that file neither selecting nor describing this stack.
+    (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
+
+    assert cli.main(["--manifest", str(custom), "tasks", "--json"]) == 0
+
+    assert json.loads(capsys.readouterr().out)["manifest"] == str(custom.resolve())
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        lambda custom: ["--manifest", str(custom), "ensure"],
+        lambda custom: ["ensure", "--manifest", str(custom)],
+    ],
+    ids=["global-manifest", "verb-local-manifest"],
+)
+def test_ensure_forwards_custom_manifest_source_for_global_and_local_flags(
+    tmp_path, monkeypatch, args
+) -> None:
+    from bosn.converge import ConvergeResult
+
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    custom = tmp_path / "development.toml"
+    custom.write_text("[stack.dev]\ndockerfile = 'Dockerfile'\n", encoding="utf-8")
+    (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    def converge(_opts, manifest, _stack):
+        seen["manifest"] = manifest.path
+        return ConvergeResult("dev", "sha256:custom", "reused", "image")
+
+    monkeypatch.setattr(cli, "_converge_via_daemon", converge)
+    assert cli.main(args(custom)) == 0
+    assert seen["manifest"] == custom.resolve()
+
+
+@pytest.mark.parametrize("verb", ["run", "shell"])
+def test_foreground_verbs_forward_the_selected_custom_source_to_execution_acquire(
+    verb, tmp_path, monkeypatch
+) -> None:
+    from bosn import daemon, resources
+    from bosn.converge import ConvergeResult
+
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    custom = tmp_path / "development.toml"
+    custom.write_text(
+        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8"
+    )
+    (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
+    monkeypatch.setattr(
+        cli,
+        "_converge_via_daemon",
+        lambda *_args: ConvergeResult("dev", "sha256:custom", "reused", "image"),
+    )
+    monkeypatch.setattr(resources, "process_start_time", lambda _pid: 1.0)
+    seen: dict[str, object] = {}
+
+    def request(requested_verb, *_args, **kwargs):
+        if requested_verb == "execution-acquire":
+            seen["manifest"] = kwargs["manifest"]
+            return {"ok": True, "container": "container", "session": "session"}
+        assert requested_verb == "execution-release"
+        return {"ok": True}
+
+    class Engine:
+        def __init__(self, _binary="docker") -> None:
+            pass
+
+        def execute(self, _args) -> int:
+            return 0
+
+        def interactive(self, _args) -> int:
+            return 0
+
+    monkeypatch.setattr(daemon, "request", request)
+    monkeypatch.setattr(cli, "Engine", Engine)
+    command = ["--manifest", str(custom), verb]
+    if verb == "run":
+        command.extend(["--", "true"])
+    assert cli.main(command) == 0
+    assert seen["manifest"] == str(custom.resolve())
+
+
+def test_one_word_task_forwards_the_selected_custom_manifest_to_converge(
+    tmp_path, monkeypatch
+) -> None:
+    from bosn import daemon, resources
+    from bosn.converge import ConvergeResult
+
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    custom = tmp_path / "development.toml"
+    custom.write_text(
+        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n"
+        "[task.unit]\ncmd = 'true'\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    def converge(_opts, manifest, _stack):
+        seen["converge"] = manifest.path
+        return ConvergeResult("dev", "sha256:custom", "reused", "image")
+
+    def request(verb, *_args, **_kwargs):
+        if verb == "execution-acquire":
+            return {"ok": True, "container": "container", "session": "session"}
+        return {"ok": True}
+
+    class Engine:
+        def __init__(self, _binary="docker") -> None:
+            pass
+
+        def execute(self, _args) -> int:
+            return 0
+
+    monkeypatch.setattr(cli, "_converge_via_daemon", converge)
+    monkeypatch.setattr(resources, "process_start_time", lambda _pid: 1.0)
+    monkeypatch.setattr(daemon, "request", request)
+    monkeypatch.setattr(cli, "Engine", Engine)
+    assert cli.main(["--manifest", str(custom), "unit"]) == 0
+    assert seen["converge"] == custom.resolve()
+
+
+def test_reconcile_volume_forwards_selected_custom_manifest_source(tmp_path, monkeypatch) -> None:
+    from bosn import daemon
+
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    custom = tmp_path / "development.toml"
+    custom.write_text(
+        "[stack.dev]\ndockerfile = 'Dockerfile'\n[stack.dev.volumes]\ntarget = { scope = 'spec' }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    def request(_verb, *_args, **kwargs):
+        seen["manifest"] = kwargs["manifest"]
+        return {"ok": True, "plan": {}}
+
+    monkeypatch.setattr(daemon, "request", request)
+    assert (
+        cli.main(
+            [
+                "reconcile-volume",
+                "--manifest",
+                str(custom),
+                "--stack",
+                "dev",
+                "--volume",
+                "target",
+            ]
+        )
+        == 0
+    )
+    assert seen["manifest"] == str(custom.resolve())
+
+
 def test_tasks_json_manifest_error_has_stable_remedy(tmp_path, monkeypatch, capsys) -> None:
     monkeypatch.chdir(tmp_path)
     assert cli.main(["--state-dir", str(tmp_path), "tasks", "--json"]) == 1

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -595,12 +595,14 @@ def test_gc_asks_the_daemon_for_more_than_the_shared_default_budget(tmp_path, mo
     def capture(verb, *_args, **kwargs):
         seen["verb"] = verb
         seen["request_timeout"] = kwargs.get("request_timeout")
+        seen["manifest"] = kwargs.get("manifest")
         return {"ok": True, "result": {"collected": [], "kept": []}}
 
     monkeypatch.setattr(daemon, "request", capture)
     cli.main(["--state-dir", str(tmp_path), "gc", "--dry-run", "--json"])
     assert seen["verb"] == "gc"
     assert seen["request_timeout"] == cli.GC_REQUEST_TIMEOUT_SECONDS
+    assert seen["manifest"] is None
     assert cli.GC_REQUEST_TIMEOUT_SECONDS > ipc.DEFAULT_TIMEOUT
 
 
@@ -621,7 +623,30 @@ def test_gc_passes_an_available_manifest_for_exact_collision_diagnostics(
     monkeypatch.setattr(daemon, "request", capture)
     assert cli.main(["--manifest", str(manifest), "gc", "--json"]) == 0
     assert seen["verb"] == "gc"
-    assert seen["manifest"] == str(manifest)
+    assert seen["manifest"] == str(manifest.resolve())
+
+
+def test_gc_canonicalizes_a_relative_custom_manifest_before_daemon_ipc(
+    tmp_path, monkeypatch
+) -> None:
+    from bosn import daemon
+
+    custom = tmp_path / "development.toml"
+    custom.write_text("[stack.perf]\nimage = 'alpine:3.20'\n", encoding="utf-8")
+    # The source path, not this default-named sibling, is the daemon's exact collision
+    # discriminator. Running from the client cwd makes the old relative-path handoff
+    # observably unsafe for a daemon with another cwd.
+    (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    def capture(_verb, *_args, **kwargs):
+        seen["manifest"] = kwargs["manifest"]
+        return {"ok": True, "result": {}, "errors": []}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(daemon, "request", capture)
+    assert cli.main(["--manifest", "development.toml", "gc", "--json"]) == 0
+    assert seen["manifest"] == str(custom.resolve())
 
 
 def test_gc_json_reports_images_deferred_by_container_dependencies(

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -599,6 +599,9 @@ def test_gc_asks_the_daemon_for_more_than_the_shared_default_budget(tmp_path, mo
         return {"ok": True, "result": {"collected": [], "kept": []}}
 
     monkeypatch.setattr(daemon, "request", capture)
+    # The repository checkout has its own bosn.toml. This case is specifically global GC
+    # with no discoverable manifest, so its client cwd must be the empty temporary root.
+    monkeypatch.chdir(tmp_path)
     cli.main(["--state-dir", str(tmp_path), "gc", "--dry-run", "--json"])
     assert seen["verb"] == "gc"
     assert seen["request_timeout"] == cli.GC_REQUEST_TIMEOUT_SECONDS

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -421,9 +421,7 @@ def test_foreground_verbs_forward_the_selected_custom_source_to_execution_acquir
 
     (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     custom = tmp_path / "development.toml"
-    custom.write_text(
-        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8"
-    )
+    custom.write_text("[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8")
     (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
     monkeypatch.setattr(
         cli,
@@ -444,7 +442,7 @@ def test_foreground_verbs_forward_the_selected_custom_source_to_execution_acquir
         def __init__(self, _binary="docker") -> None:
             pass
 
-        def execute(self, _args) -> int:
+        def execute(self, _args, **_kwargs) -> int:
             return 0
 
         def interactive(self, _args) -> int:
@@ -468,8 +466,7 @@ def test_one_word_task_forwards_the_selected_custom_manifest_to_converge(
     (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     custom = tmp_path / "development.toml"
     custom.write_text(
-        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n"
-        "[task.unit]\ncmd = 'true'\n",
+        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n[task.unit]\ncmd = 'true'\n",
         encoding="utf-8",
     )
     (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")
@@ -488,7 +485,7 @@ def test_one_word_task_forwards_the_selected_custom_manifest_to_converge(
         def __init__(self, _binary="docker") -> None:
             pass
 
-        def execute(self, _args) -> int:
+        def execute(self, _args, **_kwargs) -> int:
             return 0
 
     monkeypatch.setattr(cli, "_converge_via_daemon", converge)
@@ -505,7 +502,10 @@ def test_reconcile_volume_forwards_selected_custom_manifest_source(tmp_path, mon
     (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     custom = tmp_path / "development.toml"
     custom.write_text(
-        "[stack.dev]\ndockerfile = 'Dockerfile'\n[stack.dev.volumes]\ntarget = { scope = 'spec' }\n",
+        (
+            "[stack.dev]\ndockerfile = 'Dockerfile'\n[stack.dev.volumes]\n"
+            "target = { scope = 'spec' }\n"
+        ),
         encoding="utf-8",
     )
     (tmp_path / "bosn.toml").write_text("[stack.decoy]\nimage = 'busybox'\n", encoding="utf-8")

--- a/tests/test_daemon_jobs.py
+++ b/tests/test_daemon_jobs.py
@@ -180,6 +180,36 @@ def test_converge_streams_build_output_and_a_terminal_event(
     assert events[-1]["state"] == "succeeded"
 
 
+def test_custom_manifest_source_survives_daemon_queue_to_worker_payload(
+    served: Daemon, project: Path, builder: ControlledBuilder
+) -> None:
+    """A custom source filename is not rewritten to a decoy `bosn.toml` (#126)."""
+    custom = project / "development.toml"
+    custom.write_text(
+        "[stack.chosen]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8"
+    )
+    # Before #126, `_verb_converge` loaded `development.toml` correctly, then stored
+    # `<root>/bosn.toml` in the queued job. The worker would consequently build this
+    # different declaration later.
+    (project / "bosn.toml").write_text(
+        "[stack.decoy]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8"
+    )
+    stream = ipc.stream_request(
+        served.port,
+        {"verb": "converge", "manifest": str(custom), "auth": served.secret},
+        timeout=30,
+    )
+    submitted = next(stream)
+    job = served.jobs.get(submitted["job"])
+
+    assert job.stack == "chosen"
+    assert job.payload["manifest"] == str(custom.resolve())
+    # `_build` consumes this durable job payload, so pinning it is the client -> daemon
+    # queue -> worker source-path contract without needing a Docker build.
+    builder.release.set()
+    assert [event for event in stream if event.get("final")][-1]["state"] == "succeeded"
+
+
 def test_a_second_identical_converge_joins_rather_than_rebuilding(
     served: Daemon, project: Path, builder: ControlledBuilder
 ) -> None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -72,9 +72,7 @@ def test_load_retains_selected_custom_source_without_changing_context_root(tmp_p
     context.mkdir(parents=True)
     (context / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     custom = context / "development.toml"
-    custom.write_text(
-        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8"
-    )
+    custom.write_text("[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8")
 
     manifest = load(custom)
 
@@ -91,7 +89,9 @@ def test_load_default_and_directory_inputs_keep_default_source_path(project: Pat
     assert load(project / "bosn.toml").path == selected
 
 
-def test_load_relative_custom_source_is_canonical_for_daemon_ipc(tmp_path: Path, monkeypatch) -> None:
+def test_load_relative_custom_source_is_canonical_for_daemon_ipc(
+    tmp_path: Path, monkeypatch
+) -> None:
     (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
     custom = tmp_path / "custom.toml"
     custom.write_text("[stack.dev]\ndockerfile = 'Dockerfile'\n", encoding="utf-8")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -67,6 +67,42 @@ def test_find_manifest_returns_none_when_absent(tmp_path: Path) -> None:
     assert manifest_mod.find_manifest(tmp_path) is None
 
 
+def test_load_retains_selected_custom_source_without_changing_context_root(tmp_path: Path) -> None:
+    context = tmp_path / "configs" / "dev"
+    context.mkdir(parents=True)
+    (context / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    custom = context / "development.toml"
+    custom.write_text(
+        "[stack.dev]\ndockerfile = 'Dockerfile'\ndefault = true\n", encoding="utf-8"
+    )
+
+    manifest = load(custom)
+
+    assert manifest.path == custom.resolve()
+    assert manifest.root == context.resolve()
+    # Dockerfile resolution/digests remain relative to the manifest parent, not its name.
+    assert manifest.digest("dev").startswith("sha256:")
+
+
+def test_load_default_and_directory_inputs_keep_default_source_path(project: Path) -> None:
+    selected = (project / "bosn.toml").resolve()
+
+    assert load(project).path == selected
+    assert load(project / "bosn.toml").path == selected
+
+
+def test_load_relative_custom_source_is_canonical_for_daemon_ipc(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    custom = tmp_path / "custom.toml"
+    custom.write_text("[stack.dev]\ndockerfile = 'Dockerfile'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    manifest = load("custom.toml")
+
+    assert manifest.path == custom.resolve()
+    assert manifest.root == tmp_path.resolve()
+
+
 def test_unknown_stack_and_task_names_are_specific_errors(project: Path) -> None:
     manifest = load(project)
     with pytest.raises(ManifestError, match="no stack named 'nope'"):


### PR DESCRIPTION
Closes #126.

## What changed

- preserve the exact canonical manifest source path independently from the workspace/build-context root
- keep existing `Manifest(root, stacks, tasks)` and `parse(raw, root)` callers compatible
- carry custom source identity through ensure, run, shell, task, reconcile-volume, queued daemon builds, tasks reporting, and GC
- resolve selected GC manifests client-side while retaining manifest-less global GC
- cover relative custom paths beside contradictory default `bosn.toml` files

## Validation

- focused host suite: 136 passed, 1 skipped
- Ruff check and format check: passed
- Pyright: 0 errors/warnings
- source Bosn custom-manifest dogfood: global and verb-local ensure, tasks path, foreground task marker, and relative-path GC passed
- source Bosn lint task: Ruff, Pyright, and KBI passed
- source Bosn non-Docker test task: 1072 passed, 9 skipped, 37 deselected
- final source daemon status: no execution sessions; jobs empty; daemon stopped
- clud-review: clean (one reviewer)

GC apply was deliberately not run because discovery included foreign/unproven resources; no unrelated resource authority was assumed.
