### PR TITLE
fix: preserve child-owned double-dash separators

### DIFF
--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -67,8 +67,16 @@ class Options:
 
     @property
     def command(self) -> list[str]:
-        """The ad-hoc command, with any argparse `--` separator stripped."""
-        return [arg for arg in self.args if arg != "--"]
+        """The ad-hoc command, without only argparse's leading separator.
+
+        A command can legitimately contain its own ``--`` argument.  In particular,
+        ``sh -c SCRIPT -- lint`` uses it to make ``lint`` the script's ``$1``.  Removing
+        every occurrence silently changes that argv and is not argparse's job.
+        """
+        args = list(self.args)
+        if args[:1] == ["--"]:
+            return args[1:]
+        return args
 
     def with_command(self, command: list[str]) -> Options:
         from dataclasses import replace

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -62,9 +62,19 @@ def test_command_strips_the_argparse_separator() -> None:
     assert "--" not in parsed.command
 
 
+def test_command_without_a_parser_separator_is_unchanged() -> None:
+    parsed = opts(["run", "echo", "before", "--", "after"])
+    assert parsed.command == ["echo", "before", "--", "after"]
+
+
 def test_command_preserves_a_separator_that_belongs_to_the_child_argv() -> None:
     parsed = opts(["run", "--", "sh", "-c", "printf '%s\\n' \"$1\"", "--", "lint"])
     assert parsed.command == ["sh", "-c", "printf '%s\\n' \"$1\"", "--", "lint"]
+
+
+def test_command_preserves_every_later_child_separator_in_order() -> None:
+    parsed = opts(["run", "--", "child", "--", "first", "--", "second"])
+    assert parsed.command == ["child", "--", "first", "--", "second"]
 
 
 def test_options_are_frozen() -> None:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -62,6 +62,11 @@ def test_command_strips_the_argparse_separator() -> None:
     assert "--" not in parsed.command
 
 
+def test_command_preserves_a_separator_that_belongs_to_the_child_argv() -> None:
+    parsed = opts(["run", "--", "sh", "-c", "printf '%s\\n' \"$1\"", "--", "lint"])
+    assert parsed.command == ["sh", "-c", "printf '%s\\n' \"$1\"", "--", "lint"]
+
+
 def test_options_are_frozen() -> None:
     parsed = opts(["run"])
     with pytest.raises(dataclasses.FrozenInstanceError):


### PR DESCRIPTION
Closes #127.

## What changed

- strip only argparse's leading `--` separator from ad-hoc run commands
- preserve every later child-owned `--` token exactly and in order
- pin nested, no-leading, and repeated-separator behavior with focused regressions

## Validation

- focused options/CLI/daemon suite: 113 passed, 1 skipped
- Ruff check and format check: passed
- Pyright: 0 errors/warnings
- source Bosn dogfood: `sh -c SCRIPT -- lint` observed exact `lint` as `$1`
- source Bosn ordinary leading-separator path: passed
- final daemon status: offline, no execution sessions or active jobs
- immediately preceding merged mainline Linux suite: 1072 passed, 9 skipped, 37 deselected
- clud-review: clean (one reviewer)

An additional full host-suite attempt was stopped by the execution watchdog before completion; no result is claimed from that attempt. Isolated validation resources were preserved because GC dry-run exceeded its watchdog, and no unsafe apply was attempted.
