### PR TITLE
fix: detect stalled container engines at runtime

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -826,7 +826,10 @@ def cmd_run(opts: Options) -> int:
                 # is intentionally limited to this machine-facing mode; ordinary runs use
                 # ``execute`` below and remain live on both native streams.
                 try:
-                    result = engine.run(exec_args, timeout=config.get("run_max_duration"))
+                    result = engine.execute_capture(
+                        exec_args,
+                        timeout=config.get("run_max_duration"),
+                    )
                 except KeyboardInterrupt:
                     engine._abort_container(str(acquired["container"]))
                     raise

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -85,7 +85,7 @@ class ConvergeResult:
     @classmethod
     def from_dict(cls, raw: dict[str, object]) -> ConvergeResult:
         volumes = raw.get("volumes") or []
-        if not isinstance(volumes, (list, tuple)):
+        if not isinstance(volumes, list | tuple):
             volumes = []
         return cls(
             stack=str(raw.get("stack", "")),

--- a/src/bosn/engine.py
+++ b/src/bosn/engine.py
@@ -15,6 +15,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 import running_process as rp
 
@@ -22,6 +23,14 @@ DEFAULT_TIMEOUT = 60
 # How often a streaming command checks whether it has been cancelled.
 STREAM_POLL_SECONDS = 0.05
 CLOCK_SKEW_BUDGET_SECONDS = 1.0
+# A quiet Docker command is valid, so silence only schedules a read-only liveness probe.
+# Two consecutive failures avoid turning a transient overloaded daemon into a destructive
+# false positive.  These bounds detect a wedge in roughly one minute without imposing an
+# idle-output deadline on legitimate cold builds or silent tests.
+ENGINE_HEALTH_GRACE_SECONDS = 30.0
+ENGINE_HEALTH_INTERVAL_SECONDS = 10.0
+ENGINE_HEALTH_PROBE_TIMEOUT_SECONDS = 5.0
+ENGINE_HEALTH_FAILURE_LIMIT = 2
 
 
 class EngineError(RuntimeError):
@@ -91,6 +100,97 @@ def _server_failure_category(detail: str, evidence: DesktopEvidence) -> str:
     return "server_error"
 
 
+class _EngineHealthMonitor:
+    """Kill one pending local engine CLI after repeated bounded server-probe failures."""
+
+    def __init__(self, engine: Engine, process: Any) -> None:
+        self._engine = engine
+        self._process = process
+        self._stop = threading.Event()
+        self._activity = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="bosn-engine-health", daemon=True)
+        self._captured_bytes = self._output_bytes()
+        self.error: str | None = None
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def activity(self) -> None:
+        self._activity.set()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._activity.set()
+        self._thread.join(timeout=ENGINE_HEALTH_PROBE_TIMEOUT_SECONDS + 1.0)
+
+    def _wait(self, seconds: float) -> bool:
+        """Return true when stopped; activity restarts the conservative grace period."""
+        deadline = time.monotonic() + seconds
+        while not self._stop.is_set():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            if self._activity.wait(remaining):
+                self._activity.clear()
+                deadline = time.monotonic() + ENGINE_HEALTH_GRACE_SECONDS
+        return True
+
+    def _run(self) -> None:
+        if self._wait(ENGINE_HEALTH_GRACE_SECONDS):
+            return
+        failures = 0
+        details: list[str] = []
+        while not self._stop.is_set() and not self._finished():
+            if self._output_advanced():
+                failures = 0
+                details.clear()
+                if self._wait(ENGINE_HEALTH_GRACE_SECONDS):
+                    return
+                continue
+            reachable, detail = self._engine._probe_server(ENGINE_HEALTH_PROBE_TIMEOUT_SECONDS)
+            if reachable:
+                failures = 0
+                details.clear()
+            else:
+                failures += 1
+                details.append(detail)
+                if failures >= ENGINE_HEALTH_FAILURE_LIMIT:
+                    summary = "; ".join(details[-ENGINE_HEALTH_FAILURE_LIMIT:])
+                    self.error = self._engine._unresponsive_message(summary)
+                    self._process.kill()
+                    return
+            if self._wait(ENGINE_HEALTH_INTERVAL_SECONDS):
+                return
+
+    def _finished(self) -> bool:
+        finished = getattr(self._process, "finished", None)
+        if finished is not None:
+            return bool(finished)
+        poll = getattr(self._process, "poll", None)
+        return callable(poll) and poll() is not None
+
+    def _output_bytes(self) -> int | None:
+        measure = getattr(self._process, "captured_output_bytes", None)
+        if not callable(measure):
+            return None
+        try:
+            measured = measure()
+            return measured if isinstance(measured, int) else None
+        except KeyboardInterrupt:
+            raise
+        except Exception:  # noqa: BLE001 - optional false-positive guard
+            return None
+
+    def _output_advanced(self) -> bool:
+        current = self._output_bytes()
+        if current is None or self._captured_bytes is None:
+            self._captured_bytes = current
+            return False
+        advanced = current > self._captured_bytes
+        self._captured_bytes = current
+        return advanced
+
+
 def _engine_timestamp(value: str) -> float | None:
     """Parse Docker's RFC3339 ``SystemTime`` without making diagnostics fragile."""
     try:
@@ -112,6 +212,39 @@ class Engine:
     def available(self) -> bool:
         """True when the engine binary is on PATH. Does not prove the daemon is up."""
         return shutil.which(self.binary) is not None
+
+    def _probe_server(self, timeout: float) -> tuple[bool, str]:
+        """Perform one narrow read-only daemon probe, preserving a useful failure reason."""
+        if not self.available():
+            return False, f"{self.binary!r} is not on PATH"
+        try:
+            completed = rp.subprocess_run(
+                [self.binary, "version", "--format", "{{.Server.Version}}"],
+                cwd=None,
+                check=False,
+                timeout=max(1, int(timeout)),
+            )
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - the monitor reports every probe failure
+            return False, str(exc)
+        result = EngineResult(
+            returncode=completed.returncode,
+            stdout=(completed.stdout or "").strip(),
+            stderr=(getattr(completed, "stderr", "") or "").strip(),
+        )
+        if result.ok:
+            return True, ""
+        return False, result.stderr or result.stdout or "server-version probe failed"
+
+    def _monitor(self, process: Any) -> _EngineHealthMonitor:
+        return _EngineHealthMonitor(self, process)
+
+    def _unresponsive_message(self, detail: str) -> str:
+        return (
+            f"{self.binary} engine is down or unresponsive and may be in a bad state "
+            f"({detail}); run `bosn doctor` and recover or restart the engine before retrying"
+        )
 
     def run(
         self, args: list[str], *, check: bool = False, timeout: float | None = None
@@ -150,6 +283,9 @@ class Engine:
             # disappear, or a PATH entry can point at something non-executable, in between),
             # so this branch still matters even with that guard in place.
             if isinstance(exc.__cause__, rp.TimeoutExpired):
+                reachable, detail = self._probe_server(ENGINE_HEALTH_PROBE_TIMEOUT_SECONDS)
+                if not reachable:
+                    raise EngineError(self._unresponsive_message(detail)) from exc
                 raise EngineError(
                     f"{self.binary} {' '.join(args)} exceeded its "
                     f"{effective_timeout}-second deadline"
@@ -195,6 +331,8 @@ class Engine:
                 on_line(text)
 
         process = rp.RunningProcess([self.binary, *args], check=False, timeout=None)
+        monitor = self._monitor(process)
+        monitor.start()
         killed = False
         try:
             while True:
@@ -213,6 +351,7 @@ class Engine:
                     time.sleep(STREAM_POLL_SECONDS)
                     continue
                 publish(str(line))
+                monitor.activity()
         finally:
             try:
                 # wait() is typed as int | IdleWaitResult because it doubles as an idle
@@ -224,8 +363,11 @@ class Engine:
             except Exception:  # noqa: BLE001 - a wait that fails must not mask the real outcome
                 process.kill()
                 returncode = -1
+            monitor.stop()
 
         output = "\n".join(lines)
+        if monitor.error is not None:
+            raise EngineError(monitor.error)
         if killed:
             return EngineResult(returncode=returncode or -1, stdout=output, stderr="cancelled")
         return EngineResult(returncode=returncode, stdout=output, stderr="")
@@ -259,6 +401,8 @@ class Engine:
         # Python will continue to raise a real KeyboardInterrupt when the parent receives
         # Ctrl-C, giving this method an unambiguous cleanup boundary.
         process.KEYBOARD_INTERRUPT_EXIT_CODES = set()  # pyright: ignore[reportAttributeAccessIssue]
+        monitor = self._monitor(process)
+        monitor.start()
         try:
             waited = process.wait(timeout=effective_timeout, echo=True)
         except KeyboardInterrupt:
@@ -273,9 +417,47 @@ class Engine:
                 f"{self.binary} {' '.join(args)} exceeded its "
                 f"{effective_timeout:g}-second deadline{cleanup_suffix}"
             ) from exc
+        finally:
+            monitor.stop()
+        if monitor.error is not None:
+            cleanup_error = self._abort_container(abort_container)
+            cleanup_suffix = f"; {cleanup_error}" if cleanup_error else ""
+            raise EngineError(f"{monitor.error}{cleanup_suffix}")
         if not isinstance(waited, int):
             raise EngineError(f"{self.binary} {' '.join(args)} ended without an exit status")
         return waited
+
+    def execute_capture(
+        self,
+        args: list[str],
+        *,
+        timeout: float | None = None,
+    ) -> EngineResult:
+        """Run a foreground command with separated capture and runtime health monitoring."""
+        if not self.available():
+            raise EngineError(f"{self.binary!r} is not on PATH")
+        effective_timeout = self.timeout if timeout is None else max(1.0, float(timeout))
+        process = rp.RunningProcess([self.binary, *args], check=False, capture=True, stderr=rp.PIPE)
+        process.KEYBOARD_INTERRUPT_EXIT_CODES = set()  # pyright: ignore[reportAttributeAccessIssue]
+        monitor = self._monitor(process)
+        monitor.start()
+        try:
+            waited = process.wait(timeout=effective_timeout)
+        except KeyboardInterrupt:
+            if not process.finished:
+                process.kill()
+            raise
+        except TimeoutError as exc:
+            raise EngineError(
+                f"{self.binary} {' '.join(args)} exceeded its {effective_timeout:g}-second deadline"
+            ) from exc
+        finally:
+            monitor.stop()
+        if monitor.error is not None:
+            raise EngineError(monitor.error)
+        if not isinstance(waited, int):
+            raise EngineError(f"{self.binary} {' '.join(args)} ended without an exit status")
+        return EngineResult(waited, str(process.stdout).strip(), str(process.stderr).strip())
 
     def _abort_container(self, container_id: str | None) -> str | None:
         if not container_id:
@@ -304,6 +486,11 @@ class Engine:
         """
         if not self.available():
             raise EngineError(f"{self.binary!r} is not on PATH")
+        # An inherited TTY provides no portable output-activity signal. Applying the quiet
+        # subprocess monitor here would kill a healthy, actively used shell after two
+        # transient health-probe failures. Runtime wedge detection therefore covers builds,
+        # foreground non-interactive commands, JSON capture, and bounded control calls;
+        # interactive recovery remains user-directed via Ctrl-C and `bosn doctor`.
         return subprocess.run([self.binary, *args], check=False).returncode
 
     def info(self) -> EngineInfo:

--- a/src/bosn/manifest.py
+++ b/src/bosn/manifest.py
@@ -386,7 +386,7 @@ def parse(raw: dict, root: Path, *, source_path: Path | None = None) -> Manifest
         _refuse_duplicate_destinations(name, volumes, mounts, tmpfs)
         env: dict[str, str] = {}
         for env_key, env_value in (body.get("env") or {}).items():
-            if isinstance(env_value, (dict, list)):
+            if isinstance(env_value, dict | list):
                 raise ManifestError(
                     f"[stack.{name}.env] key {env_key!r} must be a scalar, not a table or array"
                 )

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -120,7 +120,7 @@ def from_namespace(ns: argparse.Namespace) -> Options:
 
     def get_list(name: str) -> tuple[str, ...]:
         value = raw.get(name)
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, list | tuple):
             return ()
         return tuple(str(item) for item in value)
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -825,7 +825,7 @@ def test_run_json_failure_reserves_stdout_for_one_envelope(tmp_path, monkeypatch
         def __init__(self, _binary="docker") -> None:
             pass
 
-        def run(self, *_args, **_kwargs):
+        def execute_capture(self, *_args, **_kwargs):
             return EngineResult(7, "partial stdout", "partial stderr")
 
         def execute(self, *_args, **_kwargs):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,11 +3,165 @@
 from __future__ import annotations
 
 import sys
+import threading
+import time
 
 import pytest
 
 from bosn import engine as engine_mod
 from bosn.engine import DesktopEvidence, Engine, EngineError, EngineResult
+
+
+class StalledProcess:
+    """Deterministic local Docker-CLI stand-in: pending until the monitor kills it."""
+
+    KEYBOARD_INTERRUPT_EXIT_CODES: set[int] = set()
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.killed = False
+        self._killed = threading.Event()
+        self.output_bytes = 0
+
+    @property
+    def finished(self) -> bool:
+        return self.killed
+
+    def has_pending_output(self) -> bool:
+        return False
+
+    def get_next_line_non_blocking(self):
+        return engine_mod.rp.EndOfStream() if self.killed else None
+
+    def wait(self, *, timeout=None, echo=False):
+        del echo
+        if not self._killed.wait(timeout):
+            raise TimeoutError()
+        return -9
+
+    def kill(self) -> None:
+        self.killed = True
+        self._killed.set()
+
+    def captured_output_bytes(self) -> int:
+        return self.output_bytes
+
+    def poll(self) -> int | None:
+        return -9 if self.killed else None
+
+
+def _fast_health_monitor(monkeypatch) -> None:
+    monkeypatch.setattr(engine_mod, "ENGINE_HEALTH_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(engine_mod, "ENGINE_HEALTH_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(engine_mod, "ENGINE_HEALTH_FAILURE_LIMIT", 2)
+
+
+def test_stream_fails_when_repeated_bounded_probes_cannot_reach_engine(monkeypatch) -> None:
+    _fast_health_monitor(monkeypatch)
+    process = StalledProcess()
+    monkeypatch.setattr(engine_mod.rp, "RunningProcess", lambda *_a, **_k: process)
+    engine = Engine("docker")
+    probes: list[float] = []
+
+    def down(timeout: float) -> tuple[bool, str]:
+        probes.append(timeout)
+        return False, "server-version probe exceeded its deadline"
+
+    monkeypatch.setattr(engine, "_probe_server", down)
+
+    with pytest.raises(EngineError, match="down or unresponsive.*bad state") as raised:
+        engine.stream(["build", "."])
+
+    assert "bosn doctor" in str(raised.value)
+    assert process.killed
+    assert len(probes) == 2
+
+
+def test_execute_fails_when_repeated_bounded_probes_cannot_reach_engine(monkeypatch) -> None:
+    _fast_health_monitor(monkeypatch)
+    process = StalledProcess()
+    monkeypatch.setattr(engine_mod.rp, "RunningProcess", lambda *_a, **_k: process)
+    engine = Engine("docker")
+    monkeypatch.setattr(engine, "_probe_server", lambda _timeout: (False, "named pipe stalled"))
+    aborted: list[str | None] = []
+    monkeypatch.setattr(engine, "_abort_container", lambda value: aborted.append(value))
+
+    with pytest.raises(EngineError, match="down or unresponsive.*bad state"):
+        engine.execute(["exec", "exact-id", "true"], timeout=60, abort_container="exact-id")
+
+    assert process.killed
+    assert aborted == ["exact-id"]
+
+
+def test_captured_execute_reports_the_same_engine_health_failure(monkeypatch) -> None:
+    _fast_health_monitor(monkeypatch)
+    process = StalledProcess()
+    monkeypatch.setattr(engine_mod.rp, "RunningProcess", lambda *_a, **_k: process)
+    engine = Engine("docker")
+    monkeypatch.setattr(engine, "_probe_server", lambda _timeout: (False, "API stalled"))
+
+    with pytest.raises(EngineError, match="down or unresponsive.*bosn doctor"):
+        engine.execute_capture(["exec", "exact-id", "true"], timeout=60)
+
+    assert process.killed
+
+
+def test_health_monitor_tolerates_a_transient_probe_failure(monkeypatch) -> None:
+    _fast_health_monitor(monkeypatch)
+    monkeypatch.setattr(engine_mod, "ENGINE_HEALTH_FAILURE_LIMIT", 2)
+    attempts = 0
+    process = StalledProcess()
+    engine = Engine("docker")
+
+    def recovers(_timeout: float) -> tuple[bool, str]:
+        nonlocal attempts
+        attempts += 1
+        return (False, "busy") if attempts == 1 else (True, "")
+
+    monkeypatch.setattr(engine, "_probe_server", recovers)
+    monitor = engine._monitor(process)
+    monitor.start()
+    time.sleep(0.05)
+    monitor.stop()
+
+    assert monitor.error is None
+    assert not process.killed
+
+
+def test_continuing_output_defers_health_failure_classification(monkeypatch) -> None:
+    _fast_health_monitor(monkeypatch)
+    process = StalledProcess()
+    engine = Engine("docker")
+    probes = 0
+
+    def down(_timeout: float) -> tuple[bool, str]:
+        nonlocal probes
+        probes += 1
+        return False, "busy"
+
+    monkeypatch.setattr(engine, "_probe_server", down)
+    monitor = engine._monitor(process)
+    monitor.start()
+    for _ in range(8):
+        process.output_bytes += 1
+        time.sleep(0.005)
+    monitor.stop()
+
+    assert monitor.error is None
+    assert not process.killed
+    assert probes <= 1
+
+
+def test_native_pending_process_is_bounded_by_engine_health_monitor(monkeypatch) -> None:
+    """A real local child cannot become immortal when the independent probe is wedged."""
+    _fast_health_monitor(monkeypatch)
+    engine = Engine(sys.executable)
+    monkeypatch.setattr(engine, "_probe_server", lambda _timeout: (False, "transport stalled"))
+    started = time.monotonic()
+
+    with pytest.raises(EngineError, match="down or unresponsive"):
+        engine.stream(["-c", "import time; time.sleep(60)"])
+
+    assert time.monotonic() - started < 2.0
 
 
 class FakeEngine(Engine):
@@ -175,12 +329,33 @@ def test_run_reports_an_actual_timeout_as_a_deadline(monkeypatch) -> None:
     # question is answered here rather than inherited from the runner.
     monkeypatch.setattr(engine_mod.Engine, "available", lambda _self: True)
     monkeypatch.setattr(engine_mod.rp, "subprocess_run", fake_subprocess_run)
+    monkeypatch.setattr(engine_mod.Engine, "_probe_server", lambda *_args: (True, ""))
 
     with pytest.raises(EngineError, match="7-second deadline") as raised:
         Engine("docker", timeout=7).run(["ps"])
 
     assert raised.value.__cause__ is wrapped
     assert wrapped.__cause__ is cause
+
+
+def test_run_timeout_reports_engine_unresponsive_when_probe_also_fails(monkeypatch) -> None:
+    cause = engine_mod.rp.TimeoutExpired(cmd=["docker", "ps"], timeout=7)
+    wrapped = RuntimeError("timed out")
+    wrapped.__cause__ = cause
+    monkeypatch.setattr(engine_mod.Engine, "available", lambda _self: True)
+    monkeypatch.setattr(
+        engine_mod.rp,
+        "subprocess_run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(wrapped),
+    )
+    monkeypatch.setattr(
+        engine_mod.Engine,
+        "_probe_server",
+        lambda *_args: (False, "server pipe did not respond"),
+    )
+
+    with pytest.raises(EngineError, match="down or unresponsive.*bad state.*bosn doctor"):
+        Engine("docker", timeout=7).run(["ps"])
 
 
 def test_run_distinguishes_a_spawn_failure_from_a_timeout(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- monitor long-running Docker build and exec clients with bounded read-only server probes
- require consecutive health failures and defer probing while captured output advances
- classify timed-out control calls as engine-down only when the independent server probe also fails
- preserve exact-container abort and execution-session release while surfacing actionable doctor/recovery guidance
- update JSON execution to use the monitored separated-capture path
- apply three pre-existing Ruff UP038 baseline fixes required by the repository lint gate

## Validation

- RED: focused issue tests failed before the monitor API existed
- GREEN: 1094 passed, 2 skipped, 37 Docker tests deselected
- full host lint: Ruff format/check, Pyright, KeyboardInterrupt audit all pass
- one-agent clud-review: clean after resolving active-output and control-call findings
- local Docker validation intentionally not run because the local engine is the wedged system under diagnosis; GitHub Actions is the Linux/Docker authority

Closes #137