### PR TITLE
Harden daemon lifecycle diagnostics and version recovery

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -74,6 +74,9 @@ EXECUTION_ACQUIRE_TIMEOUT = 120.0
 # has lost a stream, wait only long enough to distinguish that failure, then read the durable
 # registry proof rather than starting the slow Docker scan that made #119 look like a hang.
 STATUS_DAEMON_TIMEOUT_SECONDS = 2.0
+# `jobs` is also a read-only control-plane diagnostic. It must not start a fresh daemon
+# (which cannot know about an old daemon's jobs) or inherit the generic 10-second wait.
+JOBS_DAEMON_TIMEOUT_SECONDS = 2.0
 
 
 def _policy_flags(opts: Options) -> dict[str, float | None]:
@@ -500,7 +503,13 @@ def cmd_jobs(opts: Options) -> int:
     from bosn import daemon as daemon_mod
 
     try:
-        reply = daemon_mod.request("jobs", opts.state_dir)
+        reply = daemon_mod.request(
+            "jobs",
+            opts.state_dir,
+            autostart=False,
+            request_timeout=JOBS_DAEMON_TIMEOUT_SECONDS,
+            diagnostic=True,
+        )
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:  # fail closed, stay visible
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
         return 1

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import math
 import os
+import re
 import secrets
 import socket
 import socketserver
@@ -43,6 +44,21 @@ DEFAULT_PORT = 47764
 # Deterministic per-state-dir ports live in the IANA dynamic range, above the default.
 PORT_RANGE_START = 47765
 PORT_RANGE_SIZE = 1024
+MUTATING_VERBS = frozenset(
+    {
+        "converge",
+        "cancel",
+        "gc",
+        "done",
+        "adopt",
+        "compose-adopt",
+        "reconcile-volume",
+        "execution-acquire",
+        "execution-release",
+        "compose-acquire",
+        "compose-release",
+    }
+)
 
 DEFAULT_IDLE_RETIRE_SECONDS = 900.0
 DEFAULT_MAINTENANCE_INTERVAL_SECONDS = 300.0
@@ -257,30 +273,24 @@ class _Handler(socketserver.StreamRequestHandler):
                 self.connection, {"ok": False, "error": "unauthenticated IPC request"}
             )
             return
-        mutating_verbs = {
-            "converge",
-            "cancel",
-            "gc",
-            "done",
-            "adopt",
-            "compose-adopt",
-            "reconcile-volume",
-            "execution-acquire",
-            "execution-release",
-            "compose-acquire",
-            "compose-release",
-        }
         if (
             verb != "shutdown"
-            and verb in mutating_verbs
+            and verb in MUTATING_VERBS
             and "version" in request
             and str(request.get("version") or "") != __version__
         ):
+            client_version = str(request.get("version") or "unknown")
             ipc.send_response(
                 self.connection,
                 {
                     "ok": False,
-                    "error": "daemon version differs; restart the daemon before destructive use",
+                    "error": (
+                        "bosn client/daemon version mismatch: "
+                        f"client={client_version} daemon={__version__}; "
+                        "restart the daemon before destructive use"
+                    ),
+                    "client_version": client_version,
+                    "daemon_version": __version__,
                 },
             )
             return
@@ -1639,9 +1649,20 @@ class Daemon:
 
     def _verb_shutdown(self, _request: dict[str, Any]) -> dict[str, Any]:
         if not self.request_stop():
+            from bosn.resources import process_alive
+
+            blockers = []
+            with self._execution_lock:
+                for session, owner in self._execution_owners.items():
+                    state = (
+                        "live" if process_alive(*owner) else "dead awaiting exact-container reap"
+                    )
+                    blockers.append(f"{state} execution session {session} (pid {owner[0]})")
+                for session in self._execution_sessions.keys() - self._execution_owners.keys():
+                    blockers.append(f"active execution session {session} (owner details pending)")
             return {
                 "ok": False,
-                "error": "daemon has active execution session(s); wait for run or shell to exit",
+                "error": "daemon shutdown blocked by " + ", ".join(blockers),
             }
         return {"ok": True, "stopping": True}
 
@@ -1654,6 +1675,28 @@ def _clip(text: str, limit: int = 2000) -> str:
 
 
 # -- client side -----------------------------------------------------------
+
+
+def startup_log_file(state_dir: Path) -> Path:
+    return state_dir / "daemon-startup.log"
+
+
+def _startup_diagnostics(state_dir: Path, *, limit: int = 8192) -> str:
+    path = startup_log_file(state_dir)
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")[-limit:]
+    except OSError:
+        return "no startup diagnostics were captured"
+    # Daemon exceptions should not normally contain credentials, but redact common
+    # key/value forms before surfacing child output in a terminal or bug report.
+    return (
+        re.sub(
+            r"(?i)(token|secret|password|passwd|api[_-]?key)(\s*[=:]\s*)([^\s]+)",
+            r"\1\2<redacted>",
+            text,
+        ).strip()
+        or "startup diagnostics were empty"
+    )
 
 
 def _detach(state_dir: Path) -> int:
