### PR TITLE
fix(gc): size the unlabeled bucket, and measure containers at all

### DIFF
--- a/src/bosn/accounting.py
+++ b/src/bosn/accounting.py
@@ -10,8 +10,10 @@ import json
 import os
 import re
 import shutil
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol
 
 from bosn.engine import Engine
 from bosn.registry import Resource
@@ -126,7 +128,16 @@ class StorageInventory:
             ):
                 for item in row.get(key, []):
                     if isinstance(item, dict) and (size := _bytes(item.get(field))) is not None:
-                        sizes[(kind, str(item.get("Name") or item.get("ID") or ""))] = size
+                        # `df -v` names containers with `Names` (plural) and volumes with
+                        # `Name`. Reading only `Name` silently fell through to `ID` for every
+                        # container, while `resources._name_of` keys them by `Names` -- so the
+                        # two never met and every container read as unmeasured. That is not a
+                        # cosmetic gap: `gc` refuses to declare byte pressure resolved while
+                        # any managed resource is unmeasured, so one managed container was
+                        # enough to wedge pressure resolution permanently. Mirrors
+                        # `resources._name_of`; keep the two in step.
+                        name = item.get("Names") or item.get("Name") or item.get("ID") or ""
+                        sizes[(kind, str(name))] = size
             # UniqueSize is the only image attribution that cannot charge a shared layer twice.
             for item in row.get("Images", []):
                 if isinstance(item, dict) and (size := _bytes(item.get("UniqueSize"))) is not None:
@@ -149,6 +160,52 @@ def resource_bytes(
         return 0
     inventory = inventory or StorageInventory.collect(engine)
     return inventory.sizes.get((resource.kind, resource.name))
+
+
+class SizedResource(Protocol):
+    """The shape `bucket_totals` needs: anything the scanner reports with a kind and name."""
+
+    @property
+    def kind(self) -> str: ...
+
+    @property
+    def name(self) -> str: ...
+
+
+def bucket_totals(items: Iterable[SizedResource], inventory: StorageInventory) -> dict[str, object]:
+    """Size one ownership bucket from a scan, with a per-kind breakdown.
+
+    `gc.status` reported byte totals for the `foreign` bucket but only a bare count for
+    `unlabeled` (#147 G1), so a host could carry tens of gigabytes of artifacts bosn does
+    not manage and say only how *many* there were. Both buckets go through here now, so
+    neither can regain a size the other lacks.
+
+    Networks are counted as a known zero rather than unmeasured, for the same reason
+    `resource_bytes` does it: `docker system df -v` has no row shape for them because they
+    hold no data. Treating that absence as "unknown" would make an honest report of a
+    healthy host look permanently unmeasurable.
+    """
+    totals = {"count": 0, "bytes": 0, "unmeasured": 0}
+    by_kind: dict[str, dict[str, int]] = {}
+    for item in items:
+        kind_bucket = by_kind.setdefault(item.kind, {"count": 0, "bytes": 0, "unmeasured": 0})
+        totals["count"] += 1
+        kind_bucket["count"] += 1
+        size = 0 if item.kind == "network" else inventory.sizes.get((item.kind, item.name))
+        if size is None:
+            totals["unmeasured"] += 1
+            kind_bucket["unmeasured"] += 1
+            continue
+        totals["bytes"] += size
+        kind_bucket["bytes"] += size
+    return {
+        **totals,
+        # Sorted so a report, a test, and a diff of two passes all read in the same order.
+        "by_kind": dict(sorted(by_kind.items())),
+        # A size the engine could not attribute makes `bytes` a floor, not a total. Callers
+        # that print a number to a human need to know when to say "at least".
+        "bytes_are_floor": totals["unmeasured"] > 0 or not inventory.measured,
+    }
 
 
 def engine_storage_path(engine: Engine, fallback: Path) -> Path:

--- a/src/bosn/gc.py
+++ b/src/bosn/gc.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from bosn import labels, resources
-from bosn.accounting import StorageInventory, probe, resource_bytes
+from bosn.accounting import StorageInventory, bucket_totals, probe, resource_bytes
 from bosn.config import Config
 from bosn.engine import Engine
 from bosn.manifest import Manifest
@@ -644,15 +644,12 @@ def status(
         "unproven_resources": unproven_resources,
         "execution_sessions": execution_sessions,
         "foreign_registries": sorted(scan.foreign_registries),
-        "foreign_registry_totals": {
-            "count": len(scan.foreign),
-            "bytes": sum(
-                inventory.sizes.get((resource.kind, resource.name), 0) for resource in scan.foreign
-            ),
-            "unmeasured": sum(
-                (resource.kind, resource.name) not in inventory.sizes for resource in scan.foreign
-            ),
-        },
+        "foreign_registry_totals": bucket_totals(scan.foreign, inventory),
+        # The bucket that holds everything Docker made outside bosn. Reported with bytes
+        # rather than a bare count (#147 G1): a count cannot tell a user whether their
+        # unmanaged artifacts are worth acting on, which is exactly how a 16 GB pile grew
+        # unnoticed on a machine that had bosn installed the whole time.
+        "unlabeled_totals": bucket_totals(scan.unlabeled, inventory),
         "managed_bytes": managed_bytes,
         "managed_reclaimable_bytes": reclaimable,
         "pressure": {

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -6,6 +6,7 @@ import json
 
 from bosn.accounting import (
     StorageInventory,
+    bucket_totals,
     configured_desktop_vhdx_allocation,
     desktop_vhdx,
     engine_storage_path,
@@ -214,3 +215,88 @@ def test_configured_vhdx_allocation_reports_a_file_not_reclaimable_slack(tmp_pat
     assert allocation.path == vhdx
     assert allocation.allocated_bytes == len(b"allocated")
     assert not hasattr(allocation, "reclaimable_bytes")
+
+
+class _Discovered:
+    """Stand-in for `resources.DiscoveredResource`, which `accounting` must not import."""
+
+    def __init__(self, kind: str, name: str) -> None:
+        self.kind = kind
+        self.name = name
+
+
+def test_bucket_totals_sizes_a_bucket_and_breaks_it_down_by_kind() -> None:
+    inventory = StorageInventory({("image", "sha256:a"): 10, ("volume", "work"): 5})
+    totals = bucket_totals(
+        [_Discovered("image", "sha256:a"), _Discovered("volume", "work")], inventory
+    )
+    assert totals["count"] == 2
+    assert totals["bytes"] == 15
+    assert totals["unmeasured"] == 0
+    assert totals["bytes_are_floor"] is False
+    assert totals["by_kind"] == {
+        "image": {"count": 1, "bytes": 10, "unmeasured": 0},
+        "volume": {"count": 1, "bytes": 5, "unmeasured": 0},
+    }
+
+
+def test_bucket_totals_counts_a_network_as_a_known_zero_not_as_unmeasured() -> None:
+    # `system df -v` has no row shape for networks, matching `resource_bytes`. Reporting
+    # them as unmeasured would make an honest total of a healthy host read as a floor.
+    totals = bucket_totals([_Discovered("network", "bridge")], StorageInventory({}))
+    assert totals["bytes"] == 0
+    assert totals["unmeasured"] == 0
+    assert totals["bytes_are_floor"] is False
+
+
+def test_bucket_totals_marks_bytes_a_floor_when_a_size_is_unattributable() -> None:
+    totals = bucket_totals([_Discovered("image", "sha256:missing")], StorageInventory({}))
+    assert totals["count"] == 1
+    assert totals["bytes"] == 0
+    assert totals["unmeasured"] == 1
+    assert totals["bytes_are_floor"] is True
+
+
+def test_bucket_totals_marks_bytes_a_floor_when_the_whole_inventory_is_unmeasured() -> None:
+    # An unmeasured inventory reads as sizes it happens to know nothing about; without
+    # `measured` the report would claim a confident zero for a host it never managed to read.
+    inventory = StorageInventory({}, measured=False)
+    totals = bucket_totals([_Discovered("network", "bridge")], inventory)
+    assert totals["unmeasured"] == 0
+    assert totals["bytes_are_floor"] is True
+
+
+def test_bucket_totals_of_an_empty_bucket_is_a_confident_zero() -> None:
+    totals = bucket_totals([], StorageInventory({}))
+    assert totals == {
+        "count": 0,
+        "bytes": 0,
+        "unmeasured": 0,
+        "by_kind": {},
+        "bytes_are_floor": False,
+    }
+
+
+def test_container_sizes_are_keyed_by_the_name_the_scanner_uses() -> None:
+    """`df -v` calls containers `Names`; reading only `Name` left every one unmeasured."""
+
+    class ContainerEngine:
+        def run(self, args: list[str]) -> EngineResult:
+            return EngineResult(
+                0, json.dumps({"Containers": [{"ID": "abc123", "Names": "web", "Size": "4kB"}]}), ""
+            )
+
+    inventory = StorageInventory.collect(ContainerEngine())  # type: ignore[arg-type]
+    assert inventory.sizes[("container", "web")] == 4000
+    resource = Resource(
+        id="r1",
+        kind="container",
+        name="web",
+        stack="s",
+        generation="g",
+        scope="spec",
+        workspace="/w",
+        created_at=0.0,
+        last_used=0.0,
+    )
+    assert resource_bytes(ContainerEngine(), resource, inventory) == 4000  # type: ignore[arg-type]

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -1092,3 +1092,51 @@ def test_status_reports_running_as_the_kept_reason(registry: Registry) -> None:
 
     assert report["decisions"][0]["reason"] == KEPT_RUNNING
     assert report["by_reason"].get(KEPT_RUNNING) == 1
+
+
+class UnmanagedEngine(FakeEngine):
+    """Serves one unlabeled image plus a `system df -v` row that sizes it.
+
+    The point of #147's G1 is a host carrying artifacts bosn did not create, so the fake
+    has to produce a resource that lands in the `unlabeled` bucket *and* a size for it.
+    """
+
+    def run(self, args: list[str], *, check: bool = False) -> EngineResult:
+        if args == ["images", "--no-trunc", "--format", "{{json .}}"]:
+            self.commands.append(list(args))
+            return EngineResult(0, json.dumps({"ID": "sha256:loose", "Labels": ""}), "")
+        if args[:3] == ["system", "df", "-v"]:
+            self.commands.append(list(args))
+            return EngineResult(
+                0, json.dumps({"Images": [{"ID": "sha256:loose", "UniqueSize": "2GB"}]}), ""
+            )
+        return super().run(args, check=check)
+
+
+def test_status_sizes_the_unlabeled_bucket_not_just_its_count(registry: Registry) -> None:
+    # Before #147 G1 the unlabeled bucket surfaced as a bare integer, so a host could hold
+    # gigabytes of unmanaged artifacts and report only how many objects there were.
+    report = status(registry, UnmanagedEngine({}))  # type: ignore[arg-type]
+
+    totals = report["unlabeled_totals"]
+    assert totals["count"] == 1
+    assert totals["bytes"] == 2_000_000_000
+    assert totals["unmeasured"] == 0
+    assert totals["by_kind"]["image"] == {"count": 1, "bytes": 2_000_000_000, "unmeasured": 0}
+    assert report["engine"]["unlabeled"] == totals["count"], "count must not drift from bytes"
+
+
+def test_status_reports_both_ownership_buckets_with_the_same_shape(registry: Registry) -> None:
+    # Neither bucket may regain a field the other lacks; that asymmetry was the defect.
+    report = status(registry, FakeEngine({}))  # type: ignore[arg-type]
+
+    assert set(report["unlabeled_totals"]) == set(report["foreign_registry_totals"])
+
+
+def test_status_marks_unlabeled_bytes_a_floor_when_the_inventory_is_unmeasured(
+    registry: Registry,
+) -> None:
+    # A `system df -v` that could not be read must not report a confident zero.
+    report = status(registry, FakeEngine({}))  # type: ignore[arg-type]
+
+    assert report["unlabeled_totals"]["bytes_are_floor"] is True


### PR DESCRIPTION
Implements **G1** from #147 — the prerequisite for the warning system specced in #148, and milestone **M1** in #149.

## The gap

`gc.status` computed `count` **and** `bytes` for the `foreign` bucket, but reported `unlabeled` as a bare integer (`resources.py:154-158`, `gc.py:645-655`). So a host could carry tens of gigabytes of artifacts bosn did not create and say only *how many objects* there were.

That is exactly how ~16 GB accumulated unnoticed on the audit machine in #147: bosn was installed the entire time and had no way to say how large the pile it refuses to touch had become.

## Changes

**`bucket_totals` in `accounting.py`** — sizes one ownership bucket, returning `count`, `bytes`, `unmeasured`, a per-kind breakdown, and `bytes_are_floor`.

Both buckets now route through it. `foreign_registry_totals` was refactored onto the shared helper rather than left as a parallel implementation — the asymmetry between the two buckets *was* the defect, so sharing the code is what keeps it from recurring. A test asserts both have identical shape.

Networks count as a **known zero** rather than unmeasured, matching the existing rationale in `resource_bytes`: `df -v` has no row shape for them because they hold no data, and treating that absence as unknown would make an honest report of a healthy host read as a floor.

**A pre-existing bug fixed in passing.** `docker system df -v` names containers with `Names` (plural). `collect` read only `Name`, fell through to `ID`, while `resources._name_of` keys containers by `Names` — the two never met, so **every container resolved as unmeasured**.

Not cosmetic: `gc` refuses to declare byte pressure resolved while any managed resource is unmeasured, so one managed container was enough to **wedge byte-pressure resolution permanently**. Found by running the new accounting against a real engine, not by reading the code.

## Verification

Against a real Docker engine (36 images, the #147 host):

```
count      : 45
bytes      : 10,237,212,205 (9.53 GiB)
unmeasured : 0   floor?: False
  container  count=  1  bytes= 0.00 GiB
  image      count= 36  bytes= 9.28 GiB
  network    count=  4  bytes= 0.00 GiB
  volume     count=  4  bytes= 0.26 GiB
```

Before the container fix, that same run reported `unmeasured: 1` and a spurious `floor: True`.

1132 tests pass; ruff format, ruff check, and pyright all clean.

## Follow-up, not in scope here

Summing `UniqueSize` gives 9.28 GiB for images where `docker system df` reports 14.85 GB reclaimable. Both are correct and answer different questions — layers shared *among* bucket members are reclaimable but attributed to no single member. Since that is the number the warning will print, it is a product decision rather than an implementation detail; options are written up in a comment on #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RfGTwB7LCyTfC6jXvyKiv
