### PR TITLE
fix(daemon): explain a closed stream with bounded control-plane diagnostics

### DIFF
--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -886,7 +886,12 @@ def cmd_run(opts: Options) -> int:
         print(str(exc), file=sys.stderr)
         return exc.exit_code
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:  # fail closed, stay visible
+        # A closed stream is the one failure the client genuinely cannot explain from the
+        # exception alone -- #134 reports exactly this message with nothing behind it. The
+        # diagnostics are bounded and secret-free, so printing them here cannot turn a
+        # failed command into a hung one.
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        print(daemon_mod.control_diagnostics(opts.state_dir), file=sys.stderr)
         return 1
     except (ManifestError, EngineError, ConfigError) as exc:
         print(str(exc), file=sys.stderr)
@@ -915,6 +920,7 @@ def cmd_attach(opts: Options) -> int:
         return exc.exit_code
     except (daemon_mod.DaemonError, ipc.TransportError) as exc:
         print(f"cannot reach the bosn daemon: {exc}", file=sys.stderr)
+        print(daemon_mod.control_diagnostics(opts.state_dir), file=sys.stderr)
         return 1
     print(f"job {job_id} succeeded", file=sys.stderr)
     return 0
@@ -988,6 +994,24 @@ def _persisted_execution_sessions(registry, *, daemon_control_available: bool) -
             }
         )
     return sessions
+
+
+def _recorded_daemon(state_dir) -> dict[str, object] | None:
+    """The daemon's own last self-report, for the branch where it cannot be asked."""
+    from bosn import daemon as daemon_mod
+    from bosn.resources import process_alive
+
+    state = daemon_mod.recorded_state(state_dir)
+    if state is None:
+        return None
+    return {
+        "pid": state.pid,
+        "port": state.port,
+        "version": state.version,
+        "process_alive": process_alive(state.pid),
+        "client_version": __version__,
+        "version_skew": state.version != __version__,
+    }
 
 
 def cmd_status(opts: Options) -> int:
@@ -1071,6 +1095,13 @@ def cmd_status(opts: Options) -> int:
                         "reachable": False,
                         "error": daemon_error,
                         "status_timeout_seconds": STATUS_DAEMON_TIMEOUT_SECONDS,
+                        # An unreachable daemon is exactly when its identity matters most:
+                        # a version-skew refusal names a daemon version the client can
+                        # otherwise only learn from a daemon that answers (#134). This is
+                        # what the daemon last recorded about itself, marked as such --
+                        # `recorded` never claims the process is serving, only that it
+                        # wrote this and whether that pid still exists.
+                        "recorded": _recorded_daemon(opts.state_dir),
                     },
                     "next": (
                         "the daemon control channel is unavailable, so do not run `bosn "

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -1830,6 +1830,95 @@ def _startup_diagnostics(state_dir: Path, *, limit: int = 8192) -> str:
     )
 
 
+# The bounded diagnostic's own ceiling. Everything it reads is either instant (a small
+# file, a pid liveness test) or already deadlined, and its single network call reuses
+# `is_serving`'s ping with this budget. Named rather than inlined so "this must never
+# become another hang" is a checkable promise instead of an implied one (#134).
+CONTROL_DIAGNOSTIC_PING_TIMEOUT_SECONDS = 2.0
+
+
+def recorded_state(state_dir: Path | None = None) -> DaemonState | None:
+    """What the daemon last wrote about itself, believed or not.
+
+    `running_state` deliberately answers "is a daemon serving", and *deletes* the file when
+    the answer is no. That is right for spawn/stop decisions and useless for a post-mortem:
+    the moment worth diagnosing is exactly the one where a daemon recorded itself and then
+    stopped answering. This reads the same file and draws no conclusion from it.
+    """
+    return DaemonState.read(state_file(state_dir or default_state_dir()))
+
+
+def control_diagnostics(state_dir: Path | None = None, *, limit: int = 2048) -> str:
+    """A bounded, secret-free account of the control plane for a failure the client cannot explain.
+
+    "daemon closed the stream before the job ended" states what happened and nothing about
+    why. #134 reports precisely that: a state directory holding a heartbeat, a registry, a
+    secret, and an *empty* startup log, with no bounded diagnostic connecting any of it to
+    the closed stream -- and, one command later, a version-skew refusal naming a daemon
+    version the client had no other way to see.
+
+    So this reports what the daemon recorded about itself (including its version, beside
+    this client's), whether that process still exists, whether its port still answers, how
+    stale its heartbeat is, and the tail of its startup log.
+
+    Two properties this must keep, because it only ever runs on a failure path:
+
+    - It never raises. A diagnostic that can fail would replace a bad message with none.
+    - It never carries the daemon secret. The secret file is not read here, and the startup
+      tail goes through `_startup_diagnostics`' redaction.
+    """
+    state_dir = state_dir or default_state_dir()
+    lines = [f"control-plane diagnostics (client version {__version__}):"]
+
+    try:
+        recorded = recorded_state(state_dir)
+    except KeyboardInterrupt:
+        raise
+    except Exception:  # noqa: BLE001 - a diagnostic may not fail
+        lines.append("  recorded daemon: unreadable")
+    else:
+        if recorded is None:
+            lines.append("  recorded daemon: none (no daemon has recorded itself here)")
+        else:
+            try:
+                from bosn.resources import process_alive
+
+                alive = "alive" if process_alive(recorded.pid) else "absent"
+            except KeyboardInterrupt:
+                raise
+            except Exception:  # noqa: BLE001 - a diagnostic may not fail
+                alive = "unknown"
+            lines.append(
+                f"  recorded daemon: version={recorded.version} pid={recorded.pid} "
+                f"(process {alive}) port={recorded.port}"
+            )
+            if recorded.version != __version__:
+                lines.append(
+                    f"  version skew: this client is {__version__}; restart the daemon "
+                    "before destructive use"
+                )
+
+    try:
+        answered = is_serving(state_dir, timeout=CONTROL_DIAGNOSTIC_PING_TIMEOUT_SECONDS)
+        lines.append(
+            f"  control port: {'answering' if answered else 'not answering'} "
+            f"(probed for {CONTROL_DIAGNOSTIC_PING_TIMEOUT_SECONDS:g}s)"
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception:  # noqa: BLE001 - a diagnostic may not fail
+        lines.append("  control port: probe failed")
+
+    try:
+        beat = heartbeat_file(state_dir).stat().st_mtime
+        lines.append(f"  heartbeat: {max(0.0, time.time() - beat):.0f}s old")
+    except OSError:
+        lines.append("  heartbeat: never written")
+
+    lines.append(f"  startup log: {_startup_diagnostics(state_dir, limit=limit)}")
+    return "\n".join(lines)
+
+
 def _detach(state_dir: Path) -> int:
     """Start a detached `bosn __daemon`.
 

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -1512,3 +1512,154 @@ def test_init_help_lists_the_compose_and_output_flags(capsys) -> None:
     out = capsys.readouterr().out
     assert "--compose" in out
     assert "--output" in out
+
+
+def test_run_explains_a_closed_stream_instead_of_only_asserting_it(tmp_path, monkeypatch, capsys):
+    """#134: `daemon closed the stream before the job ended` said nothing about why.
+
+    The reporter was left with a state directory holding a heartbeat, a registry, a secret
+    and an empty startup log, and no bounded diagnostic tying any of it to the failure.
+    """
+    from bosn import daemon as daemon_mod
+
+    manifest = tmp_path / "bosn.toml"
+    manifest.write_text("[stack.linux]\nimage = 'alpine:3.20'\n", encoding="utf-8")
+    daemon_mod.DaemonState(
+        pid=999_999, port=daemon_mod.port_for(tmp_path), started_at=1.0, version="0.0.1-old"
+    ).write(daemon_mod.state_file(tmp_path))
+
+    def closed_stream(*_args, **_kwargs):
+        raise ipc.TransportError("daemon closed the stream before the job ended")
+
+    monkeypatch.setattr(daemon_mod, "stream", closed_stream)
+    monkeypatch.setattr(daemon_mod, "request", closed_stream)
+
+    code = cli.main(
+        [
+            "--state-dir",
+            str(tmp_path),
+            "--manifest",
+            str(manifest),
+            "run",
+            "--stack",
+            "linux",
+            "true",
+        ]
+    )
+
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "daemon closed the stream before the job ended" in err
+    assert "control-plane diagnostics" in err
+    assert "version=0.0.1-old" in err, "the daemon version the client could not otherwise see"
+    assert "process absent" in err
+    assert "version skew" in err
+
+
+def test_degraded_status_reports_the_daemon_identity_it_could_not_reach(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """A skew refusal names a daemon version; `status` must be able to name it too (#134)."""
+    from bosn import daemon as daemon_mod
+    from bosn.registry import Registry
+
+    with Registry(tmp_path / "registry.sqlite3"):
+        pass
+    daemon_mod.DaemonState(
+        pid=999_999, port=daemon_mod.port_for(tmp_path), started_at=1.0, version="0.0.1-old"
+    ).write(daemon_mod.state_file(tmp_path))
+    monkeypatch.setattr(
+        daemon_mod,
+        "request",
+        lambda *a, **k: (_ for _ in ()).throw(ipc.TransportTimeout("no answer")),
+    )
+
+    assert cli.main(["--state-dir", str(tmp_path), "status"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    recorded = payload["daemon"]["recorded"]
+    assert payload["daemon"]["reachable"] is False
+    assert recorded["version"] == "0.0.1-old"
+    assert recorded["pid"] == 999_999
+    assert recorded["process_alive"] is False
+    assert recorded["version_skew"] is True
+    assert recorded["client_version"] == cli.__version__
+
+
+def test_status_reports_no_recorded_daemon_rather_than_inventing_one(tmp_path, monkeypatch, capsys):
+    """An empty state directory must read as "none", never as a daemon with unknown fields."""
+    from bosn import daemon as daemon_mod
+    from bosn.registry import Registry
+
+    with Registry(tmp_path / "registry.sqlite3"):
+        pass
+    monkeypatch.setattr(
+        daemon_mod,
+        "request",
+        lambda *a, **k: (_ for _ in ()).throw(daemon_mod.DaemonError("no bosn daemon is running")),
+    )
+
+    assert cli.main(["--state-dir", str(tmp_path), "status"]) == 0
+
+    assert json.loads(capsys.readouterr().out)["daemon"]["recorded"] is None
+
+
+def test_status_stays_bounded_against_a_listener_that_never_answers(tmp_path, capsys) -> None:
+    """#134's other half: after the restart attempt, control commands hung past 30 seconds.
+
+    A *closed* port fails instantly and proves nothing. The failure mode that hangs is a
+    socket that accepts the connection and then says nothing -- a wedged daemon, or a
+    half-started one -- so this test is the accepting-and-silent listener, and it asserts
+    on the wall clock rather than on a constant. Anything that reintroduces an unbounded
+    control-plane read fails here regardless of which timeout it forgot.
+    """
+    import socket
+    import threading
+    import time as _time
+
+    from bosn import daemon as daemon_mod
+    from bosn.registry import Registry
+
+    with Registry(tmp_path / "registry.sqlite3"):
+        pass
+    daemon_mod.DaemonState(
+        pid=999_999, port=daemon_mod.port_for(tmp_path), started_at=1.0, version="0.0.1-old"
+    ).write(daemon_mod.state_file(tmp_path))
+
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", daemon_mod.port_for(tmp_path)))
+    listener.listen(8)
+    held: list[socket.socket] = []
+    stop = threading.Event()
+
+    def accept_and_say_nothing() -> None:
+        listener.settimeout(0.2)
+        while not stop.is_set():
+            try:
+                conn, _ = listener.accept()
+            except (TimeoutError, OSError):
+                continue
+            held.append(conn)  # deliberately never written to
+
+    accepter = threading.Thread(target=accept_and_say_nothing, daemon=True)
+    accepter.start()
+    try:
+        started = _time.monotonic()
+        code = cli.main(["--state-dir", str(tmp_path), "status"])
+        elapsed = _time.monotonic() - started
+    finally:
+        stop.set()
+        accepter.join(timeout=5)
+        for conn in held:
+            conn.close()
+        listener.close()
+
+    assert code == 0
+    assert elapsed < 15.0, f"status must stay bounded against a silent daemon; took {elapsed:.1f}s"
+    payload = json.loads(capsys.readouterr().out)
+    # A listener that accepts and never answers is a *degraded* control plane, not an
+    # absent one -- and the recorded identity is what makes it diagnosable.
+    assert payload["mode"] == "degraded"
+    assert payload["daemon"]["reachable"] is False
+    assert payload["daemon"]["recorded"]["version"] == "0.0.1-old"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2476,3 +2476,83 @@ def test_real_detached_spawn_and_autostart(tmp_path: Path) -> None:
         assert daemon_mod.request("status", tmp_path)["pid"] == state.pid
     finally:
         assert daemon_mod.stop(tmp_path, timeout=30)
+
+
+# -- bounded control-plane diagnostics (#134) --------------------------------
+
+
+def test_control_diagnostics_explain_a_daemon_that_recorded_itself_and_stopped_answering(
+    tmp_path: Path,
+) -> None:
+    """The #134 shape: a state directory that proves a daemon existed and nothing else.
+
+    "daemon closed the stream before the job ended" is the whole message the reporter got.
+    Each fact asserted here is one the operator had no way to obtain: which version the
+    daemon was, whether its process still exists, and whether its port still answers.
+    """
+    daemon_mod.DaemonState(
+        pid=999_999, port=daemon_mod.port_for(tmp_path), started_at=1.0, version="0.1.3"
+    ).write(daemon_mod.state_file(tmp_path))
+
+    report = daemon_mod.control_diagnostics(tmp_path)
+
+    assert "version=0.1.3" in report
+    assert "pid=999999" in report
+    assert "process absent" in report, "a recorded pid that is gone must be reported as gone"
+    assert "not answering" in report
+    assert "heartbeat: never written" in report
+    assert daemon_mod.__version__ in report, "the client version belongs beside the daemon's"
+
+
+def test_control_diagnostics_name_version_skew_without_a_reachable_daemon(tmp_path: Path) -> None:
+    """A skew refusal names a daemon version; nothing else could tell the operator it."""
+    daemon_mod.DaemonState(
+        pid=os.getpid(), port=daemon_mod.port_for(tmp_path), started_at=1.0, version="0.0.1-old"
+    ).write(daemon_mod.state_file(tmp_path))
+
+    report = daemon_mod.control_diagnostics(tmp_path)
+
+    assert "version skew" in report
+    assert "0.0.1-old" in report
+    assert "process alive" in report, "this test's own pid is alive; the probe must say so"
+
+
+def test_control_diagnostics_never_leak_the_daemon_secret(tmp_path: Path) -> None:
+    """It runs on a failure path whose output lands in terminals and bug reports."""
+    secret = "s3cr3t-daemon-token-that-must-never-be-printed"
+    daemon_mod.secret_file(tmp_path).write_text(secret, encoding="utf-8")
+    log = daemon_mod.startup_log_file(tmp_path)
+    log.write_text(f"Traceback...\nsecret={secret}\napi_key={secret}\n", encoding="utf-8")
+
+    report = daemon_mod.control_diagnostics(tmp_path)
+
+    assert secret not in report
+    assert "<redacted>" in report
+    assert "Traceback" in report, "redaction must not cost the diagnostic its content"
+
+
+def test_control_diagnostics_are_bounded_and_never_raise(tmp_path: Path, monkeypatch) -> None:
+    """A diagnostic that can hang or fail replaces a bad message with no message at all."""
+    missing = tmp_path / "not-a-directory"
+
+    def exploding_state(_state_dir=None):
+        raise OSError("state file is on a disconnected volume")
+
+    monkeypatch.setattr(daemon_mod, "recorded_state", exploding_state)
+    started = time.monotonic()
+    report = daemon_mod.control_diagnostics(missing)
+    elapsed = time.monotonic() - started
+
+    assert "unreadable" in report
+    assert "control port:" in report, "one unreadable fact must not abandon the rest"
+    assert elapsed < 10.0, f"diagnostics must stay bounded; took {elapsed:.1f}s"
+
+
+def test_recorded_state_does_not_delete_what_it_reads(tmp_path: Path) -> None:
+    """`running_state` unlinks a stale file; a post-mortem must not destroy its evidence."""
+    path = daemon_mod.state_file(tmp_path)
+    daemon_mod.DaemonState(pid=999_999, port=1234, started_at=1.0, version="0.1.3").write(path)
+
+    assert daemon_mod.recorded_state(tmp_path) is not None
+    assert daemon_mod.recorded_state(tmp_path) is not None, "reading it twice must be possible"
+    assert path.exists()


### PR DESCRIPTION
Progresses #134. **Deliberately does not close it** — see "What this does not do".

## The gap

#134 reports `bosn run --task fmt` failing twice with:

```
cannot reach the bosn daemon: daemon closed the stream before the job ended
```

against a state directory holding a heartbeat, a SQLite registry, a daemon secret, and an *empty* `daemon-startup.log`. In the reporter's words: "there is no bounded diagnostic explaining the closed stream or hang." One command later, a version-skew refusal named `daemon=0.1.3` — a fact the client had no other way to obtain.

`_startup_diagnostics` already existed but was reachable only from a failed *spawn*. Nothing surfaced it when a daemon that had started fine later stopped answering, which is the reported case.

## What this adds

`daemon.control_diagnostics(state_dir)` — bounded, secret-free, never raises:

```
$ bosn --state-dir ... attach j1-nope
cannot reach the bosn daemon: no bosn daemon is running
control-plane diagnostics (client version 0.1.3):
  recorded daemon: version=0.1.2 pid=999999 (process absent) port=48682
  version skew: this client is 0.1.3; restart the daemon before destructive use
  control port: not answering (probed for 2s)
  heartbeat: never written
  startup log: Traceback (most recent call last):
  ...
RuntimeError: boom
secret=<redacted>

real  0m0.073s
```

`run` and `attach` print it when the stream closes, so the message that previously only asserted a failure now explains it.

Two properties it must keep, because it only ever runs on a failure path, both covered by tests:

- **It never raises.** A diagnostic that can fail replaces a bad message with no message. One unreadable fact does not abandon the rest.
- **It never carries the daemon secret.** The secret file is not read; the startup tail goes through the existing redaction, and a test writes a real secret into the log and asserts it cannot come back out.

`recorded_state` reads the state file *without* the deletion `running_state` performs. That deletion is correct for a spawn/stop decision and destroys the evidence of the one moment worth diagnosing: a daemon that recorded itself and then stopped answering.

`status` gains the same recorded identity on its unreachable branch (`pid`, `port`, `version`, `process_alive`, `client_version`, `version_skew`, or `null` when nothing was recorded). An unreachable daemon is exactly when its version matters most, and the degraded report previously carried no way to see it.

## Pinning the bound

#134 also reports `status` and `doctor` hanging past 30 seconds after the documented restart. #119 introduced a 2s budget for `status`; nothing pinned it. The new regression test stands up a listener that **accepts a connection and then says nothing** — a wedged or half-started daemon. A *closed* port fails instantly and proves nothing, which is why that case was never the guard. `status` answers in ~2s and reports `degraded` with the recorded identity. The assertion is on the wall clock, not on a constant, so any reintroduced unbounded control-plane read fails it regardless of which timeout was forgotten.

## What this does not do

#134 is a P1 with seven acceptance criteria spanning several subsystems, and much of it landed in #119, #130, #135, #137 and #140 after the report was filed. This PR covers:

- "Capture bounded startup/control diagnostics for a closed stream or daemon exit, with no secret leakage" — **yes**
- "A fresh daemon ... reports version state" — **the reporting half**
- "`status` ... bounded responses; none hang after the restart attempt" — **now pinned by a test**, for `status`

Not covered, and left untouched: the stale-session reap path itself (`done` reaping a confirmed-dead owner, live-owner protection, exit-code propagation after reconciliation). Those are #119/#135/#140's code, and confirming the reported sequence needs the reporter's Windows host — which is precisely what these diagnostics now make possible to report on.

## Verification

Full suite 1118 passed / 8 skipped; `ci/lint.py` clean (ruff format, ruff check, pyright, lint_kbi). Nine new tests, all confirmed RED against pre-fix source and GREEN after. Manually exercised end-to-end against a fabricated skewed/dead-daemon state directory, shown above — 0.073s, redacted, naming the skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RfGTwB7LCyTfC6jXvyKiv
