### PR TITLE
fix(doctor): report an incomplete resource scan without crashing

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -432,6 +432,29 @@ def cmd_doctor(opts: Options) -> int:
     from bosn.resources import ResourceScanner
 
     scan = ResourceScanner(Engine(opts.engine)).scan(registry_id or "")
+    if scan.failed_kinds:
+        # #117: the engine answered the reachability probe and then took longer than the
+        # 60-second command deadline to list a kind -- the signature of a host with enough
+        # objects on it that diagnosis matters most. Everything printed above stands; the
+        # inventory does not, and it is reported as unknown rather than as an empty
+        # inventory. The foreign-registry report below is skipped for the same reason:
+        # `adopt --from-registry <id>` advice derived from a listing that never finished
+        # would be guidance built on absence of evidence.
+        scanned = ", ".join(sorted(scan.scanned_kinds)) or "none"
+        print(f"engine resource inventory: incomplete (scanned: {scanned})")
+        for kind, reason in sorted(scan.failed_kinds.items()):
+            print(f"  {kind}: could not be listed -- {reason}")
+        failed = ", ".join(sorted(scan.failed_kinds))
+        print(
+            f"engine resource inventory is incomplete: the engine is reachable but "
+            f"listing these kinds did not complete: {failed}. bosn cannot say what "
+            "exists on the engine. "
+            "Rerun `bosn doctor` once the engine is less loaded. No ownership or "
+            "foreign-registry conclusion is drawn from a partial scan, and nothing "
+            "was changed.",
+            file=sys.stderr,
+        )
+        return 1
     if scan.foreign_registries:
         _report_foreign_registries(scan, opts)
     return 1 if clock_unsafe else 0

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -376,6 +376,19 @@ class _Server(socketserver.ThreadingTCPServer):
         super().__init__(addr, _Handler)
 
 
+def _incomplete_scan_detail(scan: Any) -> str:
+    """One line naming every kind whose listing did not complete, and why.
+
+    `ResourceScanner.scan` stopped raising when a single kind's listing blows the engine
+    deadline (#117) so `doctor` can still report the three that worked. Everything else in
+    here wanted the old all-or-nothing failure: recovery and adoption compare the engine
+    against the registry, and a comparison against a listing that never finished is not
+    one either should act on. Each such caller checks `scan.failed_kinds` explicitly and
+    uses this for the message, rather than the absent exception.
+    """
+    return "; ".join(f"{kind}: {reason}" for kind, reason in sorted(scan.failed_kinds.items()))
+
+
 class Daemon:
     """The serving side. Owns the registry connection and the idle clock."""
 
@@ -458,6 +471,13 @@ class Daemon:
                 return
             prior_resources = self.registry.list_resources()
             scan = ResourceScanner(engine).scan(self.registry.registry_id)
+            if scan.failed_kinds:
+                # Same outcome the escaping `EngineError` used to produce, now stated:
+                # log why, repair nothing, retry on the next pass. An unreachable engine
+                # reaches this line rather than the `except` below, so without this the
+                # most common recovery failure would stop being recorded at all.
+                self.registry.log_event("recovery.scan.unavailable", _incomplete_scan_detail(scan))
+                return
             if self._stop.is_set():
                 return
             repaired = reconcile_owned(self.registry, scan, prior_resources=prior_resources)
@@ -1257,6 +1277,17 @@ class Daemon:
                 "registry_id": self.registry.registry_id,
             }
         scan = ResourceScanner(engine).scan("", kinds=["container", "volume", "image"])
+        if scan.failed_kinds:
+            # Adoption reads an empty foreign set as "nothing to recover" and then rewrites
+            # this registry's identity from what it did find. Neither conclusion survives a
+            # partial listing, so an incomplete scan is refused rather than acted on (#117).
+            return {
+                "ok": False,
+                "error": (
+                    "engine resource listing did not complete, so adoption evidence is "
+                    f"incomplete: {_incomplete_scan_detail(scan)}"
+                ),
+            }
         registries = scan.foreign_registries
         if not registries:
             return {"ok": True, "adopted": [], "registry_id": None}
@@ -1282,6 +1313,15 @@ class Daemon:
             }
         self.registry.set_meta("registry_id", registry_id)
         recovered = ResourceScanner(engine).scan(registry_id)
+        if recovered.failed_kinds:
+            return {
+                "ok": False,
+                "registry_id": registry_id,
+                "error": (
+                    "engine resource listing did not complete while recovering "
+                    f"{registry_id}; rerun adopt: {_incomplete_scan_detail(recovered)}"
+                ),
+            }
         names = adopt(self.registry, recovered)
         recompute_manifest_generations(self.registry, recovered)
         return {"ok": True, "adopted": names, "registry_id": registry_id}

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -172,6 +172,18 @@ class Collector:
         from bosn.recovery import plan_unproven_resource
 
         scan = self.scanner.scan(self.registry.registry_id)
+        if scan.failed_kinds:
+            # Same visibility rule as `gc.inventory_unmeasured` below, applied to the other
+            # half of the evidence: a kind whose listing did not complete contributes no
+            # `unlabeled` rows, so this pass's unproven-resource report is short for a
+            # reason that must be in the event log rather than inferred from its absence
+            # (#117). Collection itself is unaffected -- candidates come from registry rows,
+            # never from the scan -- so this records the gap instead of aborting the pass.
+            self.registry.log_event(
+                "gc.scan_incomplete",
+                "; ".join(f"{kind}: {reason}" for kind, reason in sorted(scan.failed_kinds.items()))
+                + "; unproven-resource reporting is incomplete this pass",
+            )
         inventory = StorageInventory.collect(self.engine)
         resource_rows = self.registry.list_resources()
         measured = {
@@ -602,6 +614,10 @@ def status(
         "by_reason": by_reason,
         "engine": scan.counts(),
         "scanned_kinds": sorted(scan.scanned_kinds),
+        # Non-empty means the engine did not finish listing that kind, so `engine` counts
+        # above are a floor, not a census (#117) -- the same fail-closed reporting #106
+        # established for an unmeasurable `docker system df -v`.
+        "failed_kinds": dict(sorted(scan.failed_kinds.items())),
         "unproven_resources": unproven_resources,
         "execution_sessions": execution_sessions,
         "foreign_registries": sorted(scan.foreign_registries),

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -139,6 +139,13 @@ class ScanResult:
     foreign: list[DiscoveredResource] = field(default_factory=list)
     unlabeled: list[DiscoveredResource] = field(default_factory=list)
     scanned_kinds: set[str] = field(default_factory=set)
+    # kind -> why its listing did not complete. The complement of `scanned_kinds`, carrying
+    # the reason rather than only the absence, because an enumeration failure is the one
+    # case where an empty bucket means "unknown" and not "none exist" (#117). Every
+    # consumer that acts on absence already gates on `scanned_kinds`; this exists so the
+    # ones that *report* -- doctor, gc's dry run -- can say which kind failed and why
+    # instead of silently showing a short inventory.
+    failed_kinds: dict[str, str] = field(default_factory=dict)
 
     @property
     def foreign_registries(self) -> set[str]:
@@ -210,19 +217,33 @@ def _name_of(kind: str, row: dict[str, object]) -> str:
     return str(row.get("Names") or row.get("Name") or row.get("ID", ""))
 
 
+def _listing_failure(args: list[str], outcome: str, stderr: str) -> str:
+    """One line naming the command that failed and, when Docker said why, its first line."""
+    detail = next((line.strip() for line in (stderr or "").splitlines() if line.strip()), "")
+    rendered = f"docker {' '.join(args)} {outcome}"
+    return f"{rendered}: {detail}" if detail else rendered
+
+
 class ResourceScanner:
     """Enumerates engine resources and sorts them by ownership proof."""
 
     def __init__(self, engine: Engine | None = None) -> None:
         self.engine = engine or Engine()
 
-    def _discover(self, kind: str) -> tuple[list[DiscoveredResource], bool]:
+    def _discover(self, kind: str) -> tuple[list[DiscoveredResource], str | None]:
+        """List one kind. The second element is ``None`` on success, else why it failed.
+
+        Only a *non-zero exit* is reported that way. A listing that never produced a
+        result at all -- a blown deadline, a spawn failure -- raises `EngineError` out of
+        `Engine.run` and keeps doing so here, because `discover()` has nowhere to put a
+        reason; `scan()` is the caller that turns it into a failed kind (#117).
+        """
         args = _LIST_COMMANDS.get(kind)
         if args is None:
             raise ValueError(f"cannot enumerate unknown kind {kind!r}")
         result = self.engine.run(args)
         if not result.ok:
-            return [], False
+            return [], _listing_failure(args, f"exited {result.returncode}", result.stderr)
 
         # Two passes rather than one: the list format truncates labels for some kinds, and
         # confirming a truncated-looking row used to mean "call `inspect_labels` right here,
@@ -259,11 +280,11 @@ class ResourceScanner:
             if not labels.is_complete(raw):
                 raw = confirmed.get(name) or raw
             discovered.append(DiscoveredResource(kind=kind, name=name, raw_labels=raw))
-        return discovered, True
+        return discovered, None
 
     def discover(self, kind: str) -> list[DiscoveredResource]:
         """List one kind; callers needing safety metadata should use :meth:`scan`."""
-        discovered, _success = self._discover(kind)
+        discovered, _failure = self._discover(kind)
         return discovered
 
     def inspect_labels(self, kind: str, name: str) -> dict[str, str]:
@@ -340,11 +361,27 @@ class ResourceScanner:
         return recovered
 
     def scan(self, registry_id: str, kinds: list[str] | None = None) -> ScanResult:
+        """Enumerate every kind, bucketed by ownership proof, plus what could not be read.
+
+        One kind failing does not abandon the rest. A resource-heavy host is exactly where
+        `docker images` blows the 60-second engine deadline (#117) and also exactly where
+        the remaining diagnosis is worth the most, so the `EngineError` becomes a recorded
+        failed kind instead of an exception that discards three good listings. The kind is
+        deliberately kept out of `scanned_kinds`: every decision that reads absence as
+        removal gates on that set, so a failed kind stays invisible to it rather than
+        turning "could not list" into "no longer exists".
+        """
         scan = ScanResult()
         for kind in kinds or list(_LIST_COMMANDS):
-            discovered, success = self._discover(kind)
-            if success:
+            try:
+                discovered, failure = self._discover(kind)
+            except EngineError as exc:
+                scan.failed_kinds[kind] = str(exc)
+                continue
+            if failure is None:
                 scan.scanned_kinds.add(kind)
+            else:
+                scan.failed_kinds[kind] = failure
             for resource in discovered:
                 if not resource.complete:
                     scan.unlabeled.append(resource)

--- a/tests/test_accounting_pressure.py
+++ b/tests/test_accounting_pressure.py
@@ -140,3 +140,34 @@ def test_a_successful_measurement_over_ceiling_still_evicts_exactly_as_before(
     assert result.removed == ["cache"]
     report = status(registry, engine, config=config)  # type: ignore[arg-type]
     assert report["pressure"]["bytes_unknown"] is False
+
+
+def test_an_incomplete_resource_scan_is_logged_as_an_event(registry: Registry, monkeypatch) -> None:
+    """#117: a listing that did not complete makes the unproven report short, not empty."""
+    from bosn.resources import ScanResult
+
+    add(registry)
+    engine = failing_df_engine()
+    monkeypatch.setattr(
+        "bosn.resources.ResourceScanner.scan",
+        lambda _self, _registry_id, **_kwargs: ScanResult(
+            scanned_kinds={"container", "network", "volume"},
+            failed_kinds={"image": "docker images --no-trunc exceeded its 60-second deadline"},
+        ),
+    )
+
+    Collector(registry, engine).collect(dry_run=True)  # type: ignore[arg-type]
+
+    events = [row for row in registry.events() if row["kind"] == "gc.scan_incomplete"]
+    assert events, "a short inventory must say why it is short"
+    assert "image" in str(events[0]["detail"])
+
+
+def test_a_complete_resource_scan_never_logs_the_incomplete_event(registry: Registry) -> None:
+    """Regression guard for the event itself: a healthy scan must stay silent."""
+    add(registry)
+
+    Collector(registry, failing_df_engine()).collect(dry_run=True)  # type: ignore[arg-type]
+
+    kinds = [row["kind"] for row in registry.events()]
+    assert "gc.scan_incomplete" not in kinds

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -1203,6 +1203,127 @@ def test_doctor_foreign_registry_wording_never_claims_dead_or_safe_to_delete(
         assert forbidden not in err, f"doctor must not claim foreign resources are {forbidden!r}"
 
 
+def _stub_engine_with_a_timing_out_listing(monkeypatch, *, foreign_volumes: int = 0):
+    """A reachable engine whose `docker images` blows its deadline, as #117 reported it.
+
+    Deliberately not a stubbed `ResourceScanner`: the whole bug is that the real scanner
+    lets `EngineError` escape `scan()`, so the test has to drive the real scanner and fail
+    at the engine boundary the way a loaded Docker Desktop host does. Returns the recorded
+    command list so a test can prove the failure path stayed read-only.
+    """
+    from bosn import labels
+    from bosn.engine import EngineError, EngineInfo, EngineResult
+
+    commands: list[list[str]] = []
+
+    def _foreign_row(index: int) -> str:
+        raw = labels.ResourceLabels(
+            registry="lost-registry",
+            kind="volume",
+            stack="dev",
+            generation="digest",
+            scope="spec",
+            workspace="workspace",
+            created="2026-01-01T00:00:00Z",
+        ).to_dict()
+        return json.dumps({"Name": f"warm-cache-{index}", "Labels": json.dumps(raw)})
+
+    class TimingOutEngine:
+        def __init__(self, binary: str = "docker") -> None:
+            self.binary = binary
+
+        def info(self):
+            return EngineInfo(
+                binary=self.binary,
+                reachable=True,
+                client_version="28.5.1",
+                server_version="28.5.1",
+                clock_skew_seconds=0.0,
+            )
+
+        def run(self, args, *, check: bool = False, timeout: float | None = None):
+            commands.append(list(args))
+            if args[0] == "images":
+                raise EngineError(
+                    "docker images --no-trunc --format {{json .}} exceeded its 60-second deadline"
+                )
+            if args[0] == "volume":
+                rows = [_foreign_row(i) for i in range(foreign_volumes)]
+                return EngineResult(0, "\n".join(rows), "")
+            return EngineResult(0, "", "")
+
+    monkeypatch.setattr(cli, "Engine", TimingOutEngine)
+    return commands
+
+
+def test_doctor_reports_an_incomplete_inventory_instead_of_a_traceback(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """#117: only the resource-inventory phase failed, so only that phase may be lost."""
+    import hashlib
+
+    from bosn.registry import Registry
+
+    with Registry(tmp_path / "registry.sqlite3") as registry:
+        registry.register_resource(
+            kind="volume",
+            name="warm-cache",
+            stack="dev",
+            generation="digest",
+            scope="stack",
+            workspace="workspace",
+        )
+    database = tmp_path / "registry.sqlite3"
+    before = hashlib.sha256(database.read_bytes()).hexdigest()
+    commands = _stub_engine_with_a_timing_out_listing(monkeypatch)
+
+    code = cli.main(["--state-dir", str(tmp_path), "doctor"])
+
+    assert code == 1, "a partial scan must never read as a healthy engine"
+    captured = capsys.readouterr()
+    # Everything doctor had already established stays on the report.
+    assert "client version: 28.5.1" in captured.out
+    assert "registry integrity: ok" in captured.out
+    assert "docker shims:" in captured.out
+    # ...and the phase that failed says so, naming the kind and the reason.
+    assert "engine resource inventory: incomplete" in captured.out
+    assert "image" in captured.out
+    assert "60-second deadline" in captured.out
+    assert "Traceback" not in captured.err
+    assert "EngineError" not in captured.err
+    # Read-only: no engine mutation, no registry mutation.
+    assert not [c for c in commands if {"rm", "prune", "rmi", "kill", "stop"} & set(c)]
+    assert hashlib.sha256(database.read_bytes()).hexdigest() == before
+
+
+def test_doctor_withholds_adoption_guidance_when_the_scan_is_incomplete(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """Absence of evidence is not evidence of absence: half a scan cannot advise adoption."""
+    _stub_engine_with_a_timing_out_listing(monkeypatch, foreign_volumes=3)
+
+    code = cli.main(["--state-dir", str(tmp_path), "doctor"])
+
+    assert code == 1
+    captured = capsys.readouterr()
+    assert "adopt --from-registry" not in captured.err
+    assert "adopt --from-registry" not in captured.out
+    assert "incomplete" in captured.out
+
+
+def test_doctor_json_reports_an_incomplete_scan_as_one_envelope(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _stub_engine_with_a_timing_out_listing(monkeypatch)
+
+    assert cli.main(["--json", "--state-dir", str(tmp_path), "doctor"]) == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["code"] == "command.failed"
+    assert "engine resource inventory: incomplete" in payload["message"]
+
+
 def test_gc_reports_invalid_policy_without_a_traceback(monkeypatch, tmp_path, capsys) -> None:
     monkeypatch.setenv("BOSN_WARM_VOLUME_TTL", "not-a-number")
     assert cli.main(["--state-dir", str(tmp_path), "gc"]) == 1

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2041,6 +2041,84 @@ def test_startup_reconciliation_repairs_remove_before_registry_crash(
         daemon.registry.close()
 
 
+def test_startup_reconciliation_declines_to_repair_from_an_incomplete_scan(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#117 made `scan()` return partial truth; recovery must not mistake it for total truth.
+
+    The removal-repair test above proves a row whose object is gone gets dropped. That
+    inference is only valid when the listing actually ran: here the kind's listing timed
+    out, so the identical-looking empty scan must repair nothing and say why instead.
+    """
+    from bosn.resources import ScanResult
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            return ScanResult(failed_kinds={"volume": "docker volume ls exceeded its deadline"})
+
+    import bosn.engine
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    monkeypatch.setattr(bosn.engine, "Engine", lambda *a, **k: _StubEngine())
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        row = daemon.registry.register_resource(
+            kind="volume",
+            name="warm-cache",
+            stack="dev",
+            generation="digest",
+            scope="spec",
+            workspace="workspace",
+        )
+        daemon._reconcile_startup_resources()
+
+        assert daemon.registry.get_resource(row.id) is not None
+        events = [event for event in daemon.registry.events()]
+        unavailable = [e for e in events if e["kind"] == "recovery.scan.unavailable"]
+        assert unavailable, "an unrepairable pass must still record why"
+        assert "volume" in str(unavailable[0]["detail"])
+        assert not [e for e in events if e["kind"] == "recovery.startup"]
+    finally:
+        daemon.registry.close()
+
+
+def test_adopt_refuses_an_incomplete_scan_instead_of_reporting_nothing_to_adopt(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """An empty foreign set from a listing that never finished is not evidence (#117)."""
+    from bosn.resources import ScanResult
+
+    class Scanner:
+        def __init__(self, _engine) -> None:
+            pass
+
+        def scan(self, registry_id: str, **_kwargs):
+            return ScanResult(
+                scanned_kinds={"container", "volume"},
+                failed_kinds={"image": "docker images --no-trunc exceeded its deadline"},
+            )
+
+    import bosn.resources
+
+    monkeypatch.setattr(bosn.resources, "ResourceScanner", Scanner)
+    daemon = Daemon(state_dir=tmp_path)
+    try:
+        original = daemon.registry.registry_id
+        reply = daemon._verb_adopt({"engine": "docker"})
+
+        assert not reply["ok"]
+        assert "incomplete" in str(reply["error"])
+        assert "image" in str(reply["error"])
+        assert reply.get("adopted") is None, "a refusal must not also report an adoption"
+        assert daemon.registry.registry_id == original
+    finally:
+        daemon.registry.close()
+
+
 def test_startup_reconciliation_is_idempotent(monkeypatch, tmp_path: Path) -> None:
     """Mirrors the prune_dead_leases idempotency test: a second pass repairs nothing."""
     from bosn import labels

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -17,7 +17,7 @@ import pytest
 
 from bosn import labels, resources
 from bosn.clock import FakeClock
-from bosn.engine import EngineResult
+from bosn.engine import EngineError, EngineResult
 from bosn.registry import Registry
 from bosn.resources import DiscoveredResource, ResourceScanner, ScanResult
 
@@ -1010,3 +1010,97 @@ def test_explicit_volume_transfer_refuses_an_attached_volume(registry: Registry)
     resource = DiscoveredResource("volume", "foreign-cache", label_dict(registry=THEIRS))
     with pytest.raises(resources.TransferError, match="attached"):
         resources.transfer_volume(registry, AttachedEngine(), resource)  # type: ignore[arg-type]
+
+
+# -- incomplete scans (#117) -------------------------------------------------
+
+
+class _KindFailingEngine(FakeEngine):
+    """A `FakeEngine` whose listing for one kind fails the way a loaded host fails.
+
+    Two shapes, because `_discover` sees them through different channels and #117 was
+    only ever reported for the second: a non-zero exit (`fail_exit`) comes back as an
+    `EngineResult`, while a deadline overrun or a spawn failure (`fail_timeout`) is
+    raised as `EngineError` out of `Engine.run` and never reaches the return value.
+    """
+
+    def __init__(
+        self,
+        listings: dict[str, list[dict]],
+        *,
+        fail_timeout: str | None = None,
+        fail_exit: str | None = None,
+    ) -> None:
+        super().__init__(listings)
+        self.fail_timeout = fail_timeout
+        self.fail_exit = fail_exit
+
+    def run(
+        self, args: list[str], *, check: bool = False, timeout: float | None = None
+    ) -> EngineResult:
+        kind = _LISTING_KINDS.get(args[0])
+        if kind is not None and kind == self.fail_timeout:
+            self.commands.append(list(args))
+            raise EngineError(
+                f"docker {' '.join(args)} exceeded its 60-second deadline",
+            )
+        if kind is not None and kind == self.fail_exit:
+            self.commands.append(list(args))
+            return EngineResult(1, "", "Cannot connect to the Docker daemon")
+        return super().run(args, check=check, timeout=timeout)
+
+
+_LISTING_KINDS = {"ps": "container", "volume": "volume", "images": "image", "network": "network"}
+
+
+def test_a_timed_out_listing_is_a_failed_kind_not_an_empty_one() -> None:
+    """#117: `docker images` blowing its deadline must not read as "no images exist"."""
+    engine = _KindFailingEngine(
+        {"volume": [{"Name": "ours", "Labels": json.dumps(label_dict())}]},
+        fail_timeout="image",
+    )
+
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume", "image"])  # type: ignore[arg-type]
+
+    assert [r.name for r in scan.owned] == ["ours"]
+    assert scan.scanned_kinds == {"volume"}
+    assert set(scan.failed_kinds) == {"image"}
+    assert "60-second deadline" in scan.failed_kinds["image"]
+
+
+def test_a_non_zero_listing_exit_is_reported_as_a_failed_kind() -> None:
+    """The pre-existing `([], False)` path gains the reason it never carried."""
+    engine = _KindFailingEngine({}, fail_exit="volume")
+
+    scan = ResourceScanner(engine).scan(OURS, kinds=["volume"])  # type: ignore[arg-type]
+
+    assert scan.scanned_kinds == set()
+    assert set(scan.failed_kinds) == {"volume"}
+    assert "Cannot connect to the Docker daemon" in scan.failed_kinds["volume"]
+
+
+def test_a_failed_kind_never_prunes_previously_registered_rows(tmp_path: Path) -> None:
+    """`reconcile_owned` deletes rows for kinds it *scanned*; a failed kind is not one."""
+    with Registry(tmp_path / "registry.sqlite3") as registry:
+        resource = registry.register_resource(
+            kind="image",
+            name="bosn-dev-image",
+            stack="dev",
+            generation="sha256:abc",
+            scope="stack",
+            workspace="/w",
+        )
+        engine = _KindFailingEngine({}, fail_timeout="image")
+        scan = ResourceScanner(engine).scan(registry.registry_id, kinds=["image"])  # type: ignore[arg-type]
+
+        resources.reconcile_owned(registry, scan, prior_resources=[resource])
+
+        assert [r.name for r in registry.list_resources()] == ["bosn-dev-image"]
+
+
+def test_discover_still_raises_so_callers_outside_scan_are_unchanged() -> None:
+    """`discover()` has no channel for partial truth; it must keep failing loudly."""
+    engine = _KindFailingEngine({}, fail_timeout="image")
+
+    with pytest.raises(EngineError):
+        ResourceScanner(engine).discover("image")  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #117.

## The bug

On a loaded Docker Desktop host, `docker images --no-trunc --format "{{json .}}"` exceeded `Engine.DEFAULT_TIMEOUT`. `Engine.run` correctly raised `EngineError`, but nothing between there and `main` caught it: it escaped `ResourceScanner._discover` -> `scan()` -> `cmd_doctor` as a traceback. Doctor had already printed engine reachability/version, clock skew, scheduler state, registry integrity, and shim status -- all of it lost to the stack trace, on precisely the resource-heavy host where the diagnosis was needed.

## The fix

`ScanResult` gains `failed_kinds` (kind -> why its listing did not complete), the complement of the existing `scanned_kinds`. `scan()` records a failed kind instead of abandoning the kinds that did list; a non-zero listing exit, which previously collapsed to a bare `([], False)`, now carries its reason too.

The failed kind is deliberately kept **out** of `scanned_kinds`, so every decision that reads absence as removal (`reconcile_owned`'s prune path) continues to skip it. "Could not list" never becomes "no longer exists".

`bosn doctor` then:

- keeps every diagnostic it had already completed;
- prints which kinds it did scan and, per failed kind, the command and the reason;
- exits 1, so automation cannot mistake a partial scan for a healthy engine;
- withholds foreign-registry adoption guidance -- `adopt --from-registry <id>` derived from a listing that never finished is advice built on absence of evidence;
- stays read-only: no registry writes, no engine mutation.

`--json` needs no new code: the existing envelope adapter turns the non-zero exit into one parseable failure object.

## Blast radius

`scan()` no longer raising would have silently degraded three other callers, so each keeps the old all-or-nothing behavior explicitly:

- **startup reconciliation** logs `recovery.scan.unavailable` and repairs nothing (an unreachable engine now reaches this check rather than the `except EngineError` below it, so without this the most common recovery failure would have stopped being recorded);
- **`adopt`** refuses an incomplete scan rather than reporting "nothing to adopt" and rewriting the registry identity from partial evidence;
- **`gc`** logs `gc.scan_incomplete`, matching the `gc.inventory_unmeasured` precedent from #106, so a short unproven-resource report says why it is short. Collection itself is unaffected -- candidates come from registry rows, never from the scan.

`discover()` still raises; callers outside `scan()` are unchanged.

## Verification

10 new tests, all confirmed RED against the pre-fix source and GREEN after. Full suite: 1104 passed, 8 skipped. `ci/lint.py`: ruff format, ruff check, pyright, lint_kbi all clean.

Reproduced end-to-end against a real engine with a `docker` wrapper that sleeps past the deadline on `images`:

```
$ bosn --engine ./slow-docker doctor ; echo exit=$?
engine binary:  ./slow-docker
client version: 28.0.4
server version: 28.0.4
reachable:      yes
clock skew:     +0.027s
...
engine resource inventory: incomplete (scanned: container, network, volume)
  image: could not be listed -- ./slow-docker images --no-trunc --format {{json .}} exceeded its 60-second deadline
engine resource inventory is incomplete: the engine is reachable but listing these
kinds did not complete: image. bosn cannot say what exists on the engine. Rerun
`bosn doctor` once the engine is less loaded. No ownership or foreign-registry
conclusion is drawn from a partial scan, and nothing was changed.
exit=1
```

and in JSON mode, one object on stdout, nothing on stderr, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RfGTwB7LCyTfC6jXvyKiv
