### PR TITLE
feat(stack): support a macOS x64 guest stack backed by dockur/macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ policy instead of a blunt instrument.
 >
 > **Partial:** the Docker front door — `bosn init` (alias: `bosn-docker init`) and `bosn-docker compose
 > {up,down,logs,ps}` only, over a small compose subset. See
-> [Coming from Docker](#coming-from-docker).
+> [Coming from Docker](#coming-from-docker). Also the **macOS x86-64 guest stack** — the
+> manifest surface, pinned retention, `release-volume`, host preflight, KVM/tun passthrough,
+> sshd readiness, and the ssh execution transport are implemented and unit-tested, but bosn's
+> own CI has no KVM and no baked guest image, so nothing here is exercised against a live
+> `dockurr/macos` guest. See [docs/macos-guest.md](docs/macos-guest.md).
 >
 > **Not built:** podman; `docker` / `docker-compose` shims; and **BuildKit's own layer
 > cache**, which is outside the label contract — bosn manages containers, volumes, and
@@ -498,6 +502,7 @@ bosn done                    # this workspace is finished; its caches become col
 bosn gc --dry-run --json     # rich engine/storage inventory; --apply reclaims (no --force)
 bosn reconcile-volume --stack perf --volume target  # preview one legacy partial target
 bosn reconcile-volume --stack perf --volume target --apply --yes  # explicit repair
+bosn release-volume --stack mac --volume storage --apply --yes  # release one pinned volume
 bosn doctor                  # engine reachability, registry integrity, recovery commands
 bosn adopt --legacy <family> # import pre-bosn volumes; --yes to apply
 
@@ -512,6 +517,13 @@ daemon returns `mode: "online"`; an absent daemon returns `mode: "offline"`; and
 stream returns `mode: "degraded"` with persisted session diagnostics. For the rich engine,
 ownership, and storage inventory, use `bosn gc --dry-run --json` instead. `gc` and `jobs` are
 read-only but go through the daemon and fail closed if it is unreachable.
+
+`release-volume` is the only way a `retention = "pinned"` volume is ever collected. Pinning
+exists for state that is not rebuildable on demand — the motivating case is a macOS guest disk
+whose only creation path is a human sitting through a 30–60 minute interactive installer — so a
+pinned volume is exempt from age, supersession, `bosn done`, and storage pressure alike. The
+release re-proves ownership from the engine's labels, refuses an active lease, and refuses a
+volume still attached to a container.
 
 `reconcile-volume` is for incomplete legacy labels only. It derives the engine name from the
 current manifest and refuses arbitrary names, unlabeled volumes, foreign/contradictory labels,

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -1,0 +1,178 @@
+# The macOS x86-64 guest stack
+
+A guest stack runs a [`dockurr/macos`](https://github.com/dockur/macos) container whose real
+workload executes in a QEMU/KVM virtual machine *inside* it. It lets a repo declare a macOS
+x86-64 target the same way it declares a Linux one, and puts that guest under the same
+lifecycle bosn already gives every other container resource.
+
+```toml
+[stack.macos-x64]
+kind = "macos-x64-guest"
+acknowledge_macos_license = true          # see Licensing, below — no default
+image = "ghcr.io/<org>/<repo>/macos-x64-guest:ventura"
+family = "macos-x64"
+workdir = "/Users/runner"
+
+[stack.macos-x64.guest]
+ssh_port = 2222
+ssh_user = "runner"
+ready_timeout = 1800
+payload = "kernal-x64.tar.zst"            # scp'd into the guest before every task
+payload_destination = "~/kernal-x64.tar.zst"
+
+[stack.macos-x64.volumes]
+storage = { scope = "machine", destination = "/storage", retention = "pinned" }
+
+[task.test-macos-x64]
+stack = "macos-x64"
+cmd = "cargo-nextest nextest run --archive-file ~/kernal-x64.tar.zst"
+```
+
+## Why this is a stack *kind* and not a stack with unusual options
+
+Four things a guest stack needs that no Linux stack does. Each one is a place bosn's normal
+behavior would be silently wrong rather than merely absent.
+
+**Device passthrough at create time.** `--device /dev/kvm --device /dev/net/tun --cap-add
+NET_ADMIN`. Without KVM the guest emulates and is unusably slow; without the tun device it
+has no network, so no sshd, so no way in. Docker cannot add a device or a capability to a
+container after creation, which is why every one of these — and everything in
+`[stack.X.guest]` — is part of the generation digest: changing one has to roll a new
+container, exactly like `env` does.
+
+**Readiness is sshd, not "container running".** The container is up in a second. macOS is
+booted minutes later, and on one core, later than that. bosn polls the guest's sshd against
+a bounded deadline (`ready_timeout`, default 1800s) and, if it passes, attaches the last 60
+lines of the guest's own logs to the error. A fixed sleep is wrong in both directions: too
+short and the task fails against a guest that was about to be ready, too long and every run
+pays for the worst case.
+
+**The execution transport is ssh.** `docker exec` lands in the container, *beside* the VM,
+and would quietly run a macOS task against a Linux userland. Tasks are shipped over ssh and
+the guest's exit code comes back unchanged, so CI can gate on it. One ambiguity is worth
+knowing: ssh uses exit 255 for its own connection failures, so a task that genuinely exits
+255 is indistinguishable from a lost connection. bosn logs a `guest.ambiguous_exit` event
+when it sees one.
+
+**A bind mount is invisible to the guest.** A Linux stack binds `.` read-only into `/repo`.
+The VM has no view of the container's filesystem, so bosn *refuses* `[stack.X.mounts]` on a
+guest stack rather than accepting a declaration that would silently not be there. Instead,
+declare a `payload` in `[stack.X.guest]`: one repo-relative file, `scp`'d to
+`payload_destination` over the same ssh channel before every task. Before *every* task, not
+once at container creation — a payload is a build output that changes between runs, and a
+guest quietly serving last week's archive while reporting success is the worst failure this
+kind can produce. A missing payload file is refused before the task starts.
+
+## Pinned volumes
+
+The guest disk is tens of gigabytes and its only creation path is a human sitting through a
+30–60 minute interactive installer. It is not a cache that rebuilds on demand, and a GC
+sweep that reclaims it costs an hour of someone's day.
+
+```toml
+storage = { scope = "machine", destination = "/storage", retention = "pinned" }
+```
+
+A pinned volume is exempt from **every** automatic rule: age, supersession, `bosn done`, and
+storage pressure. Only an active lease outranks it, and that is not a reclaim decision. The
+tier is recorded on the volume's registry row rather than looked up in the manifest, because
+GC runs from the registry alone — it has no manifest in hand, and the worktree that declared
+the volume may be long gone. It is *also* written as a Docker label, because bosn's registry
+is explicitly disposable ("ownership lives in the Docker labels"): without the label, a
+`bosn adopt` after a lost database would rebuild the guest disk's row as warm and the next
+sweep would take it.
+
+Releasing one is deliberate and manual:
+
+```bash
+bosn release-volume --stack macos-x64 --volume storage            # preview
+bosn release-volume --stack macos-x64 --volume storage --apply --yes
+```
+
+The release re-proves ownership from the engine's labels, refuses an active lease, and
+refuses a volume still attached to a container — the same three proofs GC requires.
+
+## Recommended shape: build outside, execute inside
+
+This removes almost all of the guest's setup burden. Cross-compile on Linux; ship only
+prebuilt binaries into the guest.
+
+```bash
+# Linux stack — soldr carries its own macOS SDK and LLVM, so no Mac is involved
+soldr cargo nextest archive --target x86_64-apple-darwin --all-features \
+  --archive-file kernal-x64.tar.zst        # measured: 25 binaries, 103 files, ~112 MB, ~85 s
+
+# macOS guest stack
+cargo-nextest nextest run --archive-file kernal-x64.tar.zst
+```
+
+The guest then needs **no Rust toolchain, no Xcode CLT, no Homebrew** — only the
+`cargo-nextest` binary.
+
+Two portability traps, both invisible until you actually run cross-host:
+
+- `cargo-nextest` invoked directly needs `cargo-nextest nextest run`. As `cargo-nextest run`
+  it parses `run` as a cargo subcommand and exits 2.
+- `env!("CARGO_MANIFEST_DIR")` and `env!("CARGO_BIN_EXE_<name>")` are **compile-time**
+  constants, so they carry the *builder's* paths. nextest's `--workspace-remap` cannot
+  rewrite them; `NEXTEST_BIN_EXE_<name>` is the runtime replacement for the binary case.
+
+## Constraints bosn surfaces rather than hides
+
+**AMD hosts get one core.** [dockur/macos#268](https://github.com/dockur/macos/issues/268):
+a PCID mismatch makes a multi-core guest unstable on AMD. bosn reads `/proc/cpuinfo` at
+create time and forces `CPU_CORES=1` on an AMD host, and also on a host whose vendor it
+cannot read — guessing wrong toward AMD costs speed, guessing wrong toward Intel costs
+stability. An explicit `cpu_cores` in `[stack.X.guest]` is honored as written.
+
+**Bootstrap is manual and one-time.** `dockurr/macos` has no unattended install path, and
+Docker-OSX's prebuilt `:auto` tag no longer exists on Docker Hub. bosn supervises the
+*result*; it cannot automate the install. The realistic flow is: install once by hand → bake
+the prepared disk into an image → publish it → every consumer pulls. See "One-time
+bootstrap" below.
+
+**One guest per machine.** The container name is per-workspace, but `ssh_port` is a fixed
+host port, so a second workspace declaring the same guest stack will fail to start on
+port-in-use. That is the intended shape rather than a limitation to route around: the guest
+disk is `scope = "machine"`, and two VMs writing one disk would corrupt it. Give a second
+guest its own `ssh_port` and `web_port` — and its own storage volume — if you really need
+two.
+
+**Linux hosts only.** A guest stack is refused before anything is pulled or built if the
+host is not Linux or is missing `/dev/kvm` or `/dev/net/tun`. Failing at converge time,
+rather than several layers down inside QEMU after a multi-gigabyte pull, is the point.
+
+## Licensing
+
+Apple's EULA conditions macOS on the hardware it runs on, and building an image from a
+prepared disk does not change that analysis. Running macOS under QEMU on non-Apple hardware
+is a decision for the person doing it, not something to back into by copying somebody's
+`bosn.toml`. So a guest stack is inert until the manifest says so explicitly:
+
+```toml
+acknowledge_macos_license = true
+```
+
+Without it, loading the manifest fails with an explanation. There is no default, no
+environment variable, and no flag.
+
+## One-time bootstrap
+
+bosn does not automate this; it is here so the manifest above has something to point at.
+
+1. **Install macOS (~30–60 min, one core).** Start a `dockurr/macos` container with
+   `-p 8006:8006 -p 2222:22`, the two devices and `NET_ADMIN`, and a `/storage` volume. Open
+   `http://localhost:8006`: Disk Utility → erase the QEMU disk as APFS → Reinstall macOS →
+   walk the setup screens. Skip Apple ID; create a local account named `runner` (or set
+   `ssh_user` to whatever you chose).
+2. **Enable ssh in the guest.** System Settings → General → Sharing → Remote Login: on.
+3. **Install whatever the task needs.** For the recommended shape above that is one binary:
+   `scp -P 2222 cargo-nextest runner@localhost:~/` then move it to `/usr/local/bin`.
+4. **Bake the prepared disk into an image** with a Dockerfile that is `FROM
+   dockurr/macos:latest` plus `COPY storage/ /storage/`, and push it. Stop the container
+   first so the disk is quiescent — a baked image of a live filesystem is a torn one.
+5. Point the stack's `image` at the published tag. Every consumer now pulls a guest that
+   boots straight to a login-capable system.
+
+Working reference scripts for all five steps live in `zackees/kernal-api` under
+`ci/macos-x64/`.

--- a/src/bosn/cli.py
+++ b/src/bosn/cli.py
@@ -12,6 +12,7 @@ import contextlib
 import io
 import json
 import os
+import shlex
 import shutil
 import sqlite3
 import sys
@@ -150,6 +151,7 @@ VERBS: dict[str, tuple[str, str]] = {
     "ensure": ("pre-warm a stack without running a command", "implemented"),
     "adopt": ("recover labeled resources into this registry", "implemented"),
     "reconcile-volume": ("explicitly repair one incomplete manifest volume", "implemented"),
+    "release-volume": ("manually release one pinned volume", "implemented"),
     "doctor": ("engine health and reachability", "implemented"),
     "daemon-stop": ("stop the running daemon (needed after upgrades)", "implemented"),
     "init": ("translate a Compose file into bosn.toml (alias: bosn-docker init)", "implemented"),
@@ -192,7 +194,16 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
         sub = subparsers.add_parser(verb, help=help_text)
         _add_policy_flags(sub, default=argparse.SUPPRESS)
         sub.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
-        if verb in {"run", "tasks", "shell", "done", "ensure", "adopt", "reconcile-volume"}:
+        if verb in {
+            "run",
+            "tasks",
+            "shell",
+            "done",
+            "ensure",
+            "adopt",
+            "reconcile-volume",
+            "release-volume",
+        }:
             sub.add_argument("--stack", default=None, help="stack to use (default: the default)")
             sub.add_argument("--task", default=None, help="run a manifest task by name")
             sub.add_argument("--manifest", default=None, dest="sub_manifest")
@@ -250,6 +261,29 @@ def build_parser(*, json_errors: bool = False) -> argparse.ArgumentParser:
                 action="store_true",
                 default=False,
                 help="confirm the explicit legacy recovery when used with --apply",
+            )
+        if verb == "release-volume":
+            sub.add_argument(
+                "--volume",
+                default=None,
+                metavar="LOGICAL_NAME",
+                help=(
+                    "declared volume name from the selected stack; engine names are never accepted"
+                ),
+            )
+            sub.add_argument(
+                "--apply",
+                dest="release_apply",
+                action="store_true",
+                default=False,
+                help="actually remove the pinned volume, after preview and --yes",
+            )
+            sub.add_argument(
+                "--yes",
+                dest="yes",
+                action="store_true",
+                default=False,
+                help="confirm the release when used with --apply",
             )
         if verb == "init":
             # Matches `bosn-docker init`'s flag surface (see docker_cli._parse_init_args)
@@ -791,6 +825,53 @@ def _release_execution(daemon_mod, state_dir, session: object) -> str | None:
     return str(released.get("error") or f"could not release execution session {session}")
 
 
+def _run_in_guest(
+    stack,
+    engine,
+    container: str,
+    command: list[str],
+    *,
+    root,
+    capture: bool,
+    timeout: float | None,
+) -> int:
+    """Wait for the guest, then run one foreground task inside the VM over ssh.
+
+    `capture` follows the same rule the `docker exec` path uses: JSON mode reserves stdout
+    for exactly one parseable envelope, so output is captured and re-emitted; an ordinary
+    run inherits this process's stdio so a long test run streams live.
+    """
+    from bosn import guest as guest_mod
+    from bosn.engine import EngineError
+
+    guest = stack.guest_spec()
+    try:
+        guest_mod.ensure_ready(
+            guest,
+            fetch_logs=guest_mod.container_log_reader(engine, container),
+            report=None if capture else lambda message: print(message, file=sys.stderr),
+        )
+    except guest_mod.GuestNotReadyError as exc:
+        raise EngineError(str(exc)) from exc
+    guest_mod.ship_payload(guest, root, timeout=timeout)
+
+    # A Linux stack receives `["sh", "-c", cmd]`; the guest's own shell plays that role, so
+    # the same task text means the same thing on both kinds.
+    payload = command[2] if command[:2] == ["sh", "-c"] and len(command) == 3 else None
+    remote = guest_mod.remote_command(
+        guest,
+        payload if payload is not None else shlex.join(command),
+        workdir=stack.workdir,
+    )
+    argv = guest_mod.ssh_argv(guest, remote)
+    if not capture:
+        return guest_mod.interactive_remote(argv, timeout=timeout)
+    code, output = guest_mod.run_remote(argv, timeout=timeout)
+    if output:
+        print(output, file=sys.stderr if code else sys.stdout)
+    return code
+
+
 def cmd_run(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.config import ConfigError
@@ -841,6 +922,21 @@ def cmd_run(opts: Options) -> int:
         code: int | None = None
         try:
             engine = Engine(opts.engine)
+            stack = manifest.stack(stack_name)
+            if stack.is_guest:
+                # `docker exec` would land in the container, beside the VM rather than
+                # inside it, and quietly run a macOS task against a Linux userland. The
+                # guest's transport is ssh; see docs/macos-guest.md.
+                code = _run_in_guest(
+                    stack,
+                    engine,
+                    str(acquired["container"]),
+                    command,
+                    root=manifest.root,
+                    capture=opts.json,
+                    timeout=config.get("run_max_duration"),
+                )
+                return code
             exec_args = ["exec", str(acquired["container"]), *command]
             if opts.json:
                 # JSON errors reserve stdout for exactly one parseable envelope. Capturing
@@ -1521,6 +1617,77 @@ def cmd_reconcile_volume(opts: Options) -> int:
     return 0 if reply.get("ok") else 1
 
 
+def cmd_release_volume(opts: Options) -> int:
+    """Preview or explicitly release one pinned volume (#151).
+
+    Pinned volumes are exempt from every automatic reclamation rule, so this is their only
+    exit. It mirrors `reconcile-volume`'s shape deliberately: a declared stack plus logical
+    volume name, a preview by default, and a mutation only behind `--apply --yes`.
+    """
+    from bosn import daemon as daemon_mod
+    from bosn.manifest import DEFAULT_RETENTION, ManifestError, find_manifest, load
+
+    if not opts.stack or not opts.volume:
+        return _error(
+            code="release-volume.stack_required",
+            message="release-volume requires --stack and --volume for an unambiguous target",
+            next_step="pass the stack and logical volume declared by bosn.toml",
+            as_json=opts.json,
+        )
+    try:
+        manifest_path = opts.manifest or find_manifest()
+        if manifest_path is None:
+            raise ManifestError("no bosn.toml found; create one or pass --manifest")
+        manifest = load(manifest_path)
+        # Validated client-side too, so a typo never starts a daemon merely to be refused.
+        stack = manifest.stack(opts.stack)
+        declared = next((v for v in stack.volumes if v.name == opts.volume), None)
+        if declared is None:
+            raise ManifestError(f"volume {opts.volume!r} is not declared by stack {stack.name!r}")
+        if declared.retention == DEFAULT_RETENTION:
+            raise ManifestError(
+                f"volume {opts.volume!r} of stack {stack.name!r} is not pinned; warm volumes "
+                "are reclaimed by `bosn gc` and need no explicit release"
+            )
+    except ManifestError as exc:
+        return _error(
+            code="release-volume.invalid_manifest",
+            message=str(exc),
+            next_step="select a declared stack and a pinned logical volume",
+            as_json=opts.json,
+        )
+    try:
+        reply = daemon_mod.request(
+            "release-volume",
+            opts.state_dir,
+            manifest=str(manifest.path),
+            stack=opts.stack,
+            volume=opts.volume,
+            apply=opts.release_apply,
+            yes=opts.yes,
+            engine=opts.engine,
+            request_timeout=RECONCILE_VOLUME_REQUEST_TIMEOUT_SECONDS,
+        )
+    except (daemon_mod.DaemonError, ipc.TransportError) as exc:
+        return _error(
+            code="daemon.unreachable",
+            message=f"cannot reach the bosn daemon: {exc}",
+            next_step="start or restart the daemon, then retry",
+            as_json=opts.json,
+        )
+    if opts.json:
+        print(json.dumps(reply, indent=2))
+    elif reply.get("plan") and not reply.get("applied"):
+        print(json.dumps(reply["plan"], indent=2))
+        if reply.get("ok"):
+            print("nothing was removed; re-run with --apply --yes to release it", file=sys.stderr)
+    elif reply.get("ok"):
+        print(f"released {reply.get('plan', {}).get('engine_name', opts.volume)}")
+    if not reply.get("ok") and not opts.json:
+        print(str(reply.get("error") or "release-volume failed"), file=sys.stderr)
+    return 0 if reply.get("ok") else 1
+
+
 def cmd_shell(opts: Options) -> int:
     from bosn import daemon as daemon_mod
     from bosn.converge import workspace_of
@@ -1554,9 +1721,21 @@ def cmd_shell(opts: Options) -> int:
             raise EngineError(str(acquired.get("error") or "execution acquire failed"))
         code: int | None = None
         try:
-            code = Engine(opts.engine).interactive(
-                ["exec", "-it", str(acquired["container"]), "sh"]
-            )
+            from bosn import guest as guest_mod
+
+            stack = manifest.stack(opts.stack)
+            if stack.is_guest:
+                # The shell must land in the VM for the same reason a task does. Readiness
+                # is not polled: the user is present, so a refused connection is immediate,
+                # legible feedback rather than a silent minutes-long wait.
+                guest = stack.guest_spec()
+                code = guest_mod.interactive_remote(
+                    guest_mod.ssh_argv(guest, guest_mod.login_command(stack.workdir))
+                )
+            else:
+                code = Engine(opts.engine).interactive(
+                    ["exec", "-it", str(acquired["container"]), "sh"]
+                )
         finally:
             cleanup_error = _release_execution(daemon_mod, opts.state_dir, acquired["session"])
             if cleanup_error:
@@ -1683,6 +1862,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "done": cmd_done,
         "adopt": cmd_adopt,
         "reconcile-volume": cmd_reconcile_volume,
+        "release-volume": cmd_release_volume,
         "init": cmd_init,
     }
     handler = handlers.get(opts.verb)

--- a/src/bosn/converge.py
+++ b/src/bosn/converge.py
@@ -13,10 +13,12 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from bosn import guest as guest_mod
 from bosn import labels
 from bosn.engine import Engine, EngineError
 from bosn.manifest import (
@@ -314,11 +316,16 @@ class Converger:
         self.progress = progress
         self.cancelled = cancelled
         self.run_max_duration = run_max_duration
+        self._host_capability: guest_mod.HostCapability | None = None
 
     def converge(
         self, stack_name: str | None = None, *, workspace: str | None = None
     ) -> ConvergeResult:
         stack = self.manifest.stack(stack_name)
+        # Before anything is pulled, built, or registered: a guest stack on a host without
+        # KVM can never work, and finding that out after a multi-gigabyte image pull wastes
+        # both the pull and the user's attention.
+        self._require_supported_host(stack)
         digest, resolved_image = self._resolved_generation(stack)
         workspace = workspace or workspace_of(self.manifest)
 
@@ -395,7 +402,14 @@ class Converger:
         return self.registry.generation_recorded(digest, stack, workspace)
 
     def _resource_labels(
-        self, stack: StackSpec, kind: str, digest: str, scope: str, workspace: str
+        self,
+        stack: StackSpec,
+        kind: str,
+        digest: str,
+        scope: str,
+        workspace: str,
+        *,
+        retention: str = "warm",
     ) -> labels.ResourceLabels:
         return labels.ResourceLabels(
             registry=self.registry.registry_id,
@@ -405,6 +419,9 @@ class Converger:
             scope=scope,
             workspace=workspace,
             created=_now_iso(),
+            # Warm is the absence of the label, not a label saying "warm": that keeps an
+            # ordinary resource's label set exactly what it has always been.
+            retention=None if retention == "warm" else retention,
         )
 
     def _ensure_image(self, stack: StackSpec, digest: str, tag: str, workspace: str) -> None:
@@ -469,7 +486,7 @@ class Converger:
             )
             created.append(name)
             expected_labels = self._resource_labels(
-                stack, "volume", digest, volume.scope, workspace
+                stack, "volume", digest, volume.scope, workspace, retention=volume.retention
             )
             if self.engine.run(["volume", "inspect", name]).ok:
                 self._recover_interrupted_volume(name, expected_labels)
@@ -481,6 +498,7 @@ class Converger:
                     digest=digest,
                     scope=volume.scope,
                     workspace=workspace,
+                    retention=volume.retention,
                 )
                 continue
             # Record the exact intended identity before Docker creation.  If the process
@@ -497,7 +515,7 @@ class Converger:
             result = self.engine.run(["volume", "create", *label_args, name])
             if not result.ok:
                 raise EngineError(f"creating volume {name} failed: {result.stderr}")
-            self._register(stack, "volume", name, digest, volume.scope, workspace)
+            self._register(stack, "volume", name, digest, volume.scope, workspace, volume.retention)
             self.registry.delete_volume_creation_intent(name)
         return created
 
@@ -555,6 +573,7 @@ class Converger:
         digest: str,
         scope: str,
         workspace: str,
+        retention: str = "warm",
     ) -> None:
         """Prove ownership before reviving a reused engine object in the registry."""
         raw = ResourceScanner(self.engine).inspect_labels(kind, inspect_name)
@@ -573,6 +592,10 @@ class Converger:
             raise EngineError(f"existing {kind} {inspect_name!r} has a conflicting bosn kind label")
         if kind == "image":
             self.registry.canonicalize_image_identity(inspect_name, engine_name)
+        # The engine's label outranks the caller's default for a resource bosn did not
+        # create in this process: a volume adopted from labels alone has no manifest behind
+        # it here, and reading the row back as warm would silently un-pin it.
+        retention = parsed.retention or retention
         self.registry.reconcile_resource(
             kind=kind,
             name=engine_name,
@@ -580,10 +603,18 @@ class Converger:
             generation=digest,
             scope=scope,
             workspace=workspace,
+            retention=retention,
         )
 
     def _register(
-        self, stack: StackSpec, kind: str, name: str, digest: str, scope: str, workspace: str
+        self,
+        stack: StackSpec,
+        kind: str,
+        name: str,
+        digest: str,
+        scope: str,
+        workspace: str,
+        retention: str = "warm",
     ) -> None:
         self.registry.register_resource(
             kind=kind,
@@ -592,7 +623,25 @@ class Converger:
             generation=digest,
             scope=scope,
             workspace=workspace,
+            retention=retention,
         )
+
+    # -- guest stacks -------------------------------------------------------
+
+    def host_capability(self) -> guest_mod.HostCapability:
+        """This host's guest-stack capability, probed once per Converger.
+
+        Memoized because `create_args` and the preflight both want it and the probe reads
+        /proc and stats device nodes; the answer cannot change while a converge runs.
+        """
+        if self._host_capability is None:
+            self._host_capability = guest_mod.probe_host()
+        return self._host_capability
+
+    def _require_supported_host(self, stack: StackSpec) -> None:
+        if not stack.is_guest:
+            return
+        guest_mod.require_supported_host(stack.name, self.host_capability())
 
     # -- running -----------------------------------------------------------
 
@@ -635,6 +684,30 @@ class Converger:
             )
             if stale:
                 self._refuse_if_container_leased(name)
+                if stack.is_guest:
+                    # `rm --force` is an immediate SIGKILL: it does not honour the
+                    # `--stop-timeout 120` this kind sets at create time. For a Linux stack
+                    # that is fine -- PID 1 is a `sleep` loop with nothing to lose. Here it
+                    # is QEMU killed mid-write on a tens-of-GB pinned disk whose only
+                    # rebuild path is an hour with an installer, so bosn's own replacement
+                    # would defeat the guard bosn itself installed. Ask for a graceful stop
+                    # first and let the guest flush.
+                    #
+                    # The explicit timeout is load-bearing: `Engine.run` defaults to 60s and
+                    # `docker stop` legitimately takes the container's full 120s here, so
+                    # the default would abort the very shutdown being waited on. A failed
+                    # stop is not fatal -- the forced removal below still runs -- but it is
+                    # worth an event, because it is the one line that explains a guest disk
+                    # that comes back needing repair.
+                    stopped = self.engine.run(
+                        ["stop", container_id],
+                        timeout=guest_mod.STOP_TIMEOUT_SECONDS + 30,
+                    )
+                    if not stopped.ok:
+                        self.registry.log_event(
+                            "guest.stop_before_replace_failed",
+                            f"{name}: {stopped.stderr or stopped.stdout}",
+                        )
                 # Mutate the exact object whose ownership was proved. A name could be
                 # externally reused between inspect and remove; deleting by name would
                 # then destroy a foreign replacement we never validated.
@@ -653,7 +726,14 @@ class Converger:
                 stack, "container", converged.digest, "stack", workspace
             )
             # Docker removes an orphan automatically once PID 1's watchdog exits.
-            args = ["create", "--rm", "--name", name, *resource_labels.to_docker_args()]
+            # `--rm` only for stacks that carry the heartbeat watchdog: it is what lets
+            # Docker reap the container once PID 1 notices the daemon is gone. A guest stack
+            # has no watchdog (see `_expected_container_mounts`), so `--rm` would instead
+            # mean the container vanishes the moment the guest is stopped for any reason,
+            # taking an anonymous-volume-backed disk with it if the user forgot to declare
+            # storage. Keep it, and let the container tiers remove it on their own clock.
+            rm_args = [] if stack.is_guest else ["--rm"]
+            args = ["create", *rm_args, "--name", name, *resource_labels.to_docker_args()]
             for mount in expected_mounts.values():
                 if mount["type"] == "tmpfs":
                     entry = next(
@@ -669,16 +749,25 @@ class Converger:
             # fresh container through `_container_stale_reasons` before this code runs.
             for key, value in sorted(stack.env.items()):
                 args += ["--env", f"{key}={value}"]
-            # PID 1 exits only when the daemon heartbeat goes stale. Execution deadlines
-            # belong to the individual `docker exec`, not the container's creation time:
-            # a warm container may correctly serve many later sessions.
-            watchdog = (
-                "while :; do now=$(date +%s); "
-                "beat=$(stat -c %Y /bosn-daemon/heartbeat 2>/dev/null || echo 0); "
-                f"[ $((now-beat)) -gt {CONTAINER_HEARTBEAT_TIMEOUT_SECONDS} ] && exit 0; "
-                "sleep 30; done"
-            )
-            args += [converged.image_tag, "sh", "-c", watchdog]
+            if stack.is_guest:
+                # Device passthrough, published ports, and the guest's sizing env. No
+                # command argument follows the image, deliberately: dockur's ENTRYPOINT
+                # *is* the VM, so appending `sh -c ...` the way a Linux stack does would
+                # replace the guest with a shell and produce a container that starts, stays
+                # up, and never boots macOS.
+                args += guest_mod.create_args(stack.guest_spec(), self.host_capability())
+                args += [converged.image_tag]
+            else:
+                # PID 1 exits only when the daemon heartbeat goes stale. Execution deadlines
+                # belong to the individual `docker exec`, not the container's creation time:
+                # a warm container may correctly serve many later sessions.
+                watchdog = (
+                    "while :; do now=$(date +%s); "
+                    "beat=$(stat -c %Y /bosn-daemon/heartbeat 2>/dev/null || echo 0); "
+                    f"[ $((now-beat)) -gt {CONTAINER_HEARTBEAT_TIMEOUT_SECONDS} ] && exit 0; "
+                    "sleep 30; done"
+                )
+                args += [converged.image_tag, "sh", "-c", watchdog]
             created = self.engine.run(args)
             if not created.ok:
                 raise EngineError(f"creating persistent container {name} failed: {created.stderr}")
@@ -798,6 +887,15 @@ class Converger:
                 "destination": entry.destination,
                 "rw": entry.readwrite,
             }
+        if stack.is_guest:
+            # No heartbeat bind, because there is no watchdog to read it: a guest stack's
+            # PID 1 is dockur's own entrypoint (the VM), not the `sh -c` loop that watches
+            # this file and lets Docker reap an orphaned container. Mounting it anyway would
+            # add a host-path dependency that nothing in the container ever opens. A guest
+            # container is reclaimed by the ordinary container tiers in `retention.py`
+            # instead; unlike its storage volume, it is cheap to recreate -- a boot, not an
+            # hour with an installer.
+            return mounts
         heartbeat = (self.registry.path.parent / "daemon.heartbeat").resolve()
         heartbeat.touch(exist_ok=True)
         mounts["/bosn-daemon/heartbeat"] = {
@@ -1106,33 +1204,89 @@ class Converger:
         caller's terminal and exit status.
         """
         workspace = workspace or workspace_of(self.manifest)
+        stack = self.manifest.stack(converged.stack)
         name, leases = self._acquire_execution_container(
             converged, stack_name=stack_name, workspace=workspace
         )
-        # `workdir` is not baked into the container at create time (see
-        # `generation_digest`'s comment on why it is excluded from the digest) -- it is
-        # supplied here, fresh, on every `exec`, the same way `command` itself is.
-        workdir = self.manifest.stack(converged.stack).workdir
-        workdir_args = ["--workdir", workdir] if workdir else []
-        args = ["exec", *workdir_args, name, *command]
         try:
-            result = self.engine.run(args, timeout=self.run_max_duration)
+            if stack.is_guest:
+                returncode, output = self._run_in_guest(stack, name, command)
+            else:
+                # `workdir` is not baked into the container at create time (see
+                # `generation_digest`'s comment on why it is excluded from the digest) -- it
+                # is supplied here, fresh, on every `exec`, the same way `command` itself is.
+                workdir_args = ["--workdir", stack.workdir] if stack.workdir else []
+                result = self.engine.run(
+                    ["exec", *workdir_args, name, *command], timeout=self.run_max_duration
+                )
+                returncode, output = result.returncode, result.stdout or result.stderr
         finally:
             for lease in leases:
                 self.registry.release_lease(lease.id)
-        self.registry.log_event("run", f"{converged.stack} rc={result.returncode}")
-        return converged, result.returncode, result.stdout or result.stderr
+        self.registry.log_event("run", f"{converged.stack} rc={returncode}")
+        return converged, returncode, output
+
+    def _run_in_guest(
+        self, stack: StackSpec, container: str, command: list[str]
+    ) -> tuple[int, str]:
+        """Wait for the guest to be reachable, then run one task inside the VM over ssh.
+
+        `docker exec` is not an option here: it would land in the container, beside the VM
+        rather than inside it, and quietly run the task against a Linux userland the task
+        was never written for. The exit code that comes back is the task's own, which is
+        what lets CI gate on it -- see `guest.describe_exit` for the one ambiguity ssh
+        introduces.
+        """
+        guest = stack.guest_spec()
+        try:
+            waited = guest_mod.ensure_ready(
+                guest,
+                fetch_logs=guest_mod.container_log_reader(self.engine, container),
+                report=self.progress,
+            )
+        except guest_mod.GuestNotReadyError as exc:
+            self.registry.log_event("guest.not_ready", f"{stack.name}: {exc}")
+            raise EngineError(str(exc)) from exc
+        self.registry.log_event("guest.ready", f"{stack.name} in {waited:.0f}s")
+        shipped = guest_mod.ship_payload(guest, self.manifest.root, timeout=self.run_max_duration)
+        if shipped:
+            self.registry.log_event("guest.payload_shipped", f"{stack.name} -> {shipped}")
+
+        # A Linux stack receives `["sh", "-c", cmd]`; the guest's shell plays the role of
+        # `sh -c`, so the same task text means the same thing on both kinds.
+        payload = command[2] if command[:2] == ["sh", "-c"] and len(command) == 3 else None
+        remote = guest_mod.remote_command(
+            guest,
+            payload if payload is not None else shlex.join(command),
+            workdir=stack.workdir,
+        )
+        returncode, output = guest_mod.run_remote(
+            guest_mod.ssh_argv(guest, remote), timeout=self.run_max_duration
+        )
+        if returncode == guest_mod.SSH_TRANSPORT_FAILURE:
+            self.registry.log_event(
+                "guest.ambiguous_exit", f"{stack.name}: {guest_mod.describe_exit(returncode)}"
+            )
+        return returncode, output
 
     def shell_converged(
         self, converged: ConvergeResult, *, stack_name: str | None, workspace: str
     ) -> int:
         """Attach a real interactive shell to the persistent container."""
+        stack = self.manifest.stack(converged.stack)
         name, leases = self._acquire_execution_container(
             converged, stack_name=stack_name, workspace=workspace
         )
-        workdir = self.manifest.stack(converged.stack).workdir
-        workdir_args = ["--workdir", workdir] if workdir else []
+        workdir_args = ["--workdir", stack.workdir] if stack.workdir else []
         try:
+            if stack.is_guest:
+                # An interactive shell must land in the VM for the same reason a task does.
+                # Readiness is not polled here: the user is present, so a refused connection
+                # is immediate, legible feedback rather than a silent minutes-long wait.
+                guest = stack.guest_spec()
+                return guest_mod.interactive_remote(
+                    guest_mod.ssh_argv(guest, guest_mod.login_command(stack.workdir))
+                )
             return self.engine.interactive(["exec", "-it", *workdir_args, name, "sh"])
         finally:
             for lease in leases:

--- a/src/bosn/daemon.py
+++ b/src/bosn/daemon.py
@@ -33,7 +33,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from bosn import __version__, ipc
+from bosn import __version__, ipc, labels
 from bosn.clock import Clock, SystemClock
 from bosn.config import Config
 from bosn.jobs import BuildOutcome, Job, JobError, JobManager
@@ -53,6 +53,7 @@ MUTATING_VERBS = frozenset(
         "adopt",
         "compose-adopt",
         "reconcile-volume",
+        "release-volume",
         "execution-acquire",
         "execution-release",
         "compose-acquire",
@@ -1002,6 +1003,7 @@ class Daemon:
             "cancel": self._verb_cancel,
             "gc": self._verb_gc,
             "reconcile-volume": self._verb_reconcile_volume,
+            "release-volume": self._verb_release_volume,
             "done": self._verb_done,
             "adopt": self._verb_adopt,
             "compose-adopt": self._verb_compose_adopt,
@@ -1277,11 +1279,142 @@ class Daemon:
                     generation=digest,
                     scope=volume.scope,
                     workspace=workspace,
+                    retention=volume.retention,
                 )
                 self.registry.log_event("volume.legacy_reconciled", name)
         except TransferError as exc:
             return {"ok": False, "error": str(exc), "plan": plan.to_dict()}
         return {"ok": True, "applied": True, "plan": final_plan.to_dict()}
+
+    def _verb_release_volume(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Release one pinned volume, the only way a pinned volume is ever collected (#151).
+
+        A pinned volume is exempt from every automatic rule in `retention.py`, which is the
+        whole point of the tier -- so it needs exactly one deliberate exit, and this is it.
+        The verb is narrow on purpose:
+
+        - it takes a *declared* stack and logical volume name, never an engine name, so a
+          mistyped name fails against the manifest rather than deleting something else;
+        - it refuses a volume that is not declared pinned, because a warm volume already has
+          a lifecycle and this must not become a general "delete my volume" tool;
+        - it re-proves ownership from the engine's labels, refuses an active lease, and
+          refuses a volume still attached to a container -- the same three proofs GC
+          requires, held under the lifecycle guard so nothing can lease it in between;
+        - and it previews unless given both `--apply` and `--yes`, since the state it
+          deletes is by definition the state that was expensive to create.
+        """
+        from pathlib import Path
+
+        from bosn.converge import generation_coalescing_key, volume_name_for, workspace_of
+        from bosn.engine import Engine
+        from bosn.manifest import DEFAULT_RETENTION, ManifestError, load
+        from bosn.resources import ResourceScanner, resource_is_leased, volume_is_attached
+
+        manifest_text = str(request.get("manifest") or "")
+        stack_name = str(request.get("stack") or "")
+        logical_name = str(request.get("volume") or "")
+        if not manifest_text or not stack_name or not logical_name:
+            return {"ok": False, "error": "release-volume requires manifest, stack, and volume"}
+        try:
+            manifest = load(Path(manifest_text))
+            stack = manifest.stack(stack_name)
+            volume = next(item for item in stack.volumes if item.name == logical_name)
+        except (ManifestError, StopIteration) as exc:
+            detail = (
+                str(exc)
+                if isinstance(exc, ManifestError)
+                else "volume is not declared by the selected stack"
+            )
+            return {"ok": False, "error": detail}
+        if volume.retention == DEFAULT_RETENTION:
+            return {
+                "ok": False,
+                "error": (
+                    f"volume {logical_name!r} of stack {stack.name!r} is not pinned; "
+                    "warm volumes are reclaimed by `bosn gc` on their own tier and do not "
+                    "need an explicit release"
+                ),
+            }
+
+        workspace = workspace_of(manifest)
+        engine = Engine(str(request.get("engine") or self.engine_binary))
+        # Only a `spec`-scoped volume's name contains the digest; `stack` and `machine`
+        # scopes are keyed on the workspace and family alone. Resolving a generation for
+        # those would pull the stack's image for a name that cannot depend on it -- and for
+        # the motivating case, a pinned guest disk, that image is tens of gigabytes fetched
+        # through a control-plane timeout, to delete something. Even where the digest is
+        # needed, `generation_coalescing_key` reads local image identity without pulling:
+        # this verb removes state, so it must never be the thing that fetches any.
+        digest = (
+            generation_coalescing_key(manifest, stack, engine) if volume.scope == "spec" else ""
+        )
+        name = volume_name_for(
+            stack,
+            volume.scope,
+            volume.name,
+            digest=digest,
+            workspace=workspace,
+            family=stack.family,
+        )
+        plan = {
+            "stack": stack.name,
+            "volume": volume.name,
+            "engine_name": name,
+            "scope": volume.scope,
+            "retention": volume.retention,
+            "action": "would-remove",
+        }
+        if not bool(request.get("apply")):
+            return {"ok": True, "applied": False, "plan": plan}
+        if not bool(request.get("yes")):
+            return {
+                "ok": False,
+                "error": "release-volume requires --yes together with --apply",
+                "plan": plan,
+            }
+
+        with self.registry.lifecycle_guard():
+            raw = ResourceScanner(engine).inspect_labels("volume", name)
+            if not labels.is_owned_by(raw, self.registry.registry_id):
+                ownership = "foreign" if labels.is_complete(raw) else "unlabeled or incomplete"
+                return {
+                    "ok": False,
+                    "error": (
+                        f"volume {name!r} is {ownership}; bosn removes only resources whose "
+                        "labels prove this registry created them"
+                    ),
+                    "plan": plan,
+                }
+            resource = self.registry.get_resource_by_engine_identity("volume", name)
+            if resource is not None and resource_is_leased(self.registry, resource.id):
+                return {
+                    "ok": False,
+                    "error": (
+                        f"volume {name!r} has an active execution lease; retry after that "
+                        "command exits"
+                    ),
+                    "plan": plan,
+                }
+            if volume_is_attached(engine, name):
+                return {
+                    "ok": False,
+                    "error": (
+                        f"volume {name!r} is still attached to a container; stop it first "
+                        "(`bosn done`, or stop the guest) and retry"
+                    ),
+                    "plan": plan,
+                }
+            removed = engine.run(["volume", "rm", name])
+            if not removed.ok:
+                return {
+                    "ok": False,
+                    "error": f"removing volume {name} failed: {removed.stderr or removed.stdout}",
+                    "plan": plan,
+                }
+            if resource is not None:
+                self.registry.remove_resource(resource.id)
+            self.registry.log_event("volume.released", f"{stack.name}/{volume.name} {name}")
+        return {"ok": True, "applied": True, "plan": {**plan, "action": "removed"}}
 
     def _verb_done(self, request: dict[str, Any]) -> dict[str, Any]:
         from bosn.gc import mark_done

--- a/src/bosn/guest.py
+++ b/src/bosn/guest.py
@@ -1,0 +1,476 @@
+"""The macOS x86-64 guest stack kind.
+
+A guest stack is a `dockurr/macos` container whose real workload runs in a QEMU/KVM virtual
+machine *inside* it. That one fact is what makes it a distinct stack kind rather than a
+stack with unusual options, and it decides everything in this module:
+
+- **Create time needs device passthrough.** Without `/dev/kvm` the guest emulates and is
+  unusably slow; without `/dev/net/tun` plus `NET_ADMIN` it has no network at all, so no
+  sshd, so no way in. These are `docker create` arguments, which is why they are part of the
+  generation digest -- Docker cannot re-cap a container after the fact.
+- **"Container running" is not "ready".** The container is up in a second; macOS is booted
+  minutes later, and on one core, later than that. Readiness is a bounded poll for the
+  guest's sshd, with the guest's own logs attached if the deadline passes -- a fixed sleep
+  is wrong in both directions, and a wrong-but-invisible one costs a CI job.
+- **`docker exec` lands in the wrong namespace.** It runs in the container, beside the VM,
+  not inside it. The execution transport is ssh, and a task's real exit code has to come
+  back through it or nothing can gate on the result.
+- **A bind mount is invisible to the guest.** The manifest refuses `[stack.X.mounts]` on a
+  guest stack (see `manifest.StackSpec.__post_init__`); anything the task needs is shipped
+  over the same ssh channel that runs it.
+
+Everything here is a pure function of its arguments plus injected probes, so the whole kind
+is testable without a host that has KVM -- which no CI runner bosn builds on does.
+"""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from bosn.engine import EngineError
+from bosn.manifest import GuestSpec
+
+# Both guest failures subclass `EngineError` deliberately. They are raised from three
+# places -- `converge()` inside a daemon build job, `Converger.run_converged`, and the CLI's
+# own foreground execution -- and every one of those already has an `except EngineError`
+# that turns a failure into a legible message and an exit code. A bare `RuntimeError` would
+# escape all three and surface the single most common real failure ("this host has no
+# /dev/kvm") as a traceback.
+
+# `dockur/macos` issue #268: a PCID feature mismatch makes a multi-core guest unstable on
+# AMD hosts. Detecting the vendor and forcing one core is better than letting a user
+# discover it as a guest that hangs partway through a test run. Intel hosts are unaffected.
+AMD_VENDOR = "AuthenticAMD"
+AMD_SAFE_CPU_CORES = 1
+DEFAULT_CPU_CORES = 2
+
+# Required for the guest to have working virtualization and a network, respectively.
+REQUIRED_DEVICES = ("/dev/kvm", "/dev/net/tun")
+REQUIRED_CAPABILITIES = ("NET_ADMIN",)
+
+# Tens of gigabytes of guest disk are in flight; a `SIGKILL` after the default 10 seconds
+# can leave the filesystem torn. dockur's own documentation asks for a long stop timeout,
+# and the working scripts this kind was ported from use 120s.
+STOP_TIMEOUT_SECONDS = 120
+
+# ssh's own "could not connect" exit status. It collides with a task that genuinely exits
+# 255, which is why the failure text says which one bosn believes it saw rather than
+# silently reporting one as the other.
+SSH_TRANSPORT_FAILURE = 255
+
+# The guest is a throwaway VM reached over a loopback port that is reused across
+# generations, so its host key legitimately changes and there is no trust decision for a
+# user to make. Recording it would produce a spurious mismatch on the next rebuild.
+SSH_OPTIONS = (
+    "-o",
+    "StrictHostKeyChecking=no",
+    "-o",
+    "UserKnownHostsFile=/dev/null",
+    "-o",
+    "LogLevel=ERROR",
+)
+
+
+class GuestUnsupportedError(EngineError):
+    """This host cannot run a macOS guest stack, and no retry will change that."""
+
+
+class GuestNotReadyError(EngineError):
+    """The guest's sshd did not answer before the deadline."""
+
+
+@dataclass(frozen=True)
+class HostCapability:
+    """What a host offers a guest stack, as one inspectable value."""
+
+    platform: str
+    devices_present: tuple[str, ...]
+    cpu_vendor: str | None
+
+    @property
+    def missing_devices(self) -> tuple[str, ...]:
+        return tuple(d for d in REQUIRED_DEVICES if d not in self.devices_present)
+
+
+def probe_host(
+    *,
+    platform: str | None = None,
+    device_exists: Callable[[str], bool] | None = None,
+    cpuinfo: Callable[[], str] | None = None,
+) -> HostCapability:
+    """Read this host's capability. Every input is injectable so tests need no KVM."""
+    import sys
+
+    resolved_platform = sys.platform if platform is None else platform
+    exists = device_exists or (lambda path: Path(path).exists())
+    return HostCapability(
+        platform=resolved_platform,
+        devices_present=tuple(device for device in REQUIRED_DEVICES if exists(device)),
+        cpu_vendor=_cpu_vendor(cpuinfo or _read_cpuinfo),
+    )
+
+
+def _read_cpuinfo() -> str:
+    try:
+        return Path("/proc/cpuinfo").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _cpu_vendor(read: Callable[[], str]) -> str | None:
+    """The host CPU's `vendor_id`, or None when it cannot be read.
+
+    None is not treated as Intel anywhere below: an unknown vendor takes the conservative
+    single-core path, because the cost of guessing wrong toward AMD is a slower guest and
+    the cost of guessing wrong toward Intel is an unstable one.
+    """
+    for line in read().splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip() == "vendor_id":
+            return value.strip() or None
+    return None
+
+
+def require_supported_host(stack_name: str, host: HostCapability) -> None:
+    """Refuse a guest stack on a host that cannot run it, before touching the engine.
+
+    Everything checked here is a property of the machine, not of anything bosn did, so the
+    message names the host condition and stops. Converging first and failing inside
+    `docker create` would produce a container that can never work and an error from QEMU
+    several layers below the actual cause.
+    """
+    if not host.platform.startswith("linux"):
+        raise GuestUnsupportedError(
+            f"stack {stack_name!r} is a macOS guest stack, which needs Linux KVM device "
+            f"passthrough; this host reports platform {host.platform!r}. Run it on a Linux "
+            "host with /dev/kvm, or select a different stack."
+        )
+    missing = host.missing_devices
+    if missing:
+        raise GuestUnsupportedError(
+            f"stack {stack_name!r} needs {', '.join(missing)}, which this host does not "
+            "expose. /dev/kvm requires hardware virtualization enabled in firmware and a "
+            "user with access to it; /dev/net/tun requires the tun module loaded."
+        )
+
+
+def effective_cpu_cores(guest: GuestSpec, host: HostCapability) -> int:
+    """How many cores to give the guest.
+
+    An explicit `cpu_cores` in the manifest is honored as written -- if a user has read
+    dockur/macos#268 and decided otherwise for their hardware, that is their call. Otherwise
+    an AMD host, or a host whose vendor could not be read, gets one core.
+    """
+    if guest.cpu_cores is not None:
+        return guest.cpu_cores
+    if host.cpu_vendor == AMD_VENDOR or host.cpu_vendor is None:
+        return AMD_SAFE_CPU_CORES
+    return DEFAULT_CPU_CORES
+
+
+def create_args(guest: GuestSpec, host: HostCapability) -> list[str]:
+    """The guest-specific half of `docker create`, in a deterministic order.
+
+    Deterministic because these arguments are effectively the container's identity: they are
+    digested (see `GuestSpec.digest_fields`), they appear in every log line a human reads
+    when a guest misbehaves, and a stable ordering is what lets a test assert on them.
+    """
+    args: list[str] = []
+    for device in REQUIRED_DEVICES:
+        args += ["--device", device]
+    for capability in REQUIRED_CAPABILITIES:
+        args += ["--cap-add", capability]
+    args += ["--stop-timeout", str(STOP_TIMEOUT_SECONDS)]
+    args += ["--publish", f"{guest.web_port}:8006"]
+    args += ["--publish", f"{guest.ssh_port}:22"]
+    for key, value in sorted(
+        {
+            "VERSION": guest.version,
+            "RAM_SIZE": guest.ram_size,
+            "DISK_SIZE": guest.disk_size,
+            "CPU_CORES": str(effective_cpu_cores(guest, host)),
+        }.items()
+    ):
+        args += ["--env", f"{key}={value}"]
+    return args
+
+
+def wait_for_sshd(
+    guest: GuestSpec,
+    *,
+    probe: Callable[[str, int], bool],
+    now: Callable[[], float],
+    sleep: Callable[[float], None],
+    on_wait: Callable[[str], None] | None = None,
+) -> float:
+    """Poll the guest's sshd until it answers, or raise at the deadline.
+
+    Returns how long the wait took, so a caller can log the real boot time instead of the
+    budget. The clock, the sleep, and the probe are all injected: a test must be able to
+    exercise both the ready path and the timeout path without waiting minutes for either.
+    """
+    started = now()
+    deadline = started + guest.ready_timeout
+    report = on_wait or (lambda _message: None)
+    attempts = 0
+    while True:
+        if probe(guest.ssh_host, guest.ssh_port):
+            return now() - started
+        attempts += 1
+        if now() >= deadline:
+            raise GuestNotReadyError(
+                f"guest sshd did not answer on {guest.ssh_host}:{guest.ssh_port} within "
+                f"{guest.ready_timeout}s ({attempts} attempts). macOS boots slowly, "
+                "especially on one core; if this is a first boot the guest may still be "
+                "running its installer -- open the dockur web console on "
+                f"http://localhost:{guest.web_port} to see where it stopped."
+            )
+        report(f"waiting for guest sshd on :{guest.ssh_port} ({int(deadline - now())}s left)")
+        sleep(guest.ready_poll_interval)
+
+
+def ensure_ready(
+    guest: GuestSpec,
+    *,
+    fetch_logs: Callable[[], str],
+    report: Callable[[str], None] | None = None,
+    probe: Callable[[str, int], bool] | None = None,
+) -> float:
+    """`wait_for_sshd` with the guest's own logs attached to the timeout.
+
+    By the time the deadline passes the caller has already waited out the whole budget, and
+    the reason a guest never came up -- a stalled installer, a missing disk, a QEMU refusal
+    -- lives only in its logs. Making them go find `docker logs` themselves is the
+    fixed-sleep failure mode all over again, so the logs travel with the error.
+
+    Shared by the converge path and the CLI's own foreground execution, which run the task
+    through different transports but must fail identically when the guest is not there.
+    """
+    import time
+
+    try:
+        return wait_for_sshd(
+            guest,
+            probe=probe or tcp_probe,
+            now=time.monotonic,
+            sleep=time.sleep,
+            on_wait=report,
+        )
+    except GuestNotReadyError as exc:
+        raise GuestNotReadyError(
+            f"{exc}\n--- guest logs (last 60 lines) ---\n{fetch_logs().strip()}"
+        ) from exc
+
+
+def container_log_reader(engine: object, container: str) -> Callable[[], str]:
+    """A callable that fetches the last 60 lines of one container's logs, or explains why not."""
+
+    def read() -> str:
+        try:
+            result = engine.run(["logs", "--tail", "60", container])  # type: ignore[attr-defined]
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # noqa: BLE001 - a log fetch must never mask the real failure
+            return f"(could not read {container} logs: {exc})"
+        return getattr(result, "stdout", "") or getattr(result, "stderr", "") or ""
+
+    return read
+
+
+def tcp_probe(host: str, port: int, *, timeout: float = 3.0) -> bool:
+    """True when something accepts a TCP connection at `host:port`.
+
+    A completed handshake is exactly the readiness signal wanted here: the port is published
+    by the container from the moment it starts, but nothing listens behind it until the
+    guest's own sshd is up, so a connection that completes means macOS has booted far enough
+    to serve one.
+    """
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except KeyboardInterrupt:
+        raise
+    except OSError:
+        return False
+
+
+def payload_argv(guest: GuestSpec, source: Path) -> list[str]:
+    """`scp` argv that ships this stack's declared payload into the guest before a task.
+
+    This is the answer to "the repo mount cannot be a plain bind": the VM cannot see the
+    container's filesystem, so the one artifact a task needs travels over the same ssh
+    channel that runs it. One file, not a tree -- the recommended shape is to cross-compile
+    on Linux and ship a single prebuilt archive, which is both far smaller than the source
+    and removes the guest's whole toolchain burden. See docs/macos-guest.md.
+    """
+    return scp_argv(guest, source, guest.payload_destination)
+
+
+def ssh_argv(guest: GuestSpec, command: str) -> list[str]:
+    """`ssh` argv that runs one shell command in the guest and returns its exit code."""
+    return [
+        "ssh",
+        *SSH_OPTIONS,
+        "-p",
+        str(guest.ssh_port),
+        f"{guest.ssh_user}@{guest.ssh_host}",
+        command,
+    ]
+
+
+def scp_argv(guest: GuestSpec, source: Path | str, destination: str) -> list[str]:
+    """`scp` argv that ships one local file to `destination` inside the guest."""
+    return [
+        "scp",
+        *SSH_OPTIONS,
+        "-P",
+        str(guest.ssh_port),
+        str(source),
+        f"{guest.ssh_user}@{guest.ssh_host}:{destination}",
+    ]
+
+
+def ship_payload(
+    guest: GuestSpec,
+    root: Path,
+    *,
+    timeout: float | None = None,
+    runner: Callable[..., object] | None = None,
+) -> str | None:
+    """Copy the stack's declared payload into the guest. Returns where it landed, or None.
+
+    Runs before every task rather than once at container creation: the payload is a build
+    output that changes between runs, and a guest that keeps serving last week's archive
+    while reporting success is the worst failure this whole kind can produce.
+    """
+    if not guest.payload:
+        return None
+    source = (root / guest.payload).resolve()
+    if not source.is_file():
+        raise GuestUnsupportedError(
+            f"guest payload {guest.payload!r} resolves to {source}, which is not a file. "
+            "Build it before running the guest task -- the recommended shape is to "
+            "cross-compile on Linux and ship one prebuilt archive (see docs/macos-guest.md)."
+        )
+    code, output = run_remote(payload_argv(guest, source), timeout=timeout, runner=runner)
+    if code != 0:
+        raise GuestNotReadyError(
+            f"shipping {source.name} into the guest failed ({describe_exit(code)}): {output}"
+        )
+    return guest.payload_destination
+
+
+def remote_command(guest: GuestSpec, cmd: str, *, workdir: str | None = None) -> str:
+    """The single shell string the guest runs for one task.
+
+    `cmd` is passed to the guest's shell verbatim, exactly as `sh -c` does for a Linux
+    stack, so a task's `cmd` means the same thing on both kinds. Only the `cd` is quoted:
+    the workdir is a path bosn substitutes, and an unquoted one with a space in it would
+    silently truncate.
+    """
+    if workdir:
+        return f"cd {shlex.quote(workdir)} && {cmd}"
+    return cmd
+
+
+def run_remote(
+    argv: list[str],
+    *,
+    timeout: float | None = None,
+    runner: Callable[..., object] | None = None,
+) -> tuple[int, str]:
+    """Run an `ssh`/`scp` argv locally and return `(returncode, combined output)`.
+
+    Deliberately not routed through `engine.Engine`: that class exists to drive the
+    container engine binary and prefixes every argv with it. ssh is a peer of docker here,
+    not a subcommand of it, and giving Engine a "run something that is not the engine" verb
+    would blur the one thing it is for.
+
+    stderr is folded into stdout because a failing remote command's diagnosis is routinely
+    split across both, and the caller reports a single block of output either way.
+    """
+    import subprocess
+
+    run = runner or subprocess.run
+    try:
+        completed = run(
+            argv,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except KeyboardInterrupt:
+        raise
+    except subprocess.TimeoutExpired as exc:
+        raise GuestNotReadyError(
+            f"{argv[0]} exceeded its {timeout}-second deadline against the guest"
+        ) from exc
+    except OSError as exc:
+        raise GuestUnsupportedError(
+            f"cannot run {argv[0]!r}: {exc}. A macOS guest stack ships and executes its "
+            "work over ssh, so an ssh client must be on PATH."
+        ) from exc
+    stdout = (getattr(completed, "stdout", "") or "").strip()
+    stderr = (getattr(completed, "stderr", "") or "").strip()
+    combined = "\n".join(part for part in (stdout, stderr) if part)
+    return int(getattr(completed, "returncode", 1)), combined
+
+
+def interactive_remote(
+    argv: list[str],
+    *,
+    timeout: float | None = None,
+    runner: Callable[..., object] | None = None,
+) -> int:
+    """Run an `ssh` argv with this process's stdio inherited.
+
+    Used for `bosn shell` and for an ordinary (non-JSON) `bosn run`, which streams a long
+    test run live rather than holding its output to the end. `timeout` is the caller's
+    `run_max_duration`, the same deadline the `docker exec` path applies -- inherited stdio
+    does not exempt a guest task from it.
+    """
+    import subprocess
+
+    run = runner or subprocess.run
+    try:
+        completed = run(argv, check=False, timeout=timeout)
+    except KeyboardInterrupt:
+        raise
+    except subprocess.TimeoutExpired as exc:
+        raise GuestNotReadyError(
+            f"{argv[0]} exceeded its {timeout}-second deadline against the guest"
+        ) from exc
+    except OSError as exc:
+        raise GuestUnsupportedError(
+            f"cannot run {argv[0]!r}: {exc}. A macOS guest stack is reached over ssh, so an "
+            "ssh client must be on PATH."
+        ) from exc
+    return int(getattr(completed, "returncode", 1))
+
+
+def login_command(workdir: str | None) -> str:
+    """The remote command for an interactive `bosn shell` against a guest.
+
+    A login shell, not `sh`: the guest is a full macOS install whose user has a real
+    environment, and dropping into a bare `sh` would hide the PATH the task itself runs
+    under.
+    """
+    login = "exec $SHELL -l"
+    return f"cd {shlex.quote(workdir)} && {login}" if workdir else login
+
+
+def describe_exit(returncode: int) -> str:
+    """Explain a returncode that ssh may have produced rather than the task."""
+    if returncode == SSH_TRANSPORT_FAILURE:
+        return (
+            f"exit {SSH_TRANSPORT_FAILURE}, which ssh also uses for its own connection "
+            "failures; check whether the guest is still reachable before reading this as a "
+            "task result"
+        )
+    return f"exit {returncode}"

--- a/src/bosn/labels.py
+++ b/src/bosn/labels.py
@@ -19,6 +19,10 @@ GENERATION = f"{NAMESPACE}.generation"
 SCOPE = f"{NAMESPACE}.scope"
 WORKSPACE = f"{NAMESPACE}.workspace"
 CREATED = f"{NAMESPACE}.created"
+# Deliberately NOT in REQUIRED_LABELS. Every resource created before the pinned tier existed
+# lacks it, and adding it to the required set would make all of them read as "incompletely
+# labeled" -- which is to say, not ours, un-collectable, and un-adoptable. Absent means warm.
+RETENTION = f"{NAMESPACE}.retention"
 
 REQUIRED_LABELS: tuple[str, ...] = (REGISTRY, KIND, STACK, GENERATION, SCOPE, WORKSPACE, CREATED)
 
@@ -39,6 +43,15 @@ class ResourceLabels:
     scope: str
     workspace: str
     created: str
+    # Optional, and last, so every positional `ResourceLabels(...)` construction keeps
+    # working. `None` means the resource predates the tier, or simply is not pinned.
+    #
+    # This is on the *label*, not only the registry row, because the registry is explicitly
+    # disposable: "Losing the database is survivable. Ownership lives in the Docker labels."
+    # Without it, `bosn adopt` after a lost registry would rebuild every row as warm, and the
+    # next `bosn done` or pressure sweep would reclaim the one volume that costs an hour of
+    # someone's day to recreate (#151).
+    retention: str | None = None
 
     def __post_init__(self) -> None:
         if self.kind not in KINDS:
@@ -49,7 +62,7 @@ class ResourceLabels:
             raise LabelError("registry id must not be empty")
 
     def to_dict(self) -> dict[str, str]:
-        return {
+        rendered = {
             REGISTRY: self.registry,
             KIND: self.kind,
             STACK: self.stack,
@@ -58,6 +71,12 @@ class ResourceLabels:
             WORKSPACE: self.workspace,
             CREATED: self.created,
         }
+        # Emitted only when set, so an unpinned resource's label set is byte-identical to
+        # the one bosn has always written. Anything comparing label dicts for equality --
+        # `_recover_interrupted_volume`'s saved creation intent, for one -- keeps matching.
+        if self.retention is not None:
+            rendered[RETENTION] = self.retention
+        return rendered
 
     def to_docker_args(self) -> list[str]:
         """Render as repeated `--label k=v` arguments for the engine CLI."""
@@ -79,6 +98,7 @@ class ResourceLabels:
             scope=raw[SCOPE],
             workspace=raw[WORKSPACE],
             created=raw[CREATED],
+            retention=raw.get(RETENTION) or None,
         )
 
 

--- a/src/bosn/manifest.py
+++ b/src/bosn/manifest.py
@@ -23,6 +23,26 @@ from typing import Any
 MANIFEST_NAME = "bosn.toml"
 VALID_SCOPES = {"spec", "stack", "machine"}
 
+# Retention tiers a declared volume may ask for.
+#
+# `warm` is every volume bosn has ever managed: the tiered clocks in `retention.py` decide
+# when it goes, and losing one costs a rebuild. `pinned` is for state that is *not*
+# rebuildable on demand -- the motivating case is a macOS guest disk whose only creation
+# path is a human sitting through a 30-60 minute interactive installer (#151). A pinned
+# volume is never collected by any automatic rule: not by age, not by supersession, not by
+# `bosn done`, not under storage pressure. It leaves only when a human names it to
+# `bosn release-volume --apply --yes`.
+DEFAULT_RETENTION = "warm"
+VALID_RETENTIONS = {DEFAULT_RETENTION, "pinned"}
+
+# The one non-default stack kind. A bare stack (`kind` unset) is the Linux stack bosn has
+# always run: an image, `docker create`, `docker exec`. This kind is a QEMU/KVM macOS guest
+# inside a `dockurr/macos` container, where the workload runs in a VM *within* the
+# container -- so it needs device passthrough at create time and ssh, not `docker exec`, as
+# its execution transport.
+GUEST_MACOS_X64 = "macos-x64-guest"
+VALID_KINDS = {GUEST_MACOS_X64}
+
 # bosn mounts its own objects under this prefix and keeps the daemon heartbeat beside
 # it. User mounts may not land here: a collision would shadow a managed volume or the
 # liveness file the container's PID 1 watches.
@@ -78,12 +98,20 @@ class VolumeSpec:
     name: str
     scope: str
     destination: str | None = None
+    # Appended after the existing fields on purpose: `VolumeSpec(name, scope, destination)`
+    # is constructed positionally in several places and in the test suite.
+    retention: str = DEFAULT_RETENTION
 
     def __post_init__(self) -> None:
         if self.scope not in VALID_SCOPES:
             raise ManifestError(
                 f"volume {self.name!r} has unknown scope {self.scope!r}; "
                 f"expected one of {sorted(VALID_SCOPES)}"
+            )
+        if self.retention not in VALID_RETENTIONS:
+            raise ManifestError(
+                f"volume {self.name!r} has unknown retention {self.retention!r}; "
+                f"expected one of {sorted(VALID_RETENTIONS)}"
             )
         if self.destination is not None:
             object.__setattr__(
@@ -186,6 +214,79 @@ class TmpfsSpec:
         return readwrite
 
 
+def _positive_int(value: Any, *, stack: str, key: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ManifestError(f"[stack.{stack}.guest] {key} must be a positive integer")
+    if value <= 0:
+        raise ManifestError(f"[stack.{stack}.guest] {key} must be a positive integer")
+    return value
+
+
+@dataclass(frozen=True)
+class GuestSpec:
+    """How to reach and size the VM inside a guest stack's container.
+
+    Every default here is the value the working `zackees/kernal-api` scripts proved against
+    a real `dockurr/macos` guest, so an empty `[stack.X.guest]` table is a usable stack
+    rather than a stub. `dockurr/macos` publishes its web installer on 8006 and the guest's
+    sshd is reached by mapping a host port onto the container's 22.
+    """
+
+    ssh_port: int = 2222
+    ssh_user: str = "runner"
+    ssh_host: str = "127.0.0.1"
+    web_port: int = 8006
+    # macOS boots slowly, and on one core it is minutes rather than seconds. The deadline is
+    # bounded so a guest that never comes up fails with its logs attached instead of hanging
+    # a CI job to its own timeout.
+    ready_timeout: int = 1800
+    ready_poll_interval: int = 10
+    version: str = "ventura"
+    ram_size: str = "8G"
+    disk_size: str = "128G"
+    # `None` means "decide from the host CPU vendor at create time" -- see
+    # `guest.effective_cpu_cores`. An explicit value is honored as written.
+    cpu_cores: int | None = None
+    # One repo-relative file shipped into the guest before every task, and where it lands.
+    # A guest stack cannot bind-mount -- the VM does not see the container's filesystem -- so
+    # this is how the prebuilt artifact a task needs actually gets there. Unset means bosn
+    # ships nothing and the task is responsible for finding its own inputs.
+    payload: str | None = None
+    payload_destination: str = "~/bosn-payload"
+
+    def __post_init__(self) -> None:
+        for key in ("ssh_port", "web_port", "ready_timeout", "ready_poll_interval"):
+            value = getattr(self, key)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ManifestError(f"[stack.*.guest] {key} must be a positive integer")
+        if not self.ssh_user:
+            raise ManifestError("[stack.*.guest] ssh_user must not be empty")
+        if not self.ssh_host:
+            raise ManifestError("[stack.*.guest] ssh_host must not be empty")
+        if self.ssh_port == self.web_port:
+            raise ManifestError(
+                f"[stack.*.guest] ssh_port and web_port must differ; both are {self.ssh_port}"
+            )
+        if self.cpu_cores is not None and (
+            isinstance(self.cpu_cores, bool) or not isinstance(self.cpu_cores, int)
+        ):
+            raise ManifestError("[stack.*.guest] cpu_cores must be a positive integer")
+        if self.cpu_cores is not None and self.cpu_cores <= 0:
+            raise ManifestError("[stack.*.guest] cpu_cores must be a positive integer")
+
+    def digest_fields(self) -> list[tuple[str, str]]:
+        """A stable, sorted rendering for `generation_digest`.
+
+        Every field here lands in `docker create` -- published ports, `VERSION`, `RAM_SIZE`,
+        `DISK_SIZE` -- or decides how a task reaches the guest. Docker has no verb for
+        changing a created container's port map or env, so a change to any of them must roll
+        the generation for the same reason `env` does; see `generation_digest`.
+        """
+        return sorted(
+            (key, "" if value is None else str(value)) for key, value in self.__dict__.items()
+        )
+
+
 @dataclass(frozen=True)
 class StackSpec:
     name: str
@@ -210,12 +311,66 @@ class StackSpec:
     # `generation_digest`'s comment on why that puts it on the opposite side of the digest
     # boundary from `env`.
     workdir: str | None = None
+    # `None` is the ordinary Linux stack. See GUEST_MACOS_X64 for the one alternative.
+    kind: str | None = None
+    guest: GuestSpec | None = None
+    # Apple's EULA conditions macOS on the hardware it runs on, and running it under QEMU on
+    # a non-Apple host is the user's call to make, not something they should back into by
+    # copying somebody's bosn.toml. So a guest stack is inert until this is written out
+    # explicitly -- an opt-in keyword, not a default.
+    acknowledge_macos_license: bool = False
+
+    @property
+    def is_guest(self) -> bool:
+        return self.kind == GUEST_MACOS_X64
+
+    def guest_spec(self) -> GuestSpec:
+        """The guest configuration, for callers that already know this is a guest stack."""
+        if not self.is_guest or self.guest is None:
+            raise ManifestError(f"stack {self.name!r} is not a {GUEST_MACOS_X64} stack")
+        return self.guest
 
     def __post_init__(self) -> None:
         for key in self.env:
             _validate_env_key(key, stack=self.name)
         if self.workdir is not None:
             object.__setattr__(self, "workdir", _validate_workdir(self.workdir, stack=self.name))
+        if self.kind is not None and self.kind not in VALID_KINDS:
+            raise ManifestError(
+                f"[stack.{self.name}] has unknown kind {self.kind!r}; "
+                f"expected one of {sorted(VALID_KINDS)}"
+            )
+        if self.kind is None:
+            if self.guest is not None:
+                raise ManifestError(
+                    f'[stack.{self.name}.guest] is only meaningful with kind = "{GUEST_MACOS_X64}"'
+                )
+            if self.acknowledge_macos_license:
+                raise ManifestError(
+                    f"[stack.{self.name}] sets acknowledge_macos_license without "
+                    f'kind = "{GUEST_MACOS_X64}"'
+                )
+            return
+        if not self.acknowledge_macos_license:
+            raise ManifestError(
+                f"[stack.{self.name}] declares kind = {self.kind!r}, which boots macOS on "
+                "non-Apple hardware under QEMU. Apple's licence conditions macOS on the "
+                "hardware it runs on, so bosn will not start one unless you say so in the "
+                "manifest: add `acknowledge_macos_license = true` to this stack."
+            )
+        if self.mounts:
+            # Not a policy choice -- a bind lands in the *container's* filesystem, and the
+            # guest is a VM inside that container with no view of it. Accepting the
+            # declaration would produce a stack whose repo mount silently is not there.
+            names = sorted(mount.name for mount in self.mounts)
+            raise ManifestError(
+                f"[stack.{self.name}.mounts] declares {names}, but a {self.kind} guest "
+                "cannot see host bind mounts: the workload runs in a VM inside the "
+                "container. Ship what the task needs over the guest's ssh channel instead "
+                "(see docs/macos-guest.md)."
+            )
+        if self.guest is None:
+            object.__setattr__(self, "guest", GuestSpec())
 
     def referenced_files(self, root: Path) -> list[Path]:
         """Files whose byte content folds into this stack's digest."""
@@ -350,6 +505,50 @@ def _refuse_duplicate_destinations(
         raise ManifestError(f"[stack.{stack}] mounts {duplicated} more than once")
 
 
+_GUEST_INT_KEYS = ("ssh_port", "web_port", "ready_timeout", "ready_poll_interval", "cpu_cores")
+_GUEST_STR_KEYS = (
+    "ssh_user",
+    "ssh_host",
+    "version",
+    "ram_size",
+    "disk_size",
+    "payload",
+    "payload_destination",
+)
+
+
+def _parse_guest(stack: str, body: object) -> GuestSpec | None:
+    """Read `[stack.X.guest]`, refusing unknown keys rather than ignoring them.
+
+    A silently dropped `ssh_port` would send every task to the default 2222 and fail with a
+    connection error a long way from the typo that caused it.
+    """
+    if body is None:
+        return None
+    if not isinstance(body, dict):
+        raise ManifestError(f"[stack.{stack}.guest] must be a table")
+    known = set(_GUEST_INT_KEYS) | set(_GUEST_STR_KEYS)
+    unknown = sorted(set(body) - known)
+    if unknown:
+        raise ManifestError(
+            f"[stack.{stack}.guest] has unknown keys {unknown}; expected {sorted(known)}"
+        )
+    fields: dict[str, Any] = {}
+    for key in _GUEST_INT_KEYS:
+        if key in body:
+            fields[key] = _positive_int(body[key], stack=stack, key=key)
+    for key in _GUEST_STR_KEYS:
+        if key in body:
+            value = body[key]
+            if isinstance(value, dict | list | bool):
+                raise ManifestError(f"[stack.{stack}.guest] {key} must be a string")
+            fields[key] = str(value)
+    try:
+        return GuestSpec(**fields)
+    except ManifestError as exc:
+        raise ManifestError(str(exc).replace("[stack.*.guest]", f"[stack.{stack}.guest]")) from exc
+
+
 def parse(raw: dict, root: Path, *, source_path: Path | None = None) -> Manifest:
     manifest = Manifest(root=root, source_path=source_path)
 
@@ -365,6 +564,7 @@ def parse(raw: dict, root: Path, *, source_path: Path | None = None) -> Manifest
                     if (vol_body or {}).get("destination")
                     else None
                 ),
+                retention=str((vol_body or {}).get("retention", DEFAULT_RETENTION)),
             )
             for vol_name, vol_body in (body.get("volumes") or {}).items()
         )
@@ -392,6 +592,7 @@ def parse(raw: dict, root: Path, *, source_path: Path | None = None) -> Manifest
                 )
             env[str(env_key)] = str(env_value)
         workdir = body.get("workdir")
+        kind = body.get("kind")
         stack = StackSpec(
             name=name,
             dockerfile=body.get("dockerfile"),
@@ -403,6 +604,9 @@ def parse(raw: dict, root: Path, *, source_path: Path | None = None) -> Manifest
             tmpfs=tmpfs,
             env=env,
             workdir=str(workdir) if workdir else None,
+            kind=str(kind) if kind is not None else None,
+            guest=_parse_guest(name, body.get("guest")),
+            acknowledge_macos_license=bool(body.get("acknowledge_macos_license", False)),
         )
         if stack.dockerfile is None and stack.image is None:
             raise ManifestError(f"[stack.{name}] must set either `dockerfile` or `image`")
@@ -480,6 +684,25 @@ def generation_digest(manifest: Manifest, stack: StackSpec) -> str:
         # worse. For `workdir` the alternative is not worse, so it stays out.
         "env": sorted(stack.env.items()),
     }
+    # Everything below is added to `section` *only when it is set*, so a manifest that uses
+    # none of it hashes byte-identically to the way it hashed before these fields existed.
+    # An unconditional key would roll every existing user's generation on upgrade and
+    # rebuild every warm cache in the fleet, for a feature they are not using.
+    #
+    # When they *are* set, they belong in the digest for the same reason `env` does: `kind`
+    # and every `guest` field land in `docker create` (device passthrough, published ports,
+    # `VERSION`/`RAM_SIZE`/`DISK_SIZE`), and a created container serves its create-time
+    # configuration until it is replaced.
+    if stack.kind is not None:
+        section["kind"] = stack.kind
+    if stack.guest is not None:
+        section["guest"] = stack.guest.digest_fields()
+    # A retention change *must* roll: `pinned` is written into the volume's registry row at
+    # creation, and a volume that was registered warm keeps being collectable until a fresh
+    # generation re-registers it as pinned.
+    pinned = sorted(v.name for v in stack.volumes if v.retention != DEFAULT_RETENTION)
+    if pinned:
+        section["pinned_volumes"] = pinned
     _hash_field(
         hasher,
         json.dumps(section, sort_keys=True, separators=(",", ":")).encode("utf-8"),

--- a/src/bosn/options.py
+++ b/src/bosn/options.py
@@ -37,6 +37,7 @@ class Options:
     volume: str | None = None
     yes: bool = False
     reconcile_apply: bool = False
+    release_apply: bool = False
     args: tuple[str, ...] = ()
     json: bool = False
 
@@ -149,6 +150,7 @@ def from_namespace(ns: argparse.Namespace) -> Options:
         volume=_as_str(get("volume")),
         yes=bool(get("yes", False)),
         reconcile_apply=bool(get("reconcile_apply", False)),
+        release_apply=bool(get("release_apply", False)),
         args=get_list("args"),
         json=bool(get("json", False)),
         compose=_as_str(get("compose")),

--- a/src/bosn/recovery.py
+++ b/src/bosn/recovery.py
@@ -277,6 +277,11 @@ def legacy_expected_labels(
         scope=scope,
         workspace=workspace,
         created=raw_labels.get(labels.CREATED) or _now_iso(),
+        # A surviving retention label is preserved for the same reason `created` is: this
+        # repairs an incomplete label set, and must not quietly change the tier while it
+        # does. `retention` is not in REQUIRED_LABELS, so its absence is never the defect
+        # being repaired.
+        retention=raw_labels.get(labels.RETENTION) or None,
     )
 
 

--- a/src/bosn/registry.py
+++ b/src/bosn/registry.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from bosn.clock import Clock, SystemClock
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS meta (
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS resources (
     workspace   TEXT NOT NULL,
     created_at  REAL NOT NULL,
     last_used   REAL NOT NULL,
-    state       TEXT NOT NULL DEFAULT 'active'
+    state       TEXT NOT NULL DEFAULT 'active',
+    retention   TEXT NOT NULL DEFAULT 'warm'
 );
 
 CREATE INDEX IF NOT EXISTS idx_resources_stack ON resources(stack);
@@ -136,6 +137,11 @@ class Resource:
     created_at: float
     last_used: float
     state: str = "active"
+    # "warm" (the tiered clocks decide) or "pinned" (no automatic rule ever collects it).
+    # Persisted on the row rather than re-derived from the manifest because GC runs from the
+    # registry alone -- it has no manifest in hand, and the workspace that declared the
+    # volume may not even be checked out any more.
+    retention: str = "warm"
 
 
 @dataclass(frozen=True)
@@ -266,6 +272,10 @@ class Registry:
             (str(uuid.uuid4()),),
         )
 
+    def _resources_has_retention(self) -> bool:
+        rows = self.conn.execute("PRAGMA table_info(resources)").fetchall()
+        return any(row["name"] == "retention" for row in rows)
+
     def _migrate_schema(self) -> None:
         """Upgrade old registries without losing ownership, liveness, or leases."""
         raw_version = self.meta("schema_version")
@@ -329,6 +339,25 @@ class Registry:
                     "generation TEXT NOT NULL, scope TEXT NOT NULL, workspace TEXT NOT NULL)"
                 )
                 self.conn.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", ("3",))
+                self.conn.execute("COMMIT")
+            except KeyboardInterrupt:
+                self.conn.execute("ROLLBACK")
+                raise
+            except Exception:
+                self.conn.execute("ROLLBACK")
+                raise
+
+        if version < 4:
+            # Additive, and deliberately defaulted to 'warm': every row that predates the
+            # pinned tier was created under the tiered clocks and must keep obeying them.
+            # Pinning is only ever asserted forward, by a manifest that asks for it.
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                if not self._resources_has_retention():
+                    self.conn.execute(
+                        "ALTER TABLE resources ADD COLUMN retention TEXT NOT NULL DEFAULT 'warm'"
+                    )
+                self.conn.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", ("4",))
                 self.conn.execute("COMMIT")
             except KeyboardInterrupt:
                 self.conn.execute("ROLLBACK")
@@ -493,6 +522,7 @@ class Registry:
         workspace: str,
         resource_id: str | None = None,
         created_at: float | None = None,
+        retention: str = "warm",
     ) -> Resource:
         return self._reconcile_resource(
             kind=kind,
@@ -503,6 +533,7 @@ class Registry:
             workspace=workspace,
             resource_id=resource_id,
             created_at=created_at,
+            retention=retention,
         )
 
     def reconcile_resource(
@@ -514,6 +545,7 @@ class Registry:
         generation: str,
         scope: str,
         workspace: str,
+        retention: str = "warm",
     ) -> Resource:
         """Make one engine object have one current, freshly-used registry identity."""
         return self._reconcile_resource(
@@ -523,6 +555,7 @@ class Registry:
             generation=generation,
             scope=scope,
             workspace=workspace,
+            retention=retention,
         )
 
     def _reconcile_resource(
@@ -536,6 +569,7 @@ class Registry:
         workspace: str,
         resource_id: str | None = None,
         created_at: float | None = None,
+        retention: str = "warm",
     ) -> Resource:
         with self._lock:
             previous = self.conn.execute(
@@ -548,10 +582,16 @@ class Registry:
             self.conn.execute(
                 "INSERT INTO resources"
                 "(id, kind, name, stack, generation, scope, workspace, created_at, "
-                "last_used, state) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active') "
+                "last_used, state, retention) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?) "
                 "ON CONFLICT(kind, name) DO UPDATE SET stack = excluded.stack, "
                 "generation = excluded.generation, scope = excluded.scope, "
-                "workspace = excluded.workspace, last_used = ?, state = 'active'",
+                # Retention follows the current declaration in both directions. Re-declaring
+                # a volume `warm` after it was pinned is how a user un-pins one without
+                # deleting it, and the digest rolled when they made that edit, so this
+                # statement is the first write of the new generation, not a stale one
+                # overwriting a fresh intent.
+                "workspace = excluded.workspace, retention = excluded.retention, "
+                "last_used = ?, state = 'active'",
                 (
                     rid,
                     kind,
@@ -562,6 +602,7 @@ class Registry:
                     workspace,
                     created,
                     created,
+                    retention,
                     now,
                 ),
             )
@@ -993,6 +1034,10 @@ def _resource_from_row(row: sqlite3.Row) -> Resource:
         created_at=row["created_at"],
         last_used=row["last_used"],
         state=row["state"],
+        # A registry restored from a backup taken before schema 4, or read through a
+        # connection opened read-only against an un-migrated file, has no such column.
+        # Absent means warm, which is the safe reading: it never invents a pin.
+        retention=(row["retention"] if "retention" in row.keys() else "warm") or "warm",
     )
 
 

--- a/src/bosn/resources.py
+++ b/src/bosn/resources.py
@@ -750,6 +750,9 @@ def transfer_volume(registry: Registry, engine: Engine, resource: DiscoveredReso
         scope=parsed.scope,
         workspace=parsed.workspace,
         created=parsed.created,
+        # Preserved with everything else: a transfer changes who owns the volume, never how
+        # expensive it is to recreate.
+        retention=parsed.retention,
     )
     return recreate_volume_with_labels(engine, resource, new_labels)
 
@@ -863,6 +866,9 @@ def adopt(
             scope=parsed.scope,
             workspace=parsed.workspace,
             created_at=now,
+            # The label is the authority here -- rebuilding a lost registry is exactly the
+            # case the label exists for. Absent means warm, never an invented pin.
+            retention=parsed.retention or "warm",
         )
         registered = next(
             r
@@ -909,6 +915,7 @@ def reconcile_owned(
             generation=parsed.generation,
             scope=parsed.scope,
             workspace=parsed.workspace,
+            retention=parsed.retention or "warm",
         )
         registry.record_generation(parsed.generation, parsed.stack, parsed.workspace)
         registry.set_resource_state(registered.id, "adopted")

--- a/src/bosn/retention.py
+++ b/src/bosn/retention.py
@@ -43,6 +43,7 @@ SUPERSEDED_CAP = 1 * DAY
 
 # Reasons a resource is kept. Ordered by how strongly they bind.
 KEPT_LEASED = "leased"
+KEPT_PINNED = "pinned"
 KEPT_RUNNING = "running"
 KEPT_QUIET_PERIOD = "quiet-period"
 KEPT_CURRENT_IMAGE = "current-image"
@@ -204,6 +205,20 @@ def evaluate(
         # Leased resources are untouchable, full stop -- this outranks every other signal,
         # including an explicit `done`.
         return Verdict(resource, False, KEPT_LEASED)
+
+    if resource.retention == "pinned":
+        # Deliberately above `superseded`, `workspace_done`, and pressure -- the three
+        # signals that are otherwise allowed to reclaim a warm volume without anyone asking.
+        # Every tier below this line is an inference that a resource is cheap to rebuild.
+        # Pinning is a first-party statement that it is not: the motivating case is a macOS
+        # guest disk whose only creation path is a human sitting through a 30-60 minute
+        # interactive installer, so a wrong reclaim costs an hour of someone's day and no
+        # amount of retrying gets it back (#151). The only thing that outranks it is an
+        # active lease, because that is not a reclaim decision at all.
+        #
+        # This is why the tier is a registry column rather than a manifest lookup: GC has no
+        # manifest, and the worktree that declared the volume may be long gone.
+        return Verdict(resource, False, KEPT_PINNED)
 
     running = resource.kind == "container" and (
         True if running_containers is None else resource.name in running_containers

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -1663,3 +1664,157 @@ def test_status_stays_bounded_against_a_listener_that_never_answers(tmp_path, ca
     assert payload["mode"] == "degraded"
     assert payload["daemon"]["reachable"] is False
     assert payload["daemon"]["recorded"]["version"] == "0.0.1-old"
+
+
+# -- release-volume: the manual exit from the pinned tier (#151) ------------
+
+
+def _pinned_manifest(tmp_path) -> Path:
+    manifest = tmp_path / "bosn.toml"
+    manifest.write_text(
+        "[stack.mac]\nkind = 'macos-x64-guest'\nacknowledge_macos_license = true\n"
+        "image = 'ghcr.io/example/guest:ventura'\n\n[stack.mac.volumes]\n"
+        "storage = { scope = 'machine', destination = '/storage', retention = 'pinned' }\n"
+        "scratch = { scope = 'stack' }\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_release_volume_previews_before_it_removes_anything(tmp_path, monkeypatch) -> None:
+    from bosn import daemon
+
+    manifest = _pinned_manifest(tmp_path)
+    requests = []
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda verb, *_args, **kwargs: (
+            requests.append((verb, kwargs))
+            or {"ok": True, "applied": kwargs["apply"], "plan": {"engine_name": "bosn-m-x"}}
+        ),
+    )
+    argv = [
+        "--manifest",
+        str(manifest),
+        "--json",
+        "release-volume",
+        "--stack",
+        "mac",
+        "--volume",
+        "storage",
+    ]
+    assert cli.main(argv) == 0
+    assert cli.main([*argv, "--apply", "--yes"]) == 0
+    assert [entry[0] for entry in requests] == ["release-volume", "release-volume"]
+    assert [entry[1]["apply"] for entry in requests] == [False, True]
+
+
+def test_release_volume_refuses_a_warm_volume_without_reaching_the_daemon(
+    tmp_path, monkeypatch
+) -> None:
+    """It must not become a general "delete my volume" verb; warm volumes have `gc`."""
+    from bosn import daemon
+
+    manifest = _pinned_manifest(tmp_path)
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda *_args, **_kwargs: pytest.fail("a warm volume must be refused client-side"),
+    )
+    assert (
+        cli.main(
+            [
+                "--manifest",
+                str(manifest),
+                "--json",
+                "release-volume",
+                "--stack",
+                "mac",
+                "--volume",
+                "scratch",
+            ]
+        )
+        == 1
+    )
+
+
+def test_release_volume_requires_an_unambiguous_target(tmp_path, monkeypatch) -> None:
+    from bosn import daemon
+
+    monkeypatch.setattr(
+        daemon, "request", lambda *_args, **_kwargs: pytest.fail("no target was named")
+    )
+    assert cli.main(["--json", "release-volume", "--stack", "mac"]) == 1
+
+
+def test_bosn_run_ships_a_guest_task_over_ssh_not_docker_exec(tmp_path, monkeypatch) -> None:
+    """`cmd_run` execs in the CLI process, not through Converger, so it needs its own branch.
+
+    Without it a macOS task would land in the container beside the VM and run against a
+    Linux userland -- succeeding, silently, against the wrong machine.
+    """
+    from bosn import daemon
+    from bosn import guest as guest_mod
+    from bosn.converge import ConvergeResult
+
+    manifest = _pinned_manifest(tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "_converge_via_daemon",
+        lambda *_args: ConvergeResult(
+            stack="mac", digest="sha256:g", action="reused", image_tag="img"
+        ),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda verb, *_args, **_kwargs: {"ok": True, "container": "c1", "session": "s1"},
+    )
+    monkeypatch.setattr(guest_mod, "tcp_probe", lambda _h, _p: True)
+    sent: list[list[str]] = []
+    monkeypatch.setattr(
+        guest_mod,
+        "interactive_remote",
+        lambda argv, timeout=None: (sent.append(argv), 0)[1],
+    )
+    monkeypatch.setattr(
+        cli.Engine,
+        "interactive",
+        lambda *_a, **_k: pytest.fail("a guest task must never go through docker exec"),
+    )
+
+    code = cli.main(["--manifest", str(manifest), "run", "--stack", "mac", "--", "sw_vers"])
+    assert code == 0
+    assert sent and sent[0][0] == "ssh"
+    assert sent[0][-1] == "sw_vers"
+
+
+def test_a_missing_ssh_client_is_reported_not_traced(tmp_path, monkeypatch, capsys) -> None:
+    """`GuestUnsupportedError` subclasses `EngineError` so cmd_run's handler catches it."""
+    from bosn import daemon
+    from bosn import guest as guest_mod
+    from bosn.converge import ConvergeResult
+
+    manifest = _pinned_manifest(tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "_converge_via_daemon",
+        lambda *_args: ConvergeResult(
+            stack="mac", digest="sha256:g", action="reused", image_tag="img"
+        ),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "request",
+        lambda verb, *_args, **_kwargs: {"ok": True, "container": "c1", "session": "s1"},
+    )
+    monkeypatch.setattr(guest_mod, "tcp_probe", lambda _h, _p: True)
+
+    def no_ssh(_argv, **_kwargs):
+        raise FileNotFoundError("ssh")
+
+    monkeypatch.setattr("subprocess.run", no_ssh)
+
+    assert cli.main(["--manifest", str(manifest), "run", "--stack", "mac", "--", "true"]) == 1
+    assert "on PATH" in capsys.readouterr().err

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -12,6 +12,7 @@ from typing import cast
 
 import pytest
 
+from bosn import guest as guest_mod
 from bosn import labels
 from bosn.converge import (
     REGISTERED,
@@ -151,7 +152,9 @@ class FakeEngine:
                 # Docker does not report `--tmpfs` entries in `.Mounts`; it round-trips
                 # them through `.HostConfig.Tmpfs` as destination -> option string (#116).
                 tmpfs[destination] = options
-            image = args[-4]
+            # A Linux stack ends `... IMAGE sh -c <watchdog>`; a guest stack ends at the
+            # image, because dockur's ENTRYPOINT is the VM and must not be overridden.
+            image = args[-4] if args[-3:-1] == ["sh", "-c"] else args[-1]
             self.container_specs[name] = {
                 "Id": container_id,
                 "Config": {"Labels": raw_labels, "Image": image},
@@ -1635,3 +1638,217 @@ def test_execution_uses_configured_deadline_not_engine_control_timeout(
     converger.run(["true"])
     engine: FakeEngine = converger.engine  # type: ignore[assignment]
     assert engine.timeouts[-1] == 123.0
+
+
+# -- macOS guest stacks (#151) ---------------------------------------------
+
+GUEST_SAMPLE = """
+[stack.mac]
+kind = "macos-x64-guest"
+acknowledge_macos_license = true
+image = "ghcr.io/example/macos-x64-guest:ventura"
+family = "macos-x64"
+default = true
+workdir = "/Users/runner"
+
+[stack.mac.guest]
+ssh_port = 2299
+
+[stack.mac.volumes]
+storage = { scope = "machine", destination = "/storage", retention = "pinned" }
+"""
+
+CAPABLE_HOST = guest_mod.HostCapability(
+    platform="linux",
+    devices_present=guest_mod.REQUIRED_DEVICES,
+    cpu_vendor="GenuineIntel",
+)
+
+
+@pytest.fixture
+def guest_converger(tmp_path: Path, registry: Registry) -> Converger:
+    (tmp_path / "bosn.toml").write_text(GUEST_SAMPLE, encoding="utf-8")
+    converger = Converger(load(tmp_path), registry, FakeEngine())  # type: ignore[arg-type]
+    # The host probe reads /proc and stats device nodes; CI has neither, and the point of
+    # these tests is the argv bosn builds, not what this machine happens to expose.
+    converger._host_capability = CAPABLE_HOST
+    return converger
+
+
+def guest_create_args(converger: Converger) -> list[str]:
+    engine = cast(FakeEngine, converger.engine)
+    converged = converger.converge("mac")
+    converger.ensure_container(converged, stack_name="mac", workspace="/w")
+    return engine.ran("create")[0]
+
+
+def test_a_guest_container_gets_kvm_tun_and_net_admin(guest_converger: Converger) -> None:
+    args = guest_create_args(guest_converger)
+    assert args.count("--device") == 2
+    assert "/dev/kvm" in args
+    assert "/dev/net/tun" in args
+    assert "NET_ADMIN" in args
+
+
+def test_a_guest_container_publishes_its_ssh_port(guest_converger: Converger) -> None:
+    assert "2299:22" in guest_create_args(guest_converger)
+
+
+def test_a_guest_container_does_not_override_dockurs_entrypoint(
+    guest_converger: Converger,
+) -> None:
+    """Appending `sh -c <watchdog>` would replace the VM with a shell that never boots."""
+    engine = cast(FakeEngine, guest_converger.engine)
+    args = guest_create_args(guest_converger)
+    # The image is the last argument: nothing follows it to displace dockur's ENTRYPOINT.
+    assert args[-1] == engine.image_ids["ghcr.io/example/macos-x64-guest:ventura"]
+    assert "sh" not in args
+
+
+def test_a_guest_container_is_not_created_with_rm(guest_converger: Converger) -> None:
+    # `--rm` only makes sense alongside the heartbeat watchdog that triggers the reap.
+    assert "--rm" not in guest_create_args(guest_converger)
+
+
+def test_a_guest_container_carries_no_heartbeat_bind(guest_converger: Converger) -> None:
+    args = guest_create_args(guest_converger)
+    assert "/bosn-daemon/heartbeat" not in " ".join(args)
+
+
+def test_a_guest_container_still_mounts_its_declared_storage_volume(
+    guest_converger: Converger,
+) -> None:
+    args = guest_create_args(guest_converger)
+    assert any(value.endswith(":/storage") for value in args)
+
+
+def test_a_pinned_volume_is_registered_as_pinned(guest_converger: Converger) -> None:
+    """GC reads this row, not the manifest, so the tier has to survive into the registry."""
+    guest_converger.converge("mac")
+    volumes = [r for r in guest_converger.registry.list_resources() if r.kind == "volume"]
+    assert [v.retention for v in volumes] == ["pinned"]
+
+
+def test_a_guest_stack_is_refused_before_anything_is_pulled(
+    tmp_path: Path, registry: Registry
+) -> None:
+    (tmp_path / "bosn.toml").write_text(GUEST_SAMPLE, encoding="utf-8")
+    engine = FakeEngine()
+    converger = Converger(load(tmp_path), registry, engine)  # type: ignore[arg-type]
+    converger._host_capability = guest_mod.HostCapability(
+        platform="linux", devices_present=(), cpu_vendor=None
+    )
+    with pytest.raises(guest_mod.GuestUnsupportedError):
+        converger.converge("mac")
+    assert engine.ran("pull") == [], "the refusal must precede a multi-gigabyte pull"
+
+
+def test_a_guest_task_is_shipped_over_ssh_not_docker_exec(
+    guest_converger: Converger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sent: list[list[str]] = []
+    monkeypatch.setattr(guest_mod, "tcp_probe", lambda _h, _p: True)
+    monkeypatch.setattr(
+        guest_mod,
+        "run_remote",
+        lambda argv, timeout=None: (sent.append(argv), (0, "ok"))[1],
+    )
+    converged = guest_converger.converge("mac")
+    _result, code, output = guest_converger.run_converged(
+        converged, ["sh", "-c", "make test"], stack_name="mac", workspace="/w"
+    )
+
+    assert code == 0
+    assert output == "ok"
+    assert sent[0][0] == "ssh"
+    # The workdir is applied inside the guest, not as a `docker exec --workdir`.
+    assert sent[0][-1] == "cd /Users/runner && make test"
+    assert cast(FakeEngine, guest_converger.engine).ran("exec") == []
+
+
+def test_a_guest_task_propagates_its_real_exit_code(
+    guest_converger: Converger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CI gates on this number; a swallowed failure is the whole point of the feature."""
+    monkeypatch.setattr(guest_mod, "tcp_probe", lambda _h, _p: True)
+    monkeypatch.setattr(guest_mod, "run_remote", lambda _argv, timeout=None: (101, "boom"))
+    converged = guest_converger.converge("mac")
+    _result, code, _output = guest_converger.run_converged(
+        converged, ["sh", "-c", "false"], stack_name="mac", workspace="/w"
+    )
+    assert code == 101
+
+
+def test_an_unready_guest_fails_with_its_own_logs_attached(
+    guest_converger: Converger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(guest_mod, "tcp_probe", lambda _h, _p: False)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    converged = guest_converger.converge("mac")
+    # A short deadline so the bounded wait is exercised without a real 30-minute budget.
+    stack = guest_converger.manifest.stacks["mac"]
+    object.__setattr__(stack, "guest", replace(stack.guest_spec(), ready_timeout=1))
+
+    with pytest.raises(EngineError) as exc:
+        guest_converger.run_converged(
+            converged, ["sh", "-c", "true"], stack_name="mac", workspace="/w"
+        )
+    assert "did not answer" in str(exc.value)
+    assert "logs (last 60 lines)" in str(exc.value)
+    assert cast(FakeEngine, guest_converger.engine).ran("logs")
+
+
+def test_replacing_a_guest_container_stops_it_before_forcing_removal(
+    guest_converger: Converger,
+) -> None:
+    """`rm --force` is an immediate SIGKILL and ignores `--stop-timeout`.
+
+    Killing QEMU mid-write on the pinned guest disk is exactly what the long stop timeout
+    exists to prevent, so bosn's own replacement must not be the thing that does it.
+    """
+    engine = cast(FakeEngine, guest_converger.engine)
+    converged = guest_converger.converge("mac")
+    guest_converger.ensure_container(converged, stack_name="mac", workspace="/w")
+
+    # Roll the generation the way a `ram_size` edit would, forcing a replacement.
+    stack = guest_converger.manifest.stacks["mac"]
+    object.__setattr__(stack, "guest", replace(stack.guest_spec(), ram_size="16G"))
+    rolled = guest_converger.converge("mac")
+    assert rolled.digest != converged.digest
+    guest_converger.ensure_container(rolled, stack_name="mac", workspace="/w")
+
+    order = [c for c in engine.commands if c[:1] == ["stop"] or c[:2] == ["container", "rm"]]
+    assert order[0][0] == "stop"
+    assert order[1][:3] == ["container", "rm", "--force"]
+
+
+def test_the_guest_stop_waits_longer_than_the_engines_default_control_timeout(
+    guest_converger: Converger,
+) -> None:
+    """`Engine.run`'s 60s default would abort the very 120s shutdown being waited on."""
+    engine = cast(FakeEngine, guest_converger.engine)
+    converged = guest_converger.converge("mac")
+    guest_converger.ensure_container(converged, stack_name="mac", workspace="/w")
+    stack = guest_converger.manifest.stacks["mac"]
+    object.__setattr__(stack, "guest", replace(stack.guest_spec(), ram_size="16G"))
+    guest_converger.ensure_container(
+        guest_converger.converge("mac"), stack_name="mac", workspace="/w"
+    )
+
+    index = next(i for i, c in enumerate(engine.commands) if c[:1] == ["stop"])
+    deadline = engine.timeouts[index]
+    assert deadline is not None
+    assert deadline > guest_mod.STOP_TIMEOUT_SECONDS
+
+
+def test_replacing_an_ordinary_container_still_goes_straight_to_forced_removal(
+    project: Path, registry: Registry
+) -> None:
+    """A Linux stack's PID 1 is a sleep loop; a graceful stop would only add latency."""
+    engine = FakeEngine()
+    Converger(load(project), registry, engine).run(["true"])  # type: ignore[arg-type]
+    (project / "Dockerfile").write_text("FROM alpine\nRUN echo changed\n", encoding="utf-8")
+    Converger(load(project), registry, engine).run(["true"])  # type: ignore[arg-type]
+
+    assert engine.ran("container", "rm", "--force")
+    assert engine.ran("stop") == []

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2757,3 +2757,174 @@ def test_recorded_state_does_not_delete_what_it_reads(tmp_path: Path) -> None:
     assert daemon_mod.recorded_state(tmp_path) is not None
     assert daemon_mod.recorded_state(tmp_path) is not None, "reading it twice must be possible"
     assert path.exists()
+
+
+# -- release-volume: the only exit from the pinned tier (#151) --------------
+
+
+PINNED_MANIFEST = """
+[stack.mac]
+kind = "macos-x64-guest"
+acknowledge_macos_license = true
+image = "ghcr.io/example/guest:ventura"
+family = "macos-x64"
+
+[stack.mac.volumes]
+storage = { scope = "machine", destination = "/storage", retention = "pinned" }
+scratch = { scope = "stack" }
+"""
+
+
+class ReleaseEngine:
+    """Just enough engine for the release path: labels, attachment, and removal."""
+
+    def __init__(self, registry_id: str) -> None:
+        self.registry_id = registry_id
+        self.removed: list[str] = []
+        self.attached = False
+        self.owned = True
+
+    def _labels(self) -> dict[str, str]:
+        from bosn import labels
+
+        if not self.owned:
+            return {}
+        return {
+            labels.REGISTRY: self.registry_id,
+            labels.KIND: "volume",
+            labels.STACK: "mac",
+            labels.GENERATION: "sha256:g",
+            labels.SCOPE: "machine",
+            labels.WORKSPACE: "/w",
+            labels.CREATED: "2026-01-01T00:00:00Z",
+        }
+
+    def run(self, args: list[str], *, check: bool = False, timeout: float | None = None):
+        import json as _json
+
+        from bosn.engine import EngineResult
+
+        if args[:2] == ["version", "--format"]:
+            return EngineResult(0, "linux/amd64", "")
+        if args[:2] == ["volume", "inspect"] and "{{json .Labels}}" in args:
+            return EngineResult(0, _json.dumps(self._labels()), "")
+        if args[:2] == ["image", "inspect"] and "{{.Id}}" in args:
+            return EngineResult(0, "sha256:guest-image", "")
+        if args[0] == "ps":
+            return EngineResult(0, "holder" if self.attached else "", "")
+        if args[:2] == ["volume", "rm"]:
+            self.removed.append(args[-1])
+            return EngineResult(0, "", "")
+        return EngineResult(0, "", "")
+
+
+@pytest.fixture
+def release_daemon(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    manifest = tmp_path / "bosn.toml"
+    manifest.write_text(PINNED_MANIFEST, encoding="utf-8")
+    daemon = Daemon(state_dir=tmp_path / "state")
+    engine = ReleaseEngine(daemon.registry.registry_id)
+    monkeypatch.setattr("bosn.engine.Engine", lambda _binary: engine)
+    request = {"manifest": str(manifest), "stack": "mac", "volume": "storage"}
+    try:
+        yield daemon, engine, request
+    finally:
+        daemon.registry.close()
+
+
+def test_release_volume_previews_without_removing(release_daemon) -> None:
+    daemon, engine, request = release_daemon
+    reply = daemon._verb_release_volume(request)
+    assert reply["ok"] is True and reply["applied"] is False
+    assert reply["plan"]["action"] == "would-remove"
+    assert engine.removed == []
+
+
+def test_release_volume_refuses_apply_without_yes(release_daemon) -> None:
+    daemon, engine, request = release_daemon
+    reply = daemon._verb_release_volume({**request, "apply": True})
+    assert reply["ok"] is False
+    assert engine.removed == [], "the expensive state must survive a half-typed command"
+
+
+def test_release_volume_removes_and_forgets_a_pinned_volume(release_daemon) -> None:
+    daemon, engine, request = release_daemon
+    reply = daemon._verb_release_volume({**request, "apply": True, "yes": True})
+    assert reply["ok"] is True and reply["applied"] is True
+    name = reply["plan"]["engine_name"]
+    assert engine.removed == [name]
+    assert daemon.registry.get_resource_by_engine_identity("volume", name) is None
+    assert any(row["kind"] == "volume.released" for row in daemon.registry.events())
+
+
+def test_release_volume_refuses_a_warm_volume(release_daemon) -> None:
+    daemon, engine, request = release_daemon
+    reply = daemon._verb_release_volume(
+        {**request, "volume": "scratch", "apply": True, "yes": True}
+    )
+    assert reply["ok"] is False
+    assert "not pinned" in str(reply["error"])
+    assert engine.removed == []
+
+
+def test_release_volume_refuses_a_volume_it_cannot_prove_it_owns(release_daemon) -> None:
+    daemon, engine, request = release_daemon
+    engine.owned = False
+    reply = daemon._verb_release_volume({**request, "apply": True, "yes": True})
+    assert reply["ok"] is False
+    assert engine.removed == []
+
+
+def test_release_volume_refuses_a_volume_still_attached_to_a_container(release_daemon) -> None:
+    daemon, engine, request = release_daemon
+    engine.attached = True
+    reply = daemon._verb_release_volume({**request, "apply": True, "yes": True})
+    assert reply["ok"] is False
+    assert "attached" in str(reply["error"])
+    assert engine.removed == []
+
+
+def test_release_volume_refuses_a_leased_volume(release_daemon) -> None:
+    daemon, engine, request = release_daemon
+    preview = daemon._verb_release_volume(request)
+    name = preview["plan"]["engine_name"]
+    resource = daemon.registry.register_resource(
+        kind="volume",
+        name=name,
+        stack="mac",
+        generation="sha256:g",
+        scope="machine",
+        workspace="/w",
+        retention="pinned",
+    )
+    daemon.registry.acquire_lease(resource.id, pid=os.getpid(), proc_start=None, ttl_seconds=600)
+
+    reply = daemon._verb_release_volume({**request, "apply": True, "yes": True})
+    assert reply["ok"] is False
+    assert "lease" in str(reply["error"])
+    assert engine.removed == []
+
+
+def test_release_volume_is_gated_as_a_mutating_verb() -> None:
+    assert "release-volume" in daemon_mod.MUTATING_VERBS
+
+
+def test_release_volume_never_pulls_an_image_to_delete_a_volume(release_daemon) -> None:
+    """The guest image is tens of gigabytes; a delete must not be the thing that fetches it.
+
+    A `machine`-scoped volume's name is keyed on family and volume alone, so resolving a
+    generation for it would pull an image the name cannot even depend on.
+    """
+    daemon, engine, request = release_daemon
+    pulls: list[list[str]] = []
+    original = engine.run
+
+    def watched(args, **kwargs):
+        if args and args[0] == "pull":
+            pulls.append(list(args))
+        return original(args, **kwargs)
+
+    engine.run = watched  # type: ignore[method-assign]
+    reply = daemon._verb_release_volume({**request, "apply": True, "yes": True})
+    assert reply["ok"] is True
+    assert pulls == []

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -1,0 +1,445 @@
+"""The macOS x86-64 guest stack kind (#151).
+
+Every probe, clock, and subprocess is injected, so this whole file runs on a host with no
+KVM, no `dockurr/macos` image, and no ssh client -- which is every CI runner bosn builds on.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bosn import guest
+from bosn.guest import GuestNotReadyError, GuestUnsupportedError, HostCapability
+from bosn.manifest import GUEST_MACOS_X64, GuestSpec, ManifestError, parse
+
+INTEL_HOST = HostCapability(
+    platform="linux", devices_present=guest.REQUIRED_DEVICES, cpu_vendor="GenuineIntel"
+)
+AMD_HOST = HostCapability(
+    platform="linux", devices_present=guest.REQUIRED_DEVICES, cpu_vendor=guest.AMD_VENDOR
+)
+
+
+def guest_manifest(root: Path, **stack_overrides: object):
+    body: dict[str, object] = {
+        "kind": GUEST_MACOS_X64,
+        "acknowledge_macos_license": True,
+        "image": "ghcr.io/example/macos-x64-guest:ventura",
+        "family": "macos-x64",
+    }
+    body.update(stack_overrides)
+    return parse({"stack": {"mac": body}}, root)
+
+
+# -- manifest surface -------------------------------------------------------
+
+
+def test_a_guest_stack_needs_an_explicit_licence_acknowledgement(tmp_path: Path) -> None:
+    with pytest.raises(ManifestError) as exc:
+        parse({"stack": {"mac": {"kind": GUEST_MACOS_X64, "image": "x"}}}, tmp_path)
+    assert "acknowledge_macos_license" in str(exc.value)
+
+
+def test_the_acknowledgement_is_meaningless_without_the_guest_kind(tmp_path: Path) -> None:
+    # Otherwise a copied stanza would leave a licence claim attached to a Linux stack.
+    with pytest.raises(ManifestError):
+        parse({"stack": {"s": {"image": "x", "acknowledge_macos_license": True}}}, tmp_path)
+
+
+def test_a_guest_stack_refuses_bind_mounts(tmp_path: Path) -> None:
+    """A bind lands in the container; the VM inside it cannot see one."""
+    with pytest.raises(ManifestError) as exc:
+        guest_manifest(
+            tmp_path,
+            mounts={"repo": {"source": ".", "destination": "/repo", "readonly": True}},
+        )
+    assert "cannot see host bind mounts" in str(exc.value)
+
+
+def test_a_guest_stack_defaults_its_guest_table(tmp_path: Path) -> None:
+    stack = guest_manifest(tmp_path).stack("mac")
+    assert stack.is_guest
+    assert stack.guest_spec() == GuestSpec()
+
+
+def test_the_guest_table_refuses_unknown_keys(tmp_path: Path) -> None:
+    # A silently dropped `ssh_port` would fail as a connection error a long way from here.
+    with pytest.raises(ManifestError) as exc:
+        guest_manifest(tmp_path, guest={"ssh_prot": 2222})
+    assert "ssh_prot" in str(exc.value)
+
+
+def test_the_guest_table_refuses_a_colliding_port_pair(tmp_path: Path) -> None:
+    with pytest.raises(ManifestError) as exc:
+        guest_manifest(tmp_path, guest={"ssh_port": 8006})
+    assert "must differ" in str(exc.value)
+
+
+def test_an_unknown_stack_kind_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(ManifestError) as exc:
+        parse({"stack": {"s": {"image": "x", "kind": "macos-arm64"}}}, tmp_path)
+    assert "unknown kind" in str(exc.value)
+
+
+def test_a_guest_table_without_the_guest_kind_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(ManifestError):
+        parse({"stack": {"s": {"image": "x", "guest": {"ssh_port": 2222}}}}, tmp_path)
+
+
+def test_guest_configuration_is_part_of_the_generation_digest(tmp_path: Path) -> None:
+    """Ports and sizing land in `docker create`, which Docker cannot revise afterwards."""
+    baseline = guest_manifest(tmp_path).digest("mac")
+    moved = guest_manifest(tmp_path, guest={"ssh_port": 2299}).digest("mac")
+    assert baseline != moved
+
+
+def test_a_plain_stack_digest_is_unchanged_by_the_guest_feature(tmp_path: Path) -> None:
+    """Pinned to the value main produced, so upgrading never rolls a live generation."""
+    manifest = parse(
+        {"stack": {"t": {"image": "x", "volumes": {"v": {"scope": "machine"}}}}}, tmp_path
+    )
+    assert (
+        manifest.digest("t")
+        == "sha256:45a1096c85b98ebbf505795fa547bc8c6be8706e42160eece61df5b19e904291"
+    )
+
+
+# -- host preflight ---------------------------------------------------------
+
+
+def test_a_non_linux_host_is_refused_by_name() -> None:
+    host = HostCapability(platform="darwin", devices_present=(), cpu_vendor=None)
+    with pytest.raises(GuestUnsupportedError) as exc:
+        guest.require_supported_host("mac", host)
+    assert "darwin" in str(exc.value)
+
+
+def test_a_linux_host_without_kvm_is_refused_and_says_which_device() -> None:
+    host = HostCapability(platform="linux", devices_present=("/dev/net/tun",), cpu_vendor=None)
+    with pytest.raises(GuestUnsupportedError) as exc:
+        guest.require_supported_host("mac", host)
+    assert "/dev/kvm" in str(exc.value)
+
+
+def test_a_capable_linux_host_is_accepted() -> None:
+    guest.require_supported_host("mac", INTEL_HOST)
+
+
+def test_probe_host_reads_the_cpu_vendor_and_devices() -> None:
+    host = guest.probe_host(
+        platform="linux",
+        device_exists=lambda path: path == "/dev/kvm",
+        cpuinfo=lambda: "processor\t: 0\nvendor_id\t: AuthenticAMD\nmodel\t: 1\n",
+    )
+    assert host.cpu_vendor == guest.AMD_VENDOR
+    assert host.missing_devices == ("/dev/net/tun",)
+
+
+def test_an_unreadable_cpuinfo_leaves_the_vendor_unknown() -> None:
+    host = guest.probe_host(platform="linux", device_exists=lambda _p: True, cpuinfo=lambda: "")
+    assert host.cpu_vendor is None
+
+
+# -- CPU cores --------------------------------------------------------------
+
+
+def test_an_amd_host_is_pinned_to_one_core() -> None:
+    """dockur/macos#268: multi-core on AMD is unstable, not merely slower."""
+    assert guest.effective_cpu_cores(GuestSpec(), AMD_HOST) == 1
+
+
+def test_an_unknown_vendor_takes_the_conservative_single_core_path() -> None:
+    unknown = HostCapability(
+        platform="linux", devices_present=guest.REQUIRED_DEVICES, cpu_vendor=None
+    )
+    assert guest.effective_cpu_cores(GuestSpec(), unknown) == 1
+
+
+def test_an_intel_host_is_not_pinned_to_one_core() -> None:
+    assert guest.effective_cpu_cores(GuestSpec(), INTEL_HOST) > 1
+
+
+def test_an_explicit_core_count_overrides_the_vendor_rule() -> None:
+    assert guest.effective_cpu_cores(GuestSpec(cpu_cores=4), AMD_HOST) == 4
+
+
+# -- create arguments -------------------------------------------------------
+
+
+def test_create_args_pass_through_both_devices_and_the_capability() -> None:
+    args = guest.create_args(GuestSpec(), INTEL_HOST)
+    assert args.count("--device") == 2
+    for device in guest.REQUIRED_DEVICES:
+        assert device in args
+    assert "--cap-add" in args
+    assert "NET_ADMIN" in args
+
+
+def test_create_args_publish_ssh_and_the_web_console() -> None:
+    args = guest.create_args(GuestSpec(ssh_port=2299, web_port=8010), INTEL_HOST)
+    assert "2299:22" in args
+    assert "8010:8006" in args
+
+
+def test_create_args_use_a_long_stop_timeout() -> None:
+    """A SIGKILL after the 10s default can tear a tens-of-GB guest filesystem."""
+    args = guest.create_args(GuestSpec(), INTEL_HOST)
+    assert args[args.index("--stop-timeout") + 1] == str(guest.STOP_TIMEOUT_SECONDS)
+
+
+def test_create_args_carry_the_amd_core_limit_as_env() -> None:
+    assert "CPU_CORES=1" in guest.create_args(GuestSpec(), AMD_HOST)
+
+
+def test_create_args_carry_the_guest_sizing() -> None:
+    args = guest.create_args(GuestSpec(version="sonoma", ram_size="16G"), INTEL_HOST)
+    assert "VERSION=sonoma" in args
+    assert "RAM_SIZE=16G" in args
+
+
+# -- readiness --------------------------------------------------------------
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def now(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def test_readiness_returns_as_soon_as_sshd_answers() -> None:
+    clock = FakeClock()
+    answers = iter([False, False, True])
+    waited = guest.wait_for_sshd(
+        GuestSpec(ready_poll_interval=10),
+        probe=lambda _h, _p: next(answers),
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    assert waited == 20.0
+
+
+def test_readiness_gives_up_at_the_deadline_rather_than_hanging() -> None:
+    clock = FakeClock()
+    with pytest.raises(GuestNotReadyError) as exc:
+        guest.wait_for_sshd(
+            GuestSpec(ready_timeout=60, ready_poll_interval=10),
+            probe=lambda _h, _p: False,
+            now=clock.now,
+            sleep=clock.sleep,
+        )
+    # The web console is where a stalled first-boot installer is actually visible.
+    assert "8006" in str(exc.value)
+    assert clock.value >= 60
+
+
+def test_a_guest_that_is_already_up_never_sleeps() -> None:
+    clock = FakeClock()
+    assert (
+        guest.wait_for_sshd(
+            GuestSpec(), probe=lambda _h, _p: True, now=clock.now, sleep=clock.sleep
+        )
+        == 0.0
+    )
+    assert clock.value == 0.0
+
+
+def test_readiness_reports_progress_while_it_waits() -> None:
+    clock = FakeClock()
+    seen: list[str] = []
+    answers = iter([False, True])
+    guest.wait_for_sshd(
+        GuestSpec(ready_poll_interval=5),
+        probe=lambda _h, _p: next(answers),
+        now=clock.now,
+        sleep=clock.sleep,
+        on_wait=seen.append,
+    )
+    assert seen and "sshd" in seen[0]
+
+
+# -- transport --------------------------------------------------------------
+
+
+def test_ssh_argv_targets_the_declared_port_and_user() -> None:
+    argv = guest.ssh_argv(GuestSpec(ssh_port=2299, ssh_user="builder"), "true")
+    assert argv[0] == "ssh"
+    assert "2299" in argv
+    assert "builder@127.0.0.1" in argv
+    assert argv[-1] == "true"
+
+
+def test_ssh_never_records_the_guest_host_key() -> None:
+    """The guest is a throwaway VM on a reused loopback port; its key legitimately rolls."""
+    argv = guest.ssh_argv(GuestSpec(), "true")
+    assert "UserKnownHostsFile=/dev/null" in argv
+    assert "StrictHostKeyChecking=no" in argv
+
+
+def test_scp_argv_uses_the_uppercase_port_flag() -> None:
+    # scp spells it -P; ssh spells it -p. Getting this wrong reads as a missing file.
+    argv = guest.scp_argv(GuestSpec(ssh_port=2299), "/tmp/a.tar", "~/a.tar")
+    assert argv[argv.index("-P") + 1] == "2299"
+
+
+def test_a_remote_command_is_prefixed_by_a_quoted_workdir() -> None:
+    remote = guest.remote_command(GuestSpec(), "make test", workdir="/Users/run ner")
+    assert remote == "cd '/Users/run ner' && make test"
+
+
+def test_a_remote_command_without_a_workdir_is_passed_through_verbatim() -> None:
+    assert guest.remote_command(GuestSpec(), "a && b") == "a && b"
+
+
+def test_run_remote_returns_the_guests_own_exit_code() -> None:
+    def runner(argv, **_kwargs):
+        assert argv[0] == "ssh"
+        return subprocess.CompletedProcess(argv, 3, "out", "err")
+
+    assert guest.run_remote(["ssh", "x"], runner=runner) == (3, "out\nerr")
+
+
+def test_a_missing_ssh_client_is_a_clear_refusal_not_a_traceback() -> None:
+    def runner(_argv, **_kwargs):
+        raise FileNotFoundError("ssh")
+
+    with pytest.raises(GuestUnsupportedError) as exc:
+        guest.run_remote(["ssh", "x"], runner=runner)
+    assert "on PATH" in str(exc.value)
+
+
+def test_ssh_transport_failures_are_flagged_as_ambiguous() -> None:
+    assert "connection failures" in guest.describe_exit(guest.SSH_TRANSPORT_FAILURE)
+    assert "connection failures" not in guest.describe_exit(1)
+
+
+def test_the_interactive_login_command_uses_a_real_login_shell() -> None:
+    assert guest.login_command(None) == "exec $SHELL -l"
+    assert guest.login_command("/repo") == "cd /repo && exec $SHELL -l"
+
+
+# -- payload shipping -------------------------------------------------------
+
+
+def test_no_payload_declared_ships_nothing(tmp_path: Path) -> None:
+    def runner(_argv, **_kwargs):
+        pytest.fail("nothing should be shipped when no payload is declared")
+
+    assert guest.ship_payload(GuestSpec(), tmp_path, runner=runner) is None
+
+
+def test_a_declared_payload_is_scp_ed_to_its_destination(tmp_path: Path) -> None:
+    (tmp_path / "kernal-x64.tar.zst").write_bytes(b"archive")
+    sent: list[list[str]] = []
+
+    def runner(argv, **_kwargs):
+        sent.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    landed = guest.ship_payload(
+        GuestSpec(payload="kernal-x64.tar.zst", payload_destination="~/a.tar.zst"),
+        tmp_path,
+        runner=runner,
+    )
+    assert landed == "~/a.tar.zst"
+    assert sent[0][0] == "scp"
+    assert sent[0][-1] == "runner@127.0.0.1:~/a.tar.zst"
+
+
+def test_a_missing_payload_is_refused_before_the_task_runs(tmp_path: Path) -> None:
+    """A guest silently serving last week's archive is the worst failure this kind has."""
+    with pytest.raises(GuestUnsupportedError) as exc:
+        guest.ship_payload(
+            GuestSpec(payload="missing.tar"), tmp_path, runner=lambda *_a, **_k: None
+        )
+    assert "not a file" in str(exc.value)
+
+
+def test_a_failed_ship_stops_the_task(tmp_path: Path) -> None:
+    (tmp_path / "a.tar").write_bytes(b"x")
+
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 1, "", "permission denied")
+
+    with pytest.raises(GuestNotReadyError):
+        guest.ship_payload(GuestSpec(payload="a.tar"), tmp_path, runner=runner)
+
+
+def test_an_ssh_timeout_is_reported_as_a_guest_failure_not_a_traceback() -> None:
+    def runner(_argv, **_kwargs):
+        raise subprocess.TimeoutExpired("ssh", 1)
+
+    with pytest.raises(GuestNotReadyError):
+        guest.run_remote(["ssh", "x"], timeout=1, runner=runner)
+    with pytest.raises(GuestNotReadyError):
+        guest.interactive_remote(["ssh", "x"], timeout=1, runner=runner)
+
+
+def test_interactive_remote_applies_the_run_deadline() -> None:
+    seen: dict[str, object] = {}
+
+    def runner(argv, **kwargs):
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(argv, 0)
+
+    guest.interactive_remote(["ssh", "x"], timeout=42, runner=runner)
+    assert seen["timeout"] == 42
+
+
+def test_guest_failures_are_engine_errors_so_every_cli_handler_catches_them() -> None:
+    from bosn.engine import EngineError
+
+    assert issubclass(GuestUnsupportedError, EngineError)
+    assert issubclass(GuestNotReadyError, EngineError)
+
+
+# -- the retention label survives a lost registry --------------------------
+
+
+def test_a_pinned_volume_carries_its_tier_in_its_labels() -> None:
+    """The registry is disposable; ownership -- and the tier -- live in the labels."""
+    from bosn import labels
+
+    pinned = labels.ResourceLabels(
+        registry="r",
+        kind="volume",
+        stack="mac",
+        generation="g",
+        scope="machine",
+        workspace="/w",
+        created="now",
+        retention="pinned",
+    )
+    raw = pinned.to_dict()
+    assert raw[labels.RETENTION] == "pinned"
+    assert labels.ResourceLabels.from_dict(raw).retention == "pinned"
+
+
+def test_an_unpinned_volume_writes_exactly_the_labels_bosn_always_wrote() -> None:
+    from bosn import labels
+
+    warm = labels.ResourceLabels(
+        registry="r",
+        kind="volume",
+        stack="s",
+        generation="g",
+        scope="stack",
+        workspace="/w",
+        created="now",
+    )
+    assert labels.RETENTION not in warm.to_dict()
+    assert labels.is_complete(warm.to_dict())
+
+
+def test_the_retention_label_is_not_required_for_ownership() -> None:
+    """Every resource predating the tier must stay ours, collectable, and adoptable."""
+    from bosn import labels
+
+    assert labels.RETENTION not in labels.REQUIRED_LABELS

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -13,6 +13,7 @@ from bosn.manifest import (
     dockerfile_external_images,
     generation_digest,
     load,
+    parse,
 )
 
 SAMPLE = """
@@ -721,3 +722,42 @@ def test_tmpfs_trailing_slash_alias_is_refused_as_a_duplicate(tmp_path: Path) ->
 
     with pytest.raises(ManifestError, match="mounts '/data' twice"):
         load(tmp_path)
+
+
+def test_volume_retention_defaults_to_warm_and_accepts_pinned(tmp_path: Path) -> None:
+    manifest = parse(
+        {
+            "stack": {
+                "s": {
+                    "image": "x",
+                    "volumes": {
+                        "cache": {"scope": "stack"},
+                        "storage": {"scope": "machine", "retention": "pinned"},
+                    },
+                }
+            }
+        },
+        tmp_path,
+    )
+    retentions = {v.name: v.retention for v in manifest.stack("s").volumes}
+    assert retentions == {"cache": "warm", "storage": "pinned"}
+
+
+def test_an_unknown_retention_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(ManifestError) as exc:
+        parse(
+            {"stack": {"s": {"image": "x", "volumes": {"v": {"retention": "forever"}}}}}, tmp_path
+        )
+    assert "unknown retention" in str(exc.value)
+
+
+def test_pinning_a_volume_rolls_the_generation(tmp_path: Path) -> None:
+    """The tier is written into the registry row at creation, so it must not reuse one."""
+
+    def digest(retention: str) -> str:
+        return parse(
+            {"stack": {"s": {"image": "x", "volumes": {"v": {"retention": retention}}}}},
+            tmp_path,
+        ).digest("s")
+
+    assert digest("warm") != digest("pinned")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from bosn.clock import FakeClock
-from bosn.registry import Registry, RegistryError
+from bosn.registry import SCHEMA_VERSION, Registry, RegistryError
 
 
 @pytest.fixture
@@ -314,7 +314,7 @@ def test_v1_migration_deduplicates_engine_objects_and_preserves_leases(tmp_path:
         assert resources[0].id == "new"
         assert resources[0].created_at == 1
         assert migrated.leases_for("new")[0].id == "lease-old"
-        assert migrated.meta("schema_version") == "3"
+        assert migrated.meta("schema_version") == str(SCHEMA_VERSION)
         assert migrated.generation_superseded_at("sha256:g", stack="test", workspace="/w") is None
         index_columns = migrated.conn.execute(
             "PRAGMA index_info(idx_resources_engine_identity)"
@@ -452,3 +452,63 @@ def test_a_failed_proc_start_migration_raises_a_named_recoverable_error(
 
     with pytest.raises(RegistryError, match="relax_lease_proc_start_nullability"):
         Registry(path, clock=clock)
+
+
+def test_v3_migration_adds_retention_and_defaults_every_existing_row_to_warm(
+    tmp_path: Path,
+) -> None:
+    """Pinning is only ever asserted forward, by a manifest that asks for it (#151).
+
+    A row written before the tier existed was created under the tiered clocks and must keep
+    obeying them; inferring a pin for it would leak storage nobody can explain.
+    """
+    path = tmp_path / "v3.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        INSERT INTO meta VALUES ('schema_version', '3'), ('registry_id', 'reg-1');
+        CREATE TABLE resources (
+            id TEXT PRIMARY KEY, kind TEXT NOT NULL, name TEXT NOT NULL, stack TEXT NOT NULL,
+            generation TEXT NOT NULL, scope TEXT NOT NULL, workspace TEXT NOT NULL,
+            created_at REAL NOT NULL, last_used REAL NOT NULL,
+            state TEXT NOT NULL DEFAULT 'active'
+        );
+        INSERT INTO resources VALUES
+            ('r1', 'volume', 'cache', 'test', 'sha256:g', 'stack', '/w', 1, 2, 'active');
+        """
+    )
+    connection.close()
+
+    with Registry(path) as migrated:
+        assert migrated.meta("schema_version") == str(SCHEMA_VERSION)
+        assert [r.retention for r in migrated.list_resources()] == ["warm"]
+        # And the column is usable for new rows, not merely present.
+        migrated.register_resource(
+            kind="volume",
+            name="guest-storage",
+            stack="mac",
+            generation="g",
+            scope="machine",
+            workspace="/w",
+            retention="pinned",
+        )
+        stored = migrated.get_resource_by_engine_identity("volume", "guest-storage")
+        assert stored is not None and stored.retention == "pinned"
+
+
+def test_re_registering_a_volume_can_move_it_off_the_pinned_tier(tmp_path: Path) -> None:
+    """Editing `retention` back to warm is how a user un-pins without deleting."""
+    with Registry(tmp_path / "r.sqlite3") as registry:
+        for retention in ("pinned", "warm"):
+            registry.register_resource(
+                kind="volume",
+                name="storage",
+                stack="mac",
+                generation="g",
+                scope="machine",
+                workspace="/w",
+                retention=retention,
+            )
+        stored = registry.get_resource_by_engine_identity("volume", "storage")
+        assert stored is not None and stored.retention == "warm"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1104,3 +1104,45 @@ def test_discover_still_raises_so_callers_outside_scan_are_unchanged() -> None:
 
     with pytest.raises(EngineError):
         ResourceScanner(engine).discover("image")  # type: ignore[arg-type]
+
+
+def test_adoption_restores_the_pinned_tier_from_labels(tmp_path) -> None:
+    """A lost registry must not silently un-pin a volume that costs an hour to recreate.
+
+    `registry.py`'s own contract is that the database is disposable and ownership lives in
+    the Docker labels. The retention tier has to travel the same way, or `bosn adopt` would
+    rebuild the guest disk's row as warm and the next pressure sweep would reclaim it (#151).
+    """
+    from bosn import labels as labels_mod
+    from bosn.registry import Registry
+    from bosn.resources import DiscoveredResource, ScanResult, adopt
+
+    pinned = labels_mod.ResourceLabels(
+        registry="reg-1",
+        kind="volume",
+        stack="mac",
+        generation="sha256:g",
+        scope="machine",
+        workspace="/w",
+        created="2026-01-01T00:00:00Z",
+        retention="pinned",
+    )
+    warm = labels_mod.ResourceLabels(
+        registry="reg-1",
+        kind="volume",
+        stack="s",
+        generation="sha256:g",
+        scope="stack",
+        workspace="/w",
+        created="2026-01-01T00:00:00Z",
+    )
+    scan = ScanResult(
+        owned=[
+            DiscoveredResource("volume", "guest-storage", pinned.to_dict()),
+            DiscoveredResource("volume", "cache", warm.to_dict()),
+        ]
+    )
+    with Registry(tmp_path / "r.sqlite3") as registry:
+        adopt(registry, scan)
+        restored = {r.name: r.retention for r in registry.list_resources()}
+    assert restored == {"guest-storage": "pinned", "cache": "warm"}

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -19,6 +19,7 @@ from bosn.retention import (
     KEPT_CURRENT_IMAGE,
     KEPT_LEASED,
     KEPT_MACHINE_SCOPE,
+    KEPT_PINNED,
     KEPT_QUIET_PERIOD,
     KEPT_RUNNING,
     KEPT_WARM,
@@ -567,3 +568,91 @@ def test_a_lease_outranks_running_in_the_reported_reason(
 
     assert not verdict.collect
     assert verdict.reason == KEPT_LEASED
+
+
+# -- the pinned tier (#151) ------------------------------------------------
+#
+# Pinning exists for state whose only creation path is a human sitting through a 30-60
+# minute interactive macOS install. Every test below is a signal that reclaims a *warm*
+# volume without anyone asking, and pinning has to beat all of them.
+
+
+def pinned(registry: Registry, scope="machine", workspace="/w"):
+    return registry.register_resource(
+        kind="volume",
+        name="guest-storage",
+        stack="mac",
+        generation="g",
+        scope=scope,
+        workspace=workspace,
+        retention="pinned",
+    )
+
+
+def test_a_pinned_volume_survives_its_warm_ttl(registry: Registry, clock: FakeClock) -> None:
+    resource = pinned(registry)
+    clock.advance(90 * DAY)
+
+    verdict = evaluate(registry, resource)
+    assert not verdict.collect
+    assert verdict.reason == KEPT_PINNED
+
+
+def test_a_pinned_volume_survives_storage_pressure(registry: Registry, clock: FakeClock) -> None:
+    resource = pinned(registry, scope="stack")
+    clock.advance(90 * DAY)
+
+    verdict = evaluate(registry, resource, pressure=Pressure(under_pressure=True))
+    assert not verdict.collect
+    assert verdict.reason == KEPT_PINNED
+
+
+def test_a_pinned_volume_survives_bosn_done(registry: Registry, clock: FakeClock) -> None:
+    resource = pinned(registry, scope="stack")
+    clock.advance(90 * DAY)
+
+    verdict = evaluate(registry, resource, workspace_done=True)
+    assert not verdict.collect, "`done` must not cost an hour of manual guest installation"
+
+
+def test_a_pinned_volume_survives_supersession(registry: Registry, clock: FakeClock) -> None:
+    resource = pinned(registry, scope="stack")
+    clock.advance(90 * DAY)
+
+    verdict = evaluate(registry, resource, superseded=True)
+    assert not verdict.collect
+    assert verdict.reason == KEPT_PINNED
+
+
+def test_a_warm_sibling_is_still_collected_under_the_same_signals(
+    registry: Registry, clock: FakeClock
+) -> None:
+    """The tier must be the thing doing the work, not a blanket softening of the rules."""
+    warm = make(registry, scope="stack")
+    clock.advance(90 * DAY)
+
+    assert evaluate(registry, warm, workspace_done=True).collect
+    assert evaluate(registry, warm, pressure=Pressure(under_pressure=True)).collect
+
+
+def test_pinning_does_not_outrank_an_active_lease(registry: Registry, clock: FakeClock) -> None:
+    """A lease is not a reclaim decision, so it is reported ahead of the pin."""
+    resource = pinned(registry)
+    registry.acquire_lease(resource.id, pid=1, proc_start=1.0, ttl_seconds=60)
+    clock.advance(10 * DAY)
+
+    verdict = evaluate(registry, resource, alive_probe=ALIVE)
+    assert not verdict.collect
+    assert verdict.reason == KEPT_LEASED
+
+
+def test_a_pinned_resource_is_never_in_the_collectable_plan(
+    registry: Registry, clock: FakeClock
+) -> None:
+    pinned(registry)
+    make(registry, scope="stack")
+    clock.advance(90 * DAY)
+
+    plan = retention.plan(registry, pressure=Pressure(under_pressure=True))
+    assert [v.name for v in retention.collectable(plan)] == ["volume-1"]
+    assert KEPT_PINNED in {v.reason for v in retention.kept(plan)}


### PR DESCRIPTION
Closes #151.

A stack kind that runs a `dockurr/macos` guest, so a repo can declare a macOS x86-64 target the same way it declares a Linux one:

```toml
[stack.macos-x64]
kind = "macos-x64-guest"
acknowledge_macos_license = true
image = "ghcr.io/<org>/<repo>/macos-x64-guest:ventura"
family = "macos-x64"
workdir = "/Users/runner"

[stack.macos-x64.guest]
payload = "kernal-x64.tar.zst"    # scp'd in before every task

[stack.macos-x64.volumes]
storage = { scope = "machine", destination = "/storage", retention = "pinned" }
```

## Why it is a *kind*, not a stack with unusual options

The workload runs in a VM **inside** the container. Four places bosn's normal behavior would be silently wrong rather than merely absent — each is issue #151's numbered requirement:

1. **Device passthrough at create time** — `--device /dev/kvm --device /dev/net/tun --cap-add NET_ADMIN`, plus `--stop-timeout 120`. Docker cannot re-cap a container afterwards, so `kind` and every `[stack.X.guest]` field are digested for the same reason `env` is. A guest stack is refused *before anything is pulled* if the host is not Linux or lacks either device.
2. **Readiness is sshd** — a bounded poll (`ready_timeout`, default 1800s) with the guest's own last-60-lines attached to the timeout. A fixed sleep is wrong in both directions.
3. **The transport is ssh** — `docker exec` would land beside the VM and run a macOS task against a Linux userland. Both execution paths branch: `Converger.run_converged` *and* the CLI's own foreground exec, which does not go through the Converger. The task's real exit code propagates; ssh's own 255 is logged as ambiguous rather than reported as a task result.
4. **`[stack.X.mounts]` is refused** — a bind lands in the container, invisible to the VM. `[stack.X.guest] payload` scp's one prebuilt artifact in instead, before *every* task, since a guest silently serving last week's archive is the worst failure this kind has.

## The pinned retention tier (requirement 4, the important one)

`retention = "pinned"` exempts a volume from age, supersession, `bosn done`, and storage pressure alike. Only an active lease outranks it, because that is not a reclaim decision.

The tier lives in two places on purpose: the **registry row** (GC runs from the registry and has no manifest in hand) *and* a new **optional Docker label** — the registry is explicitly disposable, so without the label a `bosn adopt` after a lost database would rebuild the guest disk as warm and the next sweep would take it. The label is deliberately **not** in `REQUIRED_LABELS`, so every pre-existing resource stays owned, collectable, and adoptable, and a warm volume's label set stays byte-identical to what bosn has always written.

`bosn release-volume --stack X --volume Y --apply --yes` is the one deliberate exit. It re-proves ownership from the engine's labels, refuses an active lease, refuses a volume still attached to a container, previews by default, and refuses a *warm* volume so it cannot become a general "delete my volume" verb. It never resolves a generation for a non-`spec` scope, so removing a pinned disk can never be the thing that pulls a 30 GB guest image.

## Constraints surfaced rather than hidden

- **AMD hosts get `CPU_CORES=1`** (dockur/macos#268 — a PCID mismatch makes multi-core unstable, not merely slower). An unreadable vendor takes the same conservative path; an explicit `cpu_cores` is honored as written.
- **Replacing a stale guest container stops it gracefully first.** `rm --force` is an immediate SIGKILL that ignores the `--stop-timeout` this kind sets — bosn's own replacement would otherwise kill QEMU mid-write on the pinned disk.
- **Licensing is an explicit opt-in.** `acknowledge_macos_license = true`, no default, no env var, no flag.
- **Bootstrap stays manual.** `dockurr/macos` has no unattended path; `docs/macos-guest.md` documents install → bake → publish → pull, plus the two `cargo-nextest` / `env!()` portability traps and the one-guest-per-machine port constraint.

## Compatibility

- **Existing digests are unchanged.** New digest keys are added only when set; a golden test pins a plain stack's digest to the value `main` produces, so upgrading never rolls a live generation.
- **Registry schema 4** adds `resources.retention`, defaulting every existing row to warm. Pinning is only ever asserted forward.

## Validation

`./lint` clean (ruff format, ruff check, **pyright**, lint_kbi). **1219 unit tests pass**; the docker-marked suite passes except `test_compose_e2e_docker.py::test_compose_lifecycle_through_the_real_front_door`, which fails identically on `main` on this machine (a network-endpoint race, untouched by this PR).

**Not validated end to end.** Every guest probe, clock, and subprocess is injected precisely because bosn's CI has no KVM, no baked guest image, and no ssh client — so nothing here has run against a live `dockurr/macos` guest. The README status block says so.

**Follow-ups, not in scope:** `bosn stack bake` (the issue calls it "a natural home", not a requirement); and `gc`'s own container removal still uses `rm --force`, so `bosn done` against a *running* guest can still SIGKILL it — changing gc's remove command affects every container and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESvyWPvuPoAUBAZurbLc1o