### PR TITLE
fix(doctor): classify Docker Desktop engine wedges

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,14 @@ prior registry it prints a source-specific `bosn adopt --from-registry <uuid>` c
 lost-database recovery only: it restores an identity into an empty registry and never replaces
 the identity of a registry that already has rows.
 
+On native Windows, Docker's client can be present while Docker Desktop's server API is wedged.
+When a server-version HTTP 5xx is supported by bounded Desktop and `docker-desktop` WSL
+observations, `doctor` reports the raw failure, local read-only registry counts, and the
+configured VHDX **allocation** when it can find one. Engine resource inventory is explicitly
+unavailable in this state: foreign labels, ownership, and reclaimable storage cannot be
+inferred. Restart Docker Desktop manually and rerun `doctor`; Bosn never restarts Desktop,
+prunes or adopts resources, changes WSL, or alters or compacts the VHDX from this diagnostic.
+
 ## Integration
 
 clud ships a thin `clud bosn …` forwarder that passes argv verbatim to the executable, exactly

--- a/src/bosn/accounting.py
+++ b/src/bosn/accounting.py
@@ -46,6 +46,14 @@ class StorageProbe:
     vhdx_slack_bytes: int | None = None
 
 
+@dataclass(frozen=True)
+class VhdxAllocation:
+    """Configured Docker Desktop data-disk allocation, never a reclaimability claim."""
+
+    path: Path
+    allocated_bytes: int
+
+
 def _bytes(value: object) -> int | None:
     """Parse Docker's JSON size field; absent/unrecognised remains explicitly unknown."""
     if isinstance(value, int):
@@ -179,6 +187,24 @@ def desktop_vhdx(directory: Path) -> Path | None:
     return max(
         candidates, key=lambda path: (path.name.lower() == "docker_data.vhdx", path.stat().st_size)
     )
+
+
+def configured_desktop_vhdx_allocation(
+    settings_path: Path | None = None,
+) -> VhdxAllocation | None:
+    """Read configured Desktop allocation without consulting the unavailable engine."""
+    settings_path = settings_path or (
+        Path(os.environ.get("APPDATA", "")) / "Docker" / "settings-store.json"
+    )
+    try:
+        raw = json.loads(settings_path.read_text(encoding="utf-8"))
+        for key in ("CustomWslDistroDir", "DataFolder"):
+            value = raw.get(key)
+            if value and (vhdx := desktop_vhdx(Path(str(value)))) is not None:
+                return VhdxAllocation(vhdx, vhdx.stat().st_size)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return None
 
 
 def probe(engine: Engine, fallback: Path) -> StorageProbe:

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -332,6 +332,9 @@ def cmd_doctor(opts: Options) -> int:
         deadline = None
         registry_id = None
         integrity = "not initialized"
+        local_resources = None
+        local_leases = None
+        local_sessions = None
     else:
         # A corrupt registry must still produce a diagnosis, never a traceback: doctor is
         # the tool the user reaches for precisely when the database is damaged, and the
@@ -342,10 +345,16 @@ def cmd_doctor(opts: Options) -> int:
                 deadline = registry.meta("maintenance.next_deadline")
                 registry_id = registry.registry_id
                 integrity = registry.integrity_check()
+                local_resources = len(registry.list_resources())
+                local_leases = len(registry.all_leases())
+                local_sessions = len(registry.execution_sessions())
         except sqlite3.DatabaseError as exc:
             deadline = None
             registry_id = None
             integrity = f"unreadable: {exc}"
+            local_resources = None
+            local_leases = None
+            local_sessions = None
     print(f"scheduler manifest installed: {autostart.manifest_installed()}")
     print(f"scheduler next deadline: {deadline or '-'}")
     print(f"registry integrity: {integrity}")
@@ -380,6 +389,31 @@ def cmd_doctor(opts: Options) -> int:
         )
     if not info.reachable:
         print(f"diagnosis:      {info.detail}", file=sys.stderr)
+        if info.failure_category == "docker_desktop_wedged":
+            from bosn.accounting import configured_desktop_vhdx_allocation
+
+            allocation = configured_desktop_vhdx_allocation()
+            print("engine resource inventory: unavailable")
+            print(
+                "local registered resources: "
+                f"{local_resources if local_resources is not None else 'unavailable'}"
+            )
+            print(f"local leases: {local_leases if local_leases is not None else 'unavailable'}")
+            print(
+                f"local execution sessions: {local_sessions if local_sessions is not None else 'unavailable'}"
+            )
+            if allocation is not None:
+                print(
+                    "configured Docker Desktop VHDX: "
+                    f"{allocation.path} ({allocation.allocated_bytes / 1024**3:.1f} GiB "
+                    "allocated; allocation only)"
+                )
+            print(
+                "Docker Desktop engine appears wedged; restart Docker Desktop manually, "
+                "then rerun `bosn doctor`. "
+                "Bosn will not restart Docker or alter WSL, the VHDX, registry, or engine resources.",
+                file=sys.stderr,
+            )
         return 1
     from bosn.resources import ResourceScanner
 

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -12,6 +12,7 @@ import contextlib
 import io
 import json
 import os
+import shutil
 import sqlite3
 import sys
 from collections.abc import Callable, Sequence
@@ -394,13 +395,19 @@ def cmd_doctor(opts: Options) -> int:
 
             allocation = configured_desktop_vhdx_allocation()
             print("engine resource inventory: unavailable")
+            if info.desktop_evidence is not None:
+                desktop = "running" if info.desktop_evidence.desktop_running else "unavailable"
+                wsl = "running" if info.desktop_evidence.wsl_distro_running else "unavailable"
+                print(f"Docker Desktop observation: {desktop}")
+                print(f"docker-desktop WSL observation: {wsl}")
             print(
                 "local registered resources: "
                 f"{local_resources if local_resources is not None else 'unavailable'}"
             )
             print(f"local leases: {local_leases if local_leases is not None else 'unavailable'}")
             print(
-                f"local execution sessions: {local_sessions if local_sessions is not None else 'unavailable'}"
+                "local execution sessions: "
+                f"{local_sessions if local_sessions is not None else 'unavailable'}"
             )
             if allocation is not None:
                 print(
@@ -408,10 +415,17 @@ def cmd_doctor(opts: Options) -> int:
                     f"{allocation.path} ({allocation.allocated_bytes / 1024**3:.1f} GiB "
                     "allocated; allocation only)"
                 )
+                try:
+                    volume = shutil.disk_usage(allocation.path)
+                except OSError:
+                    print("configured VHDX volume free space: unavailable")
+                else:
+                    print(f"configured VHDX volume free space: {volume.free / 1024**3:.1f} GiB")
             print(
                 "Docker Desktop engine appears wedged; restart Docker Desktop manually, "
                 "then rerun `bosn doctor`. "
-                "Bosn will not restart Docker or alter WSL, the VHDX, registry, or engine resources.",
+                "Bosn will not restart Docker or alter WSL, the VHDX, registry, "
+                "or engine resources.",
                 file=sys.stderr,
             )
         return 1

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Callable
@@ -46,6 +47,47 @@ class EngineInfo:
     server_version: str | None = None
     clock_skew_seconds: float | None = None
     detail: str | None = None
+    failure_category: str | None = None
+    desktop_evidence: DesktopEvidence | None = None
+
+
+@dataclass(frozen=True)
+class DesktopEvidence:
+    """Best-effort native Windows observations for a Docker Desktop wedge."""
+
+    desktop_running: bool | None
+    wsl_distro_running: bool | None
+
+
+def _read_only_command(args: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(args, capture_output=True, text=True, timeout=3, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return f"{completed.stdout}\n{completed.stderr}"
+
+
+def docker_desktop_evidence() -> DesktopEvidence:
+    """Read-only, bounded Windows support evidence for an HTTP-5xx server probe."""
+    if sys.platform != "win32":
+        return DesktopEvidence(desktop_running=None, wsl_distro_running=None)
+    desktop = _read_only_command(
+        ["tasklist", "/FI", "IMAGENAME eq Docker Desktop.exe", "/FO", "CSV", "/NH"]
+    )
+    wsl = _read_only_command(["wsl.exe", "--list", "--verbose"])
+    return DesktopEvidence(
+        desktop_running=("Docker Desktop.exe" in desktop) if desktop is not None else None,
+        wsl_distro_running=("docker-desktop" in wsl and "Running" in wsl)
+        if wsl is not None
+        else None,
+    )
+
+
+def _server_failure_category(detail: str, evidence: DesktopEvidence) -> str:
+    http_5xx = "http" in detail.lower() and "500" in detail
+    if http_5xx and evidence.desktop_running is True and evidence.wsl_distro_running is True:
+        return "docker_desktop_wedged"
+    return "server_error"
 
 
 def _engine_timestamp(value: str) -> float | None:
@@ -270,6 +312,7 @@ class Engine:
                 binary=self.binary,
                 reachable=False,
                 detail=f"{self.binary!r} is not on PATH",
+                failure_category="binary_unavailable",
             )
         try:
             client = self.run(["version", "--format", "{{.Client.Version}}"])
@@ -277,13 +320,23 @@ class Engine:
         except KeyboardInterrupt:
             raise
         except Exception as exc:  # noqa: BLE001 - doctor must never crash
-            return EngineInfo(binary=self.binary, reachable=False, detail=str(exc))
+            detail = str(exc)
+            return EngineInfo(
+                binary=self.binary,
+                reachable=False,
+                detail=detail,
+                failure_category="deadline" if "deadline" in detail else "probe_error",
+            )
         if not server.ok:
+            detail = server.stderr or server.stdout or "engine daemon unreachable"
+            evidence = docker_desktop_evidence()
             return EngineInfo(
                 binary=self.binary,
                 reachable=False,
                 client_version=client.stdout or None,
-                detail=server.stderr or server.stdout or "engine daemon unreachable",
+                detail=detail,
+                failure_category=_server_failure_category(detail, evidence),
+                desktop_evidence=evidence,
             )
         # ``docker info`` exposes the daemon's own nanosecond wall clock. Sampling the
         # client clock on both sides and comparing with the midpoint removes ordinary CLI

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -84,7 +84,8 @@ def docker_desktop_evidence() -> DesktopEvidence:
 
 
 def _server_failure_category(detail: str, evidence: DesktopEvidence) -> str:
-    http_5xx = "http" in detail.lower() and "500" in detail
+    lowered = detail.lower()
+    http_5xx = ("http" in lowered and "500" in detail) or "500 internal server error" in lowered
     if http_5xx and evidence.desktop_running is True and evidence.wsl_distro_running is True:
         return "docker_desktop_wedged"
     return "server_error"

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -206,9 +206,7 @@ def test_configured_vhdx_allocation_reports_a_file_not_reclaimable_slack(tmp_pat
     disk.mkdir(parents=True)
     vhdx = disk / "docker_data.vhdx"
     vhdx.write_bytes(b"allocated")
-    settings.write_text(
-        json.dumps({"CustomWslDistroDir": str(tmp_path / "wsl")}), encoding="utf-8"
-    )
+    settings.write_text(json.dumps({"CustomWslDistroDir": str(tmp_path / "wsl")}), encoding="utf-8")
 
     allocation = configured_desktop_vhdx_allocation(settings)
 

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import json
 
-from bosn.accounting import StorageInventory, desktop_vhdx, engine_storage_path, resource_bytes
+from bosn.accounting import (
+    StorageInventory,
+    configured_desktop_vhdx_allocation,
+    desktop_vhdx,
+    engine_storage_path,
+    resource_bytes,
+)
 from bosn.engine import EngineResult
 from bosn.registry import Resource
 
@@ -192,3 +198,21 @@ def test_desktop_vhdx_finds_docker_data_disk_in_configured_directory(tmp_path) -
     docker_data.write_bytes(b"xx")
 
     assert desktop_vhdx(tmp_path) == docker_data
+
+
+def test_configured_vhdx_allocation_reports_a_file_not_reclaimable_slack(tmp_path) -> None:
+    settings = tmp_path / "settings-store.json"
+    disk = tmp_path / "wsl" / "disk"
+    disk.mkdir(parents=True)
+    vhdx = disk / "docker_data.vhdx"
+    vhdx.write_bytes(b"allocated")
+    settings.write_text(
+        json.dumps({"CustomWslDistroDir": str(tmp_path / "wsl")}), encoding="utf-8"
+    )
+
+    allocation = configured_desktop_vhdx_allocation(settings)
+
+    assert allocation is not None
+    assert allocation.path == vhdx
+    assert allocation.allocated_bytes == len(b"allocated")
+    assert not hasattr(allocation, "reclaimable_bytes")

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -993,6 +993,69 @@ def test_doctor_reports_unreachable_engine_and_scheduler_state_without_crashing(
     assert "not on PATH" in captured.err
 
 
+def test_doctor_reports_a_desktop_wedge_with_local_read_only_inventory(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """#136 preserves local evidence but never turns an engine failure into authority."""
+    import hashlib
+
+    from bosn import accounting
+    from bosn.engine import DesktopEvidence, EngineInfo
+    from bosn.registry import Registry
+
+    with Registry(tmp_path / "registry.sqlite3") as registry:
+        resource = registry.register_resource(
+            kind="volume",
+            name="warm-cache",
+            stack="dev",
+            generation="digest",
+            scope="stack",
+            workspace="workspace",
+        )
+        registry.acquire_lease(resource.id, pid=123, proc_start=1.0)
+    database = tmp_path / "registry.sqlite3"
+    before = hashlib.sha256(database.read_bytes()).hexdigest()
+
+    class WedgeEngine:
+        def __init__(self, binary: str = "docker") -> None:
+            self.binary = binary
+
+        def info(self):
+            return EngineInfo(
+                binary=self.binary,
+                reachable=False,
+                client_version="28.5.1",
+                detail="request returned 500 Internal Server Error",
+                failure_category="docker_desktop_wedged",
+                desktop_evidence=DesktopEvidence(True, True),
+            )
+
+    class ScannerMustNotRun:
+        def __init__(self, *_args) -> None:
+            raise AssertionError("doctor must not scan a wedged engine")
+
+    monkeypatch.setattr(cli, "Engine", WedgeEngine)
+    monkeypatch.setattr("bosn.resources.ResourceScanner", ScannerMustNotRun)
+    monkeypatch.setattr(
+        accounting,
+        "configured_desktop_vhdx_allocation",
+        lambda: accounting.VhdxAllocation(tmp_path / "docker_data.vhdx", 382 * 1024**3),
+    )
+
+    assert cli.main(["--state-dir", str(tmp_path), "doctor"]) == 1
+    captured = capsys.readouterr()
+    assert "Docker Desktop engine appears wedged" in captured.err
+    assert "restart Docker Desktop" in captured.err
+    assert "engine resource inventory: unavailable" in captured.out
+    assert "local registered resources: 1" in captured.out
+    assert "local leases: 1" in captured.out
+    assert "382.0 GiB allocated" in captured.out
+    assert "prune" not in captured.err.lower()
+    assert "adopt" not in captured.err.lower()
+    assert "compact" not in captured.err.lower()
+    assert hashlib.sha256(database.read_bytes()).hexdigest() == before
+
+
 def test_doctor_fails_with_actionable_warning_when_engine_clock_is_skewed(
     tmp_path, monkeypatch, capsys
 ) -> None:

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -1047,9 +1047,12 @@ def test_doctor_reports_a_desktop_wedge_with_local_read_only_inventory(
     assert "Docker Desktop engine appears wedged" in captured.err
     assert "restart Docker Desktop" in captured.err
     assert "engine resource inventory: unavailable" in captured.out
+    assert "Docker Desktop observation: running" in captured.out
+    assert "docker-desktop WSL observation: running" in captured.out
     assert "local registered resources: 1" in captured.out
     assert "local leases: 1" in captured.out
     assert "382.0 GiB allocated" in captured.out
+    assert "configured VHDX volume free space:" in captured.out
     assert "prune" not in captured.err.lower()
     assert "adopt" not in captured.err.lower()
     assert "compact" not in captured.err.lower()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 
 from bosn import engine as engine_mod
-from bosn.engine import Engine, EngineError, EngineResult
+from bosn.engine import DesktopEvidence, Engine, EngineError, EngineResult
 
 
 class FakeEngine(Engine):
@@ -69,6 +69,69 @@ def test_engine_info_stays_reachable_when_clock_probe_fails(monkeypatch) -> None
 
     assert info.reachable
     assert info.clock_skew_seconds is None
+
+
+def test_engine_info_classifies_a_windows_desktop_server_500_only_with_supporting_evidence(
+    monkeypatch,
+) -> None:
+    """#136: a live client plus Desktop/WSL evidence is not generic unreachable.
+
+    The raw CLI response remains operator evidence.  A server HTTP 5xx alone is not
+    enough to claim a Docker Desktop wedge, because a remote/context engine can emit
+    the same text without a local Desktop recovery path.
+    """
+
+    class WedgeEngine(Engine):
+        def available(self) -> bool:
+            return True
+
+        def run(self, args, **_kwargs):
+            if args == ["version", "--format", "{{.Client.Version}}"]:
+                return EngineResult(0, "28.5.1", "")
+            if args == ["version", "--format", "{{.Server.Version}}"]:
+                return EngineResult(
+                    1,
+                    "",
+                    "request returned 500 Internal Server Error for API route and version",
+                )
+            raise AssertionError(f"unexpected engine call: {args}")
+
+    monkeypatch.setattr(
+        engine_mod,
+        "docker_desktop_evidence",
+        lambda: DesktopEvidence(desktop_running=True, wsl_distro_running=True),
+    )
+    info = WedgeEngine().info()
+
+    assert not info.reachable
+    assert info.failure_category == "docker_desktop_wedged"
+    assert info.client_version == "28.5.1"
+    assert "500 Internal Server Error" in (info.detail or "")
+    assert info.desktop_evidence == DesktopEvidence(desktop_running=True, wsl_distro_running=True)
+
+
+def test_engine_info_keeps_server_500_generic_without_windows_desktop_evidence(monkeypatch) -> None:
+    class ServerErrorEngine(Engine):
+        def available(self) -> bool:
+            return True
+
+        def run(self, args, **_kwargs):
+            if args == ["version", "--format", "{{.Client.Version}}"]:
+                return EngineResult(0, "28.5.1", "")
+            if args == ["version", "--format", "{{.Server.Version}}"]:
+                return EngineResult(1, "", "request returned 500 Internal Server Error")
+            raise AssertionError(f"unexpected engine call: {args}")
+
+    monkeypatch.setattr(
+        engine_mod,
+        "docker_desktop_evidence",
+        lambda: DesktopEvidence(desktop_running=None, wsl_distro_running=None),
+    )
+    info = ServerErrorEngine().info()
+
+    assert not info.reachable
+    assert info.failure_category == "server_error"
+    assert info.desktop_evidence == DesktopEvidence(desktop_running=None, wsl_distro_running=None)
 
 
 def test_engine_execute_relays_stdout_and_stderr_while_running(capfd) -> None:


### PR DESCRIPTION
Closes #136

## Summary

Classifies a Docker Desktop server-version HTTP 500 as an engine-wedged candidate only when bounded native-Windows Desktop and `docker-desktop` WSL evidence are both running. `bosn doctor` remains read-only: it preserves raw failure detail, reports local registry/lease/session counts, VHDX allocation and host-volume free capacity when available, explicitly marks engine inventory unavailable, and directs the operator to manually restart Docker Desktop. It never restarts/resets Docker, changes WSL, prunes, adopts, compacts, or alters VHDX/registry state.

## Validation

- RED at detached test-only commit `87b0d28`: `bash test tests/test_engine.py tests/test_cli_verbs.py tests/test_accounting.py` exited 1 during collection because `DesktopEvidence` and `configured_desktop_vhdx_allocation` did not yet exist.
- GREEN focused: `bash test tests/test_engine.py tests/test_cli_verbs.py tests/test_accounting.py tests/test_doctor_integrity.py` ? 88 passed, 1 skipped.
- `bash lint` ? passed: ruff format/check, pyright, and KBI lint.
- Full `bash test` was attempted; the first real-Docker integration test failed/stalled because the host Docker Desktop engine is the reported HTTP-500 wedge, so the owned test process was interrupted without changing Docker state.
- Documented full non-Docker gate: `BOSN_SKIP_DOCKER_TESTS=1 bash test` ? 1091 passed, 2 skipped, 37 Docker tests deselected.

No GitHub Actions run was requested.
