### PR TITLE
Bump Bosn to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bosn"
-version = "0.1.2"
+version = "0.1.3"
 description = "Let your agents use Docker all day without filling the disk"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/bosn/__init__.py
+++ b/src/bosn/__init__.py
@@ -1,5 +1,5 @@
 """bosn - a machine-wide lifecycle supervisor for container development resources."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "bosn"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Publishes the daemon lifecycle fixes from #130 under a new immutable PyPI version.\n\nValidation: host lint/typecheck passed; wheel and sdist passed twine metadata checks.