@@ -1692,11 +1735,16 @@ def _detach(state_dir: Path) -> int:
         str(port_for(state_dir)),
     ]
 
+    state_dir.mkdir(parents=True, exist_ok=True)
+    # Each launch gets a fresh bounded diagnostic generation. This prevents repeated
+    # startup failures from growing the state file without limit; readers additionally
+    # cap the surfaced tail in `_startup_diagnostics`.
+    startup_log = startup_log_file(state_dir).open("wb", buffering=0)
     kwargs: dict[str, Any] = {
         "env": env,
         "stdin": subprocess.DEVNULL,
-        "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
+        "stdout": startup_log,
+        "stderr": subprocess.STDOUT,
         "close_fds": True,
     }
     if sys.platform.startswith("win"):
@@ -1710,7 +1758,10 @@ def _detach(state_dir: Path) -> int:
         # and never receives the terminal's Ctrl-C.
         kwargs["start_new_session"] = True
 
-    return subprocess.Popen(argv, **kwargs).pid
+    try:
+        return subprocess.Popen(argv, **kwargs).pid
+    finally:
+        startup_log.close()
 
 
 def spawn(state_dir: Path | None = None, *, timeout: float = SPAWN_TIMEOUT_SECONDS) -> DaemonState:
@@ -1725,7 +1776,7 @@ def spawn(state_dir: Path | None = None, *, timeout: float = SPAWN_TIMEOUT_SECON
         if state is not None and state.pid:
             return state
 
-    _detach(state_dir)
+    pid = _detach(state_dir)
 
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -1733,7 +1784,10 @@ def spawn(state_dir: Path | None = None, *, timeout: float = SPAWN_TIMEOUT_SECON
         if state is not None and state.pid:
             return state
         time.sleep(0.1)
-    raise DaemonError(f"daemon did not answer on port {port_for(state_dir)} within {timeout:.0f}s")
+    raise DaemonError(
+        f"daemon pid {pid} did not answer on port {port_for(state_dir)} "
+        f"within {timeout:.0f}s; startup diagnostics: {_startup_diagnostics(state_dir)}"
+    )
 
 
 def request(
@@ -1762,11 +1816,35 @@ def request(
         if not autostart:
             raise DaemonError("no bosn daemon is running")
         spawn(state_dir)
-    return ipc.send_request(
+    wire_request = {"verb": verb, "auth": _secret(state_dir), "version": __version__, **payload}
+    reply = ipc.send_request(
         port_for(state_dir),
-        {"verb": verb, "auth": _secret(state_dir), "version": __version__, **payload},
+        wire_request,
         timeout=request_timeout,
     )
+    if verb not in MUTATING_VERBS or not reply.get("daemon_version"):
+        return reply
+
+    # A stale daemon must never execute a mutation using a newer client's assumptions.
+    # It is safe to replace automatically only when durable foreground ownership is empty;
+    # otherwise return the explicit skew response and preserve the live session.
+    status = ipc.send_request(
+        port_for(state_dir),
+        {"verb": "status", "auth": _secret(state_dir), "version": __version__},
+        timeout=request_timeout,
+    )
+    sessions = status.get("execution_sessions") or []
+    if sessions:
+        details = ", ".join(
+            f"{item.get('id', 'unknown')} (pid {item.get('client_pid', 'unknown')})"
+            for item in sessions
+        )
+        reply["error"] = f"{reply.get('error')}; live execution sessions prevent restart: {details}"
+        return reply
+    if not stop(state_dir, timeout=request_timeout):
+        raise DaemonError("version-skewed daemon did not stop cleanly; mutation was not sent")
+    spawn(state_dir)
+    return ipc.send_request(port_for(state_dir), wire_request, timeout=request_timeout)
 
 
 def stream(

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -162,6 +162,25 @@ def test_status_surfaces_a_foreground_session_without_waiting_for_engine_scan(
     assert report["execution_sessions"][0]["id"] == "session"
 
 
+def test_jobs_is_a_bounded_diagnostic_and_never_autostarts(tmp_path, monkeypatch, capsys) -> None:
+    from bosn import daemon
+
+    calls = []
+
+    def request(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise ipc.TransportTimeout("timed out waiting for the daemon")
+
+    monkeypatch.setattr(daemon, "request", request)
+    assert cli.main(["--state-dir", str(tmp_path), "jobs"]) == 1
+    assert calls[0][1] == {
+        "autostart": False,
+        "request_timeout": cli.JOBS_DAEMON_TIMEOUT_SECONDS,
+        "diagnostic": True,
+    }
+    assert "timed out" in capsys.readouterr().err
+
+
 def test_status_returns_a_healthy_empty_session_report_without_engine_inventory(
     tmp_path, monkeypatch, capsys
 ) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import socket
+import subprocess
 import sys
 import threading
 import time
@@ -162,7 +163,14 @@ def test_reconcile_volume_version_mismatch_is_rejected_before_dispatch(
     assert responses == [
         {
             "ok": False,
-            "error": "daemon version differs; restart the daemon before destructive use",
+            "error": (
+                "bosn client/daemon version mismatch: client="
+                "a-client-version-that-does-not-match daemon="
+                + daemon_mod.__version__
+                + "; restart the daemon before destructive use"
+            ),
+            "client_version": "a-client-version-that-does-not-match",
+            "daemon_version": daemon_mod.__version__,
         }
     ]
 
@@ -2032,6 +2040,48 @@ def test_mutating_request_fails_closed_without_a_daemon(tmp_path: Path) -> None:
         daemon_mod.request("status", tmp_path, autostart=False)
 
 
+def test_mutating_request_restarts_version_skew_only_without_live_sessions(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(daemon_mod, "is_serving", lambda *_a, **_k: True)
+    replies = iter(
+        [
+            {"ok": False, "daemon_version": "old", "client_version": "new"},
+            {"ok": True, "execution_sessions": []},
+            {"ok": True, "result": "retried"},
+        ]
+    )
+    monkeypatch.setattr(ipc, "send_request", lambda *_a, **_k: next(replies))
+    stopped = []
+    spawned = []
+    monkeypatch.setattr(daemon_mod, "stop", lambda *_a, **_k: stopped.append(True) or True)
+    monkeypatch.setattr(daemon_mod, "spawn", lambda *_a, **_k: spawned.append(True))
+
+    assert daemon_mod.request("done", tmp_path)["result"] == "retried"
+    assert stopped == [True]
+    assert spawned == [True]
+
+
+def test_mutating_request_preserves_live_session_during_version_skew(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(daemon_mod, "is_serving", lambda *_a, **_k: True)
+    replies = iter(
+        [
+            {"ok": False, "error": "version mismatch", "daemon_version": "old"},
+            {"ok": True, "execution_sessions": [{"id": "session-1", "client_pid": 42}]},
+        ]
+    )
+    monkeypatch.setattr(ipc, "send_request", lambda *_a, **_k: next(replies))
+    monkeypatch.setattr(
+        daemon_mod, "stop", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError())
+    )
+
+    reply = daemon_mod.request("done", tmp_path)
+    assert not reply["ok"]
+    assert "session-1 (pid 42)" in reply["error"]
+
+
 def test_transport_error_on_a_dead_port() -> None:
     with pytest.raises(ipc.TransportError, match="unreachable"):
         ipc.send_request(daemon_mod.free_port(), {"verb": "ping"}, timeout=1.0)
@@ -2048,12 +2098,27 @@ def test_stop_raises_immediately_when_daemon_refuses_shutdown(tmp_path: Path, mo
         "send_request",
         lambda *a, **k: {
             "ok": False,
-            "error": "daemon has active execution session(s); wait for run or shell to exit",
+            "error": "daemon shutdown blocked by live execution session session-1 (pid 42)",
         },
     )
 
-    with pytest.raises(DaemonError, match="active execution session"):
+    with pytest.raises(DaemonError, match=r"live execution session session-1 \(pid 42\)"):
         daemon_mod.stop(tmp_path, timeout=0.0)
+
+
+def test_spawn_failure_includes_bounded_detached_diagnostics(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(daemon_mod, "is_serving", lambda *_a, **_k: False)
+    monkeypatch.setattr(daemon_mod, "running_state", lambda *_a, **_k: None)
+    monkeypatch.setattr(daemon_mod, "_detach", lambda *_a, **_k: 4321)
+    log = daemon_mod.startup_log_file(tmp_path)
+    log.write_text("fatal: token=top-secret\n", encoding="utf-8")
+
+    with pytest.raises(DaemonError) as caught:
+        daemon_mod.spawn(tmp_path, timeout=0)
+    message = str(caught.value)
+    assert "pid 4321" in message
+    assert "fatal:" in message
+    assert "top-secret" not in message
 
 
 def test_detach_does_not_depend_on_the_running_process_broker() -> None:
@@ -2068,6 +2133,18 @@ def test_detach_does_not_depend_on_the_running_process_broker() -> None:
     assert "launch_detached" not in code
     assert "rp_daemon" not in code
     assert "subprocess.Popen" in code
+
+
+def test_detach_truncates_diagnostics_for_each_launch(tmp_path: Path, monkeypatch) -> None:
+    log = daemon_mod.startup_log_file(tmp_path)
+    log.write_text("old failure that must not accumulate", encoding="utf-8")
+
+    class Child:
+        pid = 4321
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *_a, **_k: Child())
+    assert daemon_mod._detach(tmp_path) == 4321
+    assert log.read_bytes() == b""
 
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows console flags")


### PR DESCRIPTION
## Summary\n- make jobs a bounded, non-autostart diagnostic\n- capture and redact detached daemon startup diagnostics with bounded retention\n- report explicit client/daemon version skew and safely restart only without live execution sessions\n- classify shutdown blockers with session IDs and owner PIDs\n\n## Validation\n- host lint/typecheck: pass\n- host non-Docker suite: 1085 passed, 2 skipped\n- focused lifecycle regressions: 7 passed\n- isolated Bosn Linux lint: pass\n- isolated Bosn Linux tests: 1079 passed, 9 skipped\n\nFixes #130