### PR TITLE
fix: recover slow dead-session container reaps

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -81,6 +81,14 @@ SHUTDOWN_DRAIN_SECONDS = 60.0
 # int (not a float) because Engine.__init__'s `timeout` parameter is typed int.
 MAINTENANCE_ENGINE_PROBE_TIMEOUT_SECONDS = 5
 
+# A dead foreground client leaves a remote process in the exact persistent container it
+# acquired. Reaping it must remain a bounded control-plane operation, but Docker Desktop can
+# take longer than the old 10-second one-shot deadline to stop and remove an otherwise healthy
+# container. Keep the operation narrowly scoped to the immutable session container and give it
+# Engine's normal bounded control deadline instead of treating a slow successful reap as an
+# unrecoverable session leak. Any failure still leaves the session and leases intact.
+ORPHAN_REAP_TIMEOUT_SECONDS = 60.0
+
 # Upper bound on how long shutdown() waits for the watchdog thread to notice `_stop` and
 # exit, once the cooperative checks in `_run_maintenance` and the bounded probe above are
 # both in place. `EngineInfo.info()` can make the probe call up to twice before it decides
@@ -1424,7 +1432,10 @@ class Daemon:
                 engine_binary = self._execution_engines[session]
                 try:
                     engine = Engine(engine_binary)
-                    removed = engine.run(["container", "rm", "--force", container_id], timeout=10)
+                    removed = engine.run(
+                        ["container", "rm", "--force", container_id],
+                        timeout=ORPHAN_REAP_TIMEOUT_SECONDS,
+                    )
                     detail = removed.stderr or removed.stdout
                     if not removed.ok and "no such container" not in detail.lower():
                         raise RuntimeError(detail or "container removal failed")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -684,14 +684,14 @@ def test_dead_execution_owner_is_stopped_and_reaped_before_next_acquire(
     )
     result = ConvergeResult("dev", "sha256:g", "reused", "image")
     alive = {111: True, 222: True}
-    removals: list[tuple[str, list[str]]] = []
+    removals: list[tuple[str, list[str], object]] = []
 
     class FakeEngine:
         def __init__(self, binary: str = "docker", **_kwargs: object) -> None:
             self.binary = binary
 
-        def run(self, args: list[str], **_kwargs: object) -> EngineResult:
-            removals.append((self.binary, args))
+        def run(self, args: list[str], **kwargs: object) -> EngineResult:
+            removals.append((self.binary, args, kwargs.get("timeout")))
             return EngineResult(0, "sha256:immutable-container", "")
 
     daemon = Daemon(state_dir=tmp_path / "state")
@@ -731,7 +731,11 @@ def test_dead_execution_owner_is_stopped_and_reaped_before_next_acquire(
 
         assert second["ok"] is True
         assert removals == [
-            ("podman", ["container", "rm", "--force", "sha256:immutable-container"])
+            (
+                "podman",
+                ["container", "rm", "--force", "sha256:immutable-container"],
+                daemon_mod.ORPHAN_REAP_TIMEOUT_SECONDS,
+            )
         ]
         assert daemon.registry.get_lease(first_lease.id) is None
         assert first["session"] not in daemon._execution_sessions


### PR DESCRIPTION
## Summary
- give dead foreground-session exact-container reaping a named 60-second bounded control deadline
- preserve immutable container-ID removal and fail-closed retention of the session and leases on any reap failure
- pin the reap timeout contract in the no-Docker daemon regression

Closes #135

## Validation
- `bash ./test tests/test_daemon.py -k dead_execution_owner_is_stopped_and_reaped_before_next_acquire` (RED before production change, then GREEN)
- `BOSN_SKIP_DOCKER_TESTS=1 bash ./test` — 1098 passed, 2 skipped, 37 deselected
- `bash ./lint` — ruff format/check, pyright, and KeyboardInterrupt checker passed

No Docker resources were created or modified during validation.