### PR TITLE
fix(daemon): pin in-flight synchronous requests

### DIFF
--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -298,7 +298,11 @@ class _Handler(socketserver.StreamRequestHandler):
             if verb in STREAMING_VERBS:
                 self._stream(daemon_ref, verb, request)
                 return
-            response = daemon_ref.dispatch(verb, request)
+            daemon_ref.begin_request()
+            try:
+                response = daemon_ref.dispatch(verb, request)
+            finally:
+                daemon_ref.finish_request()
         except KeyboardInterrupt:
             # Ctrl-C on the daemon means shut down, not "this one request failed".
             daemon_ref.request_stop()
@@ -403,6 +407,7 @@ class Daemon:
         self._execution_owners: dict[str, tuple[int, float | None]] = {}
         self._execution_engines: dict[str, str] = {}
         self._execution_lock = threading.RLock()
+        self._active_requests = 0
         self._stopping = False
         self.secret = secrets.token_urlsafe(32)
         self.registry = Registry(self.state_dir / "registry.sqlite3", clock=self.clock)
@@ -502,6 +507,14 @@ class Daemon:
         self.last_activity = self.clock.now()
         self.heartbeat_at = self.last_activity
 
+    def begin_request(self) -> None:
+        with self._execution_lock:
+            self._active_requests += 1
+
+    def finish_request(self) -> None:
+        with self._execution_lock:
+            self._active_requests -= 1
+
     def idle_seconds(self) -> float:
         return self.clock.now() - self.last_activity
 
@@ -516,7 +529,8 @@ class Daemon:
         """
         with self._execution_lock:
             sessions_active = bool(self._execution_sessions)
-        if self.jobs.active_count() > 0 or sessions_active:
+            requests_active = self._active_requests > 0
+        if self.jobs.active_count() > 0 or sessions_active or requests_active:
             return False
         return self.idle_seconds() >= self.idle_retire_seconds
 

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -294,29 +294,26 @@ class _Handler(socketserver.StreamRequestHandler):
                 },
             )
             return
+        if verb in STREAMING_VERBS:
+            self._stream(daemon_ref, verb, request)
+            return
+        daemon_ref.begin_request()
         try:
-            if verb in STREAMING_VERBS:
-                self._stream(daemon_ref, verb, request)
-                return
-            daemon_ref.begin_request()
             try:
                 response = daemon_ref.dispatch(verb, request)
-            finally:
-                daemon_ref.finish_request()
-        except KeyboardInterrupt:
-            # Ctrl-C on the daemon means shut down, not "this one request failed".
-            daemon_ref.request_stop()
-            raise
-        except Exception as exc:  # noqa: BLE001 - every failure is observable, none fatal
-            response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
-        try:
-            ipc.send_response(self.connection, response)
-        except (ipc.TransportError, OSError) as exc:
-            # A GC/status client can time out after the daemon has completed its work.
-            # Its disconnected socket is not authority to stop the shared daemon.
-            daemon_ref.registry.log_event(
-                "ipc.response_disconnected", f"{verb}: {type(exc).__name__}: {exc}"
-            )
+            except KeyboardInterrupt:
+                daemon_ref.request_stop()
+                raise
+            except Exception as exc:  # noqa: BLE001
+                response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+            try:
+                ipc.send_response(self.connection, response)
+            except (ipc.TransportError, OSError) as exc:
+                daemon_ref.registry.log_event(
+                    "ipc.response_disconnected", f"{verb}: {type(exc).__name__}: {exc}"
+                )
+        finally:
+            daemon_ref.finish_request()
 
     def _stream(self, daemon_ref: Daemon, verb: str, request: dict[str, Any]) -> None:
         """Hold the connection open and write events until the job reaches a terminal one.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -366,28 +366,45 @@ def test_active_execution_session_pins_daemon_and_refuses_shutdown(tmp_path: Pat
 
 
 def test_inflight_non_streaming_request_pins_daemon(tmp_path: Path) -> None:
-    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0)
+    entered = threading.Event()
+    release = threading.Event()
+    reply: list[dict[str, object]] = []
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0.1)
+    daemon._set_next_maintenance(daemon.clock.now() + 3600)
+    original_dispatch = daemon.dispatch
+
+    def blocking_dispatch(verb: str, request: dict[str, object]) -> dict[str, object]:
+        if verb != "gc":
+            return original_dispatch(verb, request)
+        entered.set()
+        assert release.wait(10), "test did not release blocking GC request"
+        return {"ok": True}
+
+    daemon.dispatch = blocking_dispatch  # type: ignore[method-assign]
+    server = threading.Thread(target=daemon.serve_forever, daemon=True)
+    server.start()
     try:
-        handler = object.__new__(daemon_mod._Handler)
-        handler.connection = object()
-        handler.server = SimpleNamespace(daemon_ref=daemon)  # type: ignore[assignment]
-        sent: list[dict[str, object]] = []
-        original_read = ipc.read_request
-        original_send = ipc.send_response
-        ipc.read_request = lambda _conn: {"auth": daemon.secret, "verb": "gc"}  # type: ignore[assignment]
-        daemon.dispatch = lambda *_args: {"ok": True}  # type: ignore[method-assign]
-
-        def send(_conn: object, response: dict[str, object]) -> None:
-            assert not daemon.should_retire(), "watchdog must not retire during response"
-            sent.append(response)
-
-        ipc.send_response = send  # type: ignore[assignment]
-        handler.handle()
-        ipc.read_request = original_read  # type: ignore[assignment]
-        ipc.send_response = original_send  # type: ignore[assignment]
-        assert sent == [{"ok": True}]
-        assert daemon.should_retire()
+        assert _wait_until(lambda: daemon_mod.is_serving(tmp_path)), "daemon never came up"
+        client = threading.Thread(
+            target=lambda: reply.append(
+                ipc.send_request(daemon.port, {"auth": daemon.secret, "verb": "gc"}, timeout=10)
+            ),
+            daemon=True,
+        )
+        client.start()
+        assert entered.wait(5), "GC handler never started"
+        time.sleep(0.4)
+        assert daemon_mod.is_serving(tmp_path), "watchdog retired an in-flight GC request"
+        release.set()
+        client.join(timeout=10)
+        assert not client.is_alive(), "GC client never received a response"
+        assert reply == [{"ok": True}]
+        server.join(timeout=10)
+        assert not server.is_alive(), "daemon did not retire after request completion"
     finally:
+        release.set()
+        daemon.request_stop()
+        server.join(timeout=10)
         daemon.registry.close()
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -368,9 +368,22 @@ def test_active_execution_session_pins_daemon_and_refuses_shutdown(tmp_path: Pat
 def test_inflight_non_streaming_request_pins_daemon(tmp_path: Path) -> None:
     daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0)
     try:
-        daemon.begin_request()
-        assert not daemon.should_retire()
-        daemon.finish_request()
+        handler = object.__new__(daemon_mod._Handler)
+        handler.connection = object()
+        handler.server = SimpleNamespace(daemon_ref=daemon)  # type: ignore[assignment]
+        sent: list[dict[str, object]] = []
+        original_read = ipc.read_request
+        original_send = ipc.send_response
+        ipc.read_request = lambda _conn: {"auth": daemon.secret, "verb": "gc"}  # type: ignore[assignment]
+        daemon.dispatch = lambda *_args: {"ok": True}  # type: ignore[method-assign]
+        def send(_conn: object, response: dict[str, object]) -> None:
+            assert not daemon.should_retire(), "watchdog must not retire during response"
+            sent.append(response)
+        ipc.send_response = send  # type: ignore[assignment]
+        handler.handle()
+        ipc.read_request = original_read  # type: ignore[assignment]
+        ipc.send_response = original_send  # type: ignore[assignment]
+        assert sent == [{"ok": True}]
         assert daemon.should_retire()
     finally:
         daemon.registry.close()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -365,6 +365,17 @@ def test_active_execution_session_pins_daemon_and_refuses_shutdown(tmp_path: Pat
         daemon.registry.close()
 
 
+def test_inflight_non_streaming_request_pins_daemon(tmp_path: Path) -> None:
+    daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0)
+    try:
+        daemon.begin_request()
+        assert not daemon.should_retire()
+        daemon.finish_request()
+        assert daemon.should_retire()
+    finally:
+        daemon.registry.close()
+
+
 # -- Compose project leases (#48) -------------------------------------------
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -365,9 +365,12 @@ def test_active_execution_session_pins_daemon_and_refuses_shutdown(tmp_path: Pat
         daemon.registry.close()
 
 
-def test_inflight_non_streaming_request_pins_daemon(tmp_path: Path) -> None:
+def test_inflight_non_streaming_request_pins_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     entered = threading.Event()
     release = threading.Event()
+    watchdog_checked = threading.Event()
     reply: list[dict[str, object]] = []
     daemon = Daemon(state_dir=tmp_path, idle_retire_seconds=0.1)
     daemon._set_next_maintenance(daemon.clock.now() + 3600)
@@ -381,6 +384,15 @@ def test_inflight_non_streaming_request_pins_daemon(tmp_path: Path) -> None:
         return {"ok": True}
 
     daemon.dispatch = blocking_dispatch  # type: ignore[method-assign]
+    original_should_retire = daemon.should_retire
+
+    def observed_should_retire() -> bool:
+        result = original_should_retire()
+        if entered.is_set() and not release.is_set():
+            watchdog_checked.set()
+        return result
+
+    monkeypatch.setattr(daemon, "should_retire", observed_should_retire)
     server = threading.Thread(target=daemon.serve_forever, daemon=True)
     server.start()
     try:
@@ -393,7 +405,7 @@ def test_inflight_non_streaming_request_pins_daemon(tmp_path: Path) -> None:
         )
         client.start()
         assert entered.wait(5), "GC handler never started"
-        time.sleep(0.4)
+        assert watchdog_checked.wait(5), "watchdog never checked retirement while GC was blocked"
         assert daemon_mod.is_serving(tmp_path), "watchdog retired an in-flight GC request"
         release.set()
         client.join(timeout=10)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -376,9 +376,11 @@ def test_inflight_non_streaming_request_pins_daemon(tmp_path: Path) -> None:
         original_send = ipc.send_response
         ipc.read_request = lambda _conn: {"auth": daemon.secret, "verb": "gc"}  # type: ignore[assignment]
         daemon.dispatch = lambda *_args: {"ok": True}  # type: ignore[method-assign]
+
         def send(_conn: object, response: dict[str, object]) -> None:
             assert not daemon.should_retire(), "watchdog must not retire during response"
             sent.append(response)
+
         ipc.send_response = send  # type: ignore[assignment]
         handler.handle()
         ipc.read_request = original_read  # type: ignore[assignment]


### PR DESCRIPTION
Fixes #141\n\nPrevents idle retirement while a validated non-streaming daemon request, including GC, is executing.\n\nFocused test: uv run --no-project pytest tests/test_daemon.py -k 'inflight_non_streaming_request_pins_daemon or active_execution_session_pins_daemon'